### PR TITLE
M0.1: scaffold acceptance CLI with check subcommand

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "acceptance-tool"
+version = "0.1.0"
+description = "Independent acceptance review for AI-assisted software changes."
+requires-python = ">=3.10"
+readme = "README.md"
+
+[project.optional-dependencies]
+dev = ["pytest", "ruff"]
+
+[project.scripts]
+acceptance = "acceptance.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/src/acceptance/__init__.py
+++ b/src/acceptance/__init__.py
@@ -1,0 +1,1 @@
+"""Acceptance review tool for AI-assisted software changes."""

--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -1,0 +1,82 @@
+"""`acceptance` CLI entrypoint.
+
+Stage 1, M0.1: parses `check --task --base --head`, validates its inputs, and
+exits cleanly with an empty structured Review. Requirement interpretation,
+diffing, and reporting land in later M0/M1/M2 milestones.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from acceptance.review_state import Review
+
+
+class CliError(Exception):
+    """A user-facing CLI failure (bad input), not a bug."""
+
+
+def _resolve_revision(revision: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--verify", f"{revision}^{{commit}}"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except FileNotFoundError as exc:
+        raise CliError("git executable not found") from exc
+    except subprocess.CalledProcessError as exc:
+        raise CliError(f"revision not found: {revision!r}") from exc
+    return result.stdout.strip()
+
+
+def _read_task(task_path: str) -> str:
+    path = Path(task_path)
+    if not path.is_file():
+        raise CliError(f"task file not found: {task_path!r}")
+    return path.read_text()
+
+
+def run_check(task: str, base: str, head: str) -> Review:
+    _read_task(task)
+    _resolve_revision(base)
+    head_sha = _resolve_revision(head)
+    return Review(mode="local", reviewed_revision=head_sha)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="acceptance")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    check = subparsers.add_parser("check", help="Run a local completion check.")
+    check.add_argument("--task", required=True, help="Path to the task file.")
+    check.add_argument("--base", required=True, help="Base Git revision.")
+    check.add_argument("--head", required=True, help="Head Git revision.")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "check":
+        try:
+            review = run_check(args.task, args.base, args.head)
+        except CliError as exc:
+            print(f"acceptance: error: {exc}", file=sys.stderr)
+            return 1
+        print(json.dumps(review.to_dict(), indent=2))
+        return 0
+
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -1,0 +1,29 @@
+"""Review-state stub.
+
+Provisional placeholder for the §15 data model. M0.2 replaces this with the
+full typed schemas (Obligation, Finding with enforced evidence tier, etc.);
+until then this only exists so M0.1's CLI has a named structured object to
+return instead of an ad hoc dict.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+@dataclass
+class Review:
+    mode: str
+    reviewed_revision: str
+    mandate: Any = None
+    declaration: Any = None
+    change_set: Any = None
+    obligation_map: list = field(default_factory=list)
+    findings: list = field(default_factory=list)
+    evidence_tiers: dict = field(default_factory=dict)
+    limitations: list = field(default_factory=list)
+    recommendation: Any = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,42 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+
+def _rev_parse(repo: Path, revision: str) -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", revision], cwd=repo, check=True, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+@pytest.fixture
+def git_repo(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+
+    (repo / "file.txt").write_text("v1\n")
+    _git(repo, "add", "file.txt")
+    _git(repo, "commit", "-q", "-m", "base")
+    base_sha = _rev_parse(repo, "HEAD")
+
+    (repo / "file.txt").write_text("v2\n")
+    _git(repo, "add", "file.txt")
+    _git(repo, "commit", "-q", "-m", "head")
+    head_sha = _rev_parse(repo, "HEAD")
+
+    monkeypatch.chdir(repo)
+    return {"path": repo, "base": base_sha, "head": head_sha}
+
+
+@pytest.fixture
+def fixture_task_path():
+    return str(Path(__file__).parent / "fixtures" / "tasks" / "minimal_task.md")

--- a/tests/fixtures/tasks/minimal_task.md
+++ b/tests/fixtures/tasks/minimal_task.md
@@ -1,0 +1,5 @@
+## Deliverable
+minimal fixture task used to exercise the `acceptance check` CLI in tests.
+
+## Acceptance
+the CLI parses this file without error.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,47 @@
+import json
+
+import pytest
+
+from acceptance.cli import main
+
+
+def test_check_exits_zero_with_empty_structured_review(git_repo, fixture_task_path, capsys):
+    exit_code = main(
+        ["check", "--task", fixture_task_path, "--base", git_repo["base"], "--head", git_repo["head"]]
+    )
+
+    assert exit_code == 0
+    review = json.loads(capsys.readouterr().out)
+    assert review["mode"] == "local"
+    assert review["reviewed_revision"] == git_repo["head"]
+    assert review["mandate"] is None
+    assert review["declaration"] is None
+    assert review["change_set"] is None
+    assert review["obligation_map"] == []
+    assert review["findings"] == []
+    assert review["evidence_tiers"] == {}
+    assert review["limitations"] == []
+    assert review["recommendation"] is None
+
+
+def test_check_fails_cleanly_on_missing_task_file(git_repo, capsys):
+    exit_code = main(
+        ["check", "--task", "does-not-exist.md", "--base", git_repo["base"], "--head", git_repo["head"]]
+    )
+
+    assert exit_code == 1
+    assert "task file not found" in capsys.readouterr().err
+
+
+def test_check_fails_cleanly_on_unresolvable_revision(git_repo, fixture_task_path, capsys):
+    exit_code = main(
+        ["check", "--task", fixture_task_path, "--base", "not-a-real-revision", "--head", git_repo["head"]]
+    )
+
+    assert exit_code == 1
+    assert "revision not found" in capsys.readouterr().err
+
+
+def test_check_requires_all_flags(fixture_task_path):
+    with pytest.raises(SystemExit):
+        main(["check", "--task", fixture_task_path])


### PR DESCRIPTION
## Summary
- Project scaffold (src layout, `pyproject.toml`) with an `acceptance` console script.
- `acceptance check --task --base --head` validates the task file exists and the revisions resolve via git, then exits 0 with an empty structured `Review` object (JSON).
- `Review` (`src/acceptance/review_state.py`) is a provisional stub — M0.2 replaces it with the full typed §15 schema (Obligation, Finding with enforced evidence tier, etc.).

Closes M0.1 per `planning/backlog/M0.1.md`.

## Test plan
- [x] `pytest -q` — 4 tests pass (empty-review happy path, missing task file, unresolvable revision, missing required flags)
- [x] `ruff check .` — clean
- [x] Manual smoke test: installed `acceptance` script run against a real temp git repo — exit 0, empty structured Review JSON printed, `HEAD`/`HEAD~1`-style revisions resolve
- [x] User verified locally in a separate terminal before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)