### PR TITLE
M0.2: typed review-state data model on pydantic

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,5 +1,5 @@
 ## Deliverable
-project scaffold with an `acceptance` CLI exposing `check --task --base --head` that parses args and exits cleanly.
+typed schemas for Project, Task source, Mandate interpretation, Builder declaration, Change set, Obligation, Test evidence, Execution evidence, Finding, Review (Benchmark case added in M-B0).
 
 ## Acceptance
-invoking the CLI with a fixture task and two Git revisions returns exit code 0 and an empty structured review object.
+each schema round-trips to/from persisted form; a Finding cannot be constructed without an evidence tier and at least one link target (invariant enforced by a failing constructor test).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 description = "Independent acceptance review for AI-assisted software changes."
 requires-python = ">=3.10"
 readme = "README.md"
+dependencies = ["pydantic>=2"]
 
 [project.optional-dependencies]
 dev = ["pytest", "ruff"]

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -1,29 +1,183 @@
-"""Review-state stub.
+"""Review-state data model (§15).
 
-Provisional placeholder for the §15 data model. M0.2 replaces this with the
-full typed schemas (Obligation, Finding with enforced evidence tier, etc.);
-until then this only exists so M0.1's CLI has a named structured object to
-return instead of an ad hoc dict.
+Typed, persisted review state: obligations, mappings, findings, and evidence
+tiers are explicit fields, not free text (CLAUDE.md invariant). `EvidenceTier`
+here is ordering-only; M0.3 adds the rule that a component may only raise a
+tier it is authorized to produce. Benchmark case is out of scope (M-B0).
+
+Schemas are pydantic models: validation and round-trip (de)serialization come
+from the library rather than hand-rolled per class.
 """
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
-from typing import Any
+from enum import IntEnum
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
-@dataclass
-class Review:
-    mode: str
-    reviewed_revision: str
-    mandate: Any = None
-    declaration: Any = None
-    change_set: Any = None
-    obligation_map: list = field(default_factory=list)
-    findings: list = field(default_factory=list)
-    evidence_tiers: dict = field(default_factory=dict)
-    limitations: list = field(default_factory=list)
-    recommendation: Any = None
+class EvidenceTier(IntEnum):
+    """§8.1 evidence ladder, weakest to strongest."""
+
+    BUILDER_CLAIM = 1
+    STATIC = 2
+    COVERAGE_CONFIRMED = 3
+    DEFECT_KILLED = 4
+    CI_CONFIRMED = 5
+
+
+class _Model(BaseModel):
+    """Base for all review-state schemas: strict fields, uniform persistence."""
+
+    model_config = ConfigDict(extra="forbid")
 
     def to_dict(self) -> dict:
-        return asdict(self)
+        return self.model_dump(mode="json")
+
+    @classmethod
+    def from_dict(cls, data: dict):
+        return cls.model_validate(data)
+
+
+class Project(_Model):
+    repo: str
+    default_branch: str
+    test_framework: str
+    source_locations: list[str] = Field(default_factory=list)
+    test_locations: list[str] = Field(default_factory=list)
+    test_command: str | None = None
+    execution_feasible: bool | None = None
+    review_policy: str | None = None
+
+
+class TaskSource(_Model):
+    kind: Literal["local_file", "issue"]
+    identifier: str
+    snapshot: str
+    text: str
+    references: list[str] = Field(default_factory=list)
+
+
+class MandateInterpretation(_Model):
+    interpreted_outcome: str
+    constraints: list[str] = Field(default_factory=list)
+    explicit_obligations: list[str] = Field(default_factory=list)
+    inferred_obligations: list[str] = Field(default_factory=list)
+    ambiguities: list[str] = Field(default_factory=list)
+    user_confirmations: list[str] = Field(default_factory=list)
+
+
+class BuilderDeclaration(_Model):
+    """The nine §7.4 template sections, as raw text."""
+
+    mandate_as_understood: str
+    implementation_summary: str
+    scope_exclusions: str
+    assumptions: str
+    changed_components: str
+    test_evidence: str
+    regression_evidence: str
+    known_limitations: str
+    additional_behavioral_changes: str
+
+
+class ChangeSet(_Model):
+    base_revision: str
+    head_revision: str
+    changed_files: list[str] = Field(default_factory=list)
+    source_diff: str = ""
+    test_diff: str = ""
+    config_dependency_changes: list[str] = Field(default_factory=list)
+
+
+class Obligation(_Model):
+    description: str
+    type: str
+    source_text: str
+    importance: str
+    explicit: bool
+    observable_behavior: str
+    achieved_evidence_tier: EvidenceTier | None = None
+    test_evidence: list[str] = Field(default_factory=list)
+
+
+class TestEvidence(_Model):
+    __test__ = False  # not a pytest test class; name matches §15's "Test evidence"
+
+    identifier: str
+    location: str
+    inputs: list[str] = Field(default_factory=list)
+    fixtures: list[str] = Field(default_factory=list)
+    assertions: list[str] = Field(default_factory=list)
+    expected_value_provenance: str | None = None
+    mocks: list[str] = Field(default_factory=list)
+    relevant_path: bool | None = None
+    mapped_obligations: list[str] = Field(default_factory=list)
+    static_assessment: str | None = None
+
+
+class ExecutionEvidence(_Model):
+    run_id: str
+    command: str
+    result: Literal["pass", "fail", "skip"]
+    reviewed_revision: str
+    coverage_of_obligation_lines: bool | None = None
+    mutation_descriptor: str | None = None
+    outcome: Literal["killed", "survived"] | None = None
+
+
+class Link(_Model):
+    """A finding's link to exact requirement text / code lines / test locations."""
+
+    kind: Literal["requirement", "code", "test"]
+    ref: str
+    text: str | None = None
+
+
+class Finding(_Model):
+    """Typed and linked (CLAUDE.md invariant): cannot be built without an
+    evidence tier and at least one link target."""
+
+    type: str
+    severity: str
+    description: str
+    evidence_tier: EvidenceTier
+    links: list[Link]
+    related_obligation: str | None = None
+    supporting_evidence: list[str] = Field(default_factory=list)
+    uncertainty: str | None = None
+    recommended_action: str | None = None
+
+    @field_validator("links")
+    @classmethod
+    def _require_at_least_one_link(cls, value: list[Link]) -> list[Link]:
+        if not value:
+            raise ValueError("Finding requires at least one link target")
+        return value
+
+
+class Review(_Model):
+    mode: str
+    reviewed_revision: str
+    mandate: MandateInterpretation | None = None
+    declaration: BuilderDeclaration | None = None
+    change_set: ChangeSet | None = None
+    obligation_map: list[Obligation] = Field(default_factory=list)
+    findings: list[Finding] = Field(default_factory=list)
+    limitations: list[str] = Field(default_factory=list)
+    recommendation: str | None = None
+
+    def evidence_tier_summary(self) -> dict[str, int]:
+        """Tier counts derived from obligations/findings, not stored — the
+        achieved tier lives on each Obligation/Finding; a separate stored
+        copy here would be a second source of truth that can drift."""
+        counts: dict[str, int] = {}
+        for obligation in self.obligation_map:
+            if obligation.achieved_evidence_tier is not None:
+                key = obligation.achieved_evidence_tier.name
+                counts[key] = counts.get(key, 0) + 1
+        for finding in self.findings:
+            key = finding.evidence_tier.name
+            counts[key] = counts.get(key, 0) + 1
+        return counts

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,6 @@ def test_check_exits_zero_with_empty_structured_review(git_repo, fixture_task_pa
     assert review["change_set"] is None
     assert review["obligation_map"] == []
     assert review["findings"] == []
-    assert review["evidence_tiers"] == {}
     assert review["limitations"] == []
     assert review["recommendation"] is None
 

--- a/tests/test_review_state.py
+++ b/tests/test_review_state.py
@@ -1,0 +1,272 @@
+import json
+
+import pytest
+
+from acceptance.review_state import (
+    BuilderDeclaration,
+    ChangeSet,
+    EvidenceTier,
+    ExecutionEvidence,
+    Finding,
+    Link,
+    MandateInterpretation,
+    Obligation,
+    Project,
+    Review,
+    TaskSource,
+    TestEvidence,
+)
+
+
+def _round_trip(instance):
+    cls = type(instance)
+    persisted = json.loads(json.dumps(instance.to_dict()))
+    return cls.from_dict(persisted)
+
+
+def test_project_round_trips():
+    project = Project(
+        repo="acceptance-tool",
+        default_branch="main",
+        test_framework="pytest",
+        source_locations=["src/"],
+        test_locations=["tests/"],
+        test_command="pytest -q",
+        execution_feasible=True,
+        review_policy="advisory",
+    )
+    assert _round_trip(project) == project
+
+
+def test_task_source_round_trips():
+    task_source = TaskSource(
+        kind="local_file",
+        identifier="current-task.md",
+        snapshot="abc123",
+        text="## Deliverable\n...",
+        references=["docs/spec.md"],
+    )
+    assert _round_trip(task_source) == task_source
+
+
+def test_mandate_interpretation_round_trips():
+    mandate = MandateInterpretation(
+        interpreted_outcome="Add floating-rate bonds.",
+        constraints=["Fixed-rate behavior must not change."],
+        explicit_obligations=["Coupons use index + spread."],
+        inferred_obligations=["Missing observations must error."],
+        ambiguities=["Which index source applies?"],
+        user_confirmations=[],
+    )
+    assert _round_trip(mandate) == mandate
+
+
+def test_builder_declaration_round_trips():
+    declaration = BuilderDeclaration(
+        mandate_as_understood="...",
+        implementation_summary="...",
+        scope_exclusions="none",
+        assumptions="...",
+        changed_components="...",
+        test_evidence="...",
+        regression_evidence="...",
+        known_limitations="...",
+        additional_behavioral_changes="none",
+    )
+    assert _round_trip(declaration) == declaration
+
+
+def test_change_set_round_trips():
+    change_set = ChangeSet(
+        base_revision="abc123",
+        head_revision="def456",
+        changed_files=["src/foo.py"],
+        source_diff="--- a/src/foo.py\n+++ b/src/foo.py\n",
+        test_diff="",
+        config_dependency_changes=[],
+    )
+    assert _round_trip(change_set) == change_set
+
+
+def test_obligation_round_trips_with_tier():
+    obligation = Obligation(
+        description="Coupons use index + contractual spread.",
+        type="behavior",
+        source_text="Add floating-rate bonds using an index curve plus contractual spread.",
+        importance="critical",
+        explicit=True,
+        observable_behavior="calculate_coupon returns index + spread",
+        achieved_evidence_tier=EvidenceTier.STATIC,
+        test_evidence=["test_coupon_uses_spread"],
+    )
+    assert _round_trip(obligation) == obligation
+
+
+def test_obligation_round_trips_without_tier():
+    obligation = Obligation(
+        description="Fixed-rate results unchanged.",
+        type="regression",
+        source_text="Existing fixed-rate behavior must not change.",
+        importance="critical",
+        explicit=True,
+        observable_behavior="fixed-rate coupons identical to pre-change output",
+    )
+    assert obligation.achieved_evidence_tier is None
+    assert _round_trip(obligation) == obligation
+
+
+def test_test_evidence_round_trips():
+    test_evidence = TestEvidence(
+        identifier="tests/test_bond.py::test_coupon_uses_spread",
+        location="tests/test_bond.py:42",
+        inputs=["index=0.03", "spread=0.01"],
+        fixtures=["bond_fixture"],
+        assertions=["result == 0.04"],
+        expected_value_provenance="hand-calculated",
+        mocks=[],
+        relevant_path=True,
+        mapped_obligations=["Coupons use index + contractual spread."],
+        static_assessment="strongly_supported",
+    )
+    assert _round_trip(test_evidence) == test_evidence
+
+
+def test_execution_evidence_round_trips():
+    execution_evidence = ExecutionEvidence(
+        run_id="run-1",
+        command="pytest tests/test_bond.py::test_coupon_uses_spread",
+        result="pass",
+        reviewed_revision="def456",
+        coverage_of_obligation_lines=True,
+        mutation_descriptor="flip index + spread to index - spread",
+        outcome="killed",
+    )
+    assert _round_trip(execution_evidence) == execution_evidence
+
+
+def test_finding_round_trips():
+    finding = Finding(
+        type="weak_test_evidence",
+        severity="high",
+        description="Test asserts only that a result exists.",
+        evidence_tier=EvidenceTier.STATIC,
+        links=[Link(kind="test", ref="tests/test_bond.py:42")],
+        related_obligation="Coupons use index + contractual spread.",
+        supporting_evidence=["tests/test_bond.py::test_coupon_uses_spread"],
+        uncertainty=None,
+        recommended_action="Add a discriminating-input test.",
+    )
+    assert _round_trip(finding) == finding
+
+
+def test_finding_requires_evidence_tier():
+    with pytest.raises(ValueError):
+        Finding(
+            type="weak_test_evidence",
+            severity="high",
+            description="...",
+            evidence_tier=None,
+            links=[Link(kind="test", ref="tests/test_bond.py:42")],
+        )
+
+
+def test_finding_requires_at_least_one_link():
+    with pytest.raises(ValueError):
+        Finding(
+            type="weak_test_evidence",
+            severity="high",
+            description="...",
+            evidence_tier=EvidenceTier.STATIC,
+            links=[],
+        )
+
+
+def test_finding_cannot_be_constructed_without_evidence_tier_arg():
+    with pytest.raises(ValueError):
+        Finding(
+            type="weak_test_evidence",
+            severity="high",
+            description="...",
+            links=[Link(kind="test", ref="tests/test_bond.py:42")],
+        )
+
+
+def test_finding_cannot_be_constructed_without_links_arg():
+    with pytest.raises(ValueError):
+        Finding(
+            type="weak_test_evidence",
+            severity="high",
+            description="...",
+            evidence_tier=EvidenceTier.STATIC,
+        )
+
+
+def test_evidence_tier_ordering():
+    assert EvidenceTier.BUILDER_CLAIM < EvidenceTier.STATIC
+    assert EvidenceTier.STATIC < EvidenceTier.COVERAGE_CONFIRMED
+    assert EvidenceTier.COVERAGE_CONFIRMED < EvidenceTier.DEFECT_KILLED
+    assert EvidenceTier.DEFECT_KILLED < EvidenceTier.CI_CONFIRMED
+
+
+def test_review_round_trips_empty():
+    review = Review(mode="local", reviewed_revision="def456")
+    assert _round_trip(review) == review
+
+
+def test_review_round_trips_populated():
+    obligation = Obligation(
+        description="Coupons use index + contractual spread.",
+        type="behavior",
+        source_text="...",
+        importance="critical",
+        explicit=True,
+        observable_behavior="...",
+        achieved_evidence_tier=EvidenceTier.STATIC,
+    )
+    finding = Finding(
+        type="weak_test_evidence",
+        severity="high",
+        description="...",
+        evidence_tier=EvidenceTier.STATIC,
+        links=[Link(kind="code", ref="src/bond.py:10")],
+    )
+    review = Review(
+        mode="local",
+        reviewed_revision="def456",
+        mandate=MandateInterpretation(interpreted_outcome="Add floating-rate bonds."),
+        declaration=None,
+        change_set=ChangeSet(base_revision="abc123", head_revision="def456"),
+        obligation_map=[obligation],
+        findings=[finding],
+        limitations=["Could not resolve dynamic dispatch in pricer.py"],
+        recommendation="Add a discriminating-input test.",
+    )
+    assert _round_trip(review) == review
+
+
+def test_review_evidence_tier_summary_is_derived_not_stored():
+    obligation = Obligation(
+        description="...",
+        type="behavior",
+        source_text="...",
+        importance="critical",
+        explicit=True,
+        observable_behavior="...",
+        achieved_evidence_tier=EvidenceTier.COVERAGE_CONFIRMED,
+    )
+    finding = Finding(
+        type="weak_test_evidence",
+        severity="high",
+        description="...",
+        evidence_tier=EvidenceTier.STATIC,
+        links=[Link(kind="code", ref="src/bond.py:10")],
+    )
+    review = Review(
+        mode="local",
+        reviewed_revision="def456",
+        obligation_map=[obligation],
+        findings=[finding],
+    )
+
+    assert review.evidence_tier_summary() == {"COVERAGE_CONFIRMED": 1, "STATIC": 1}
+    assert "evidence_tiers" not in review.to_dict()


### PR DESCRIPTION
Closes #2

## Summary
- Typed pydantic `BaseModel` schemas for the §15 review-state model: `Project`, `TaskSource`, `MandateInterpretation`, `BuilderDeclaration`, `ChangeSet`, `Obligation`, `TestEvidence`, `ExecutionEvidence`, `Link`, `Finding`, `Review`. `BenchmarkCase` is deliberately out of scope (added in M-B0).
- `EvidenceTier` (`IntEnum`, ordering-only for now — M0.3 adds the "only the authorized component may raise this tier" rule).
- `Finding` cannot be constructed without an `evidence_tier` or at least one `Link` — enforced via pydantic's required-field validation plus a `field_validator` on `links`, both raising `ValidationError` (a `ValueError` subclass). This is the CLAUDE.md invariant that every finding is typed and linked.
- Standardizes on pydantic over stdlib dataclasses (project decision, see commit message); adds `pydantic>=2` as a runtime dependency.
- `cli.py`'s `Review` construction and `tests/test_cli.py` updated for the new model shape (no behavior change to the CLI itself).

## Test plan
- [x] `pytest -q` — 22 tests pass, including round-trip tests for every schema and the `Finding` construction-invariant tests (missing tier, empty tier, missing links, empty links)
- [x] `ruff check .` — clean
- [x] Manual smoke test: `acceptance check` still exits 0 with an empty structured `Review` against a real temp git repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)