### PR TITLE
M0.3: evidence-tier authorization primitives

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,5 +1,5 @@
 ## Deliverable
-typed schemas for Project, Task source, Mandate interpretation, Builder declaration, Change set, Obligation, Test evidence, Execution evidence, Finding, Review (Benchmark case added in M-B0).
+an evidence-tier enum (builder-claim < static < coverage-confirmed < defect-killed < CI-confirmed) with an ordering and a rule that a tier can only be raised by the component authorized to produce it.
 
 ## Acceptance
-each schema round-trips to/from persisted form; a Finding cannot be constructed without an evidence tier and at least one link target (invariant enforced by a failing constructor test).
+attempting to set `defect-killed` from the static analyzer raises; ordering comparisons match §8.1.

--- a/src/acceptance/evidence_tier.py
+++ b/src/acceptance/evidence_tier.py
@@ -1,0 +1,54 @@
+"""Evidence-tier primitives (§8.1).
+
+`EvidenceTier` orders the evidence ladder. `Component` names the parts of the
+checker authorized to produce each tier, and `authorize_tier` enforces that a
+component can't raise a Finding above its authorized ceiling — a static
+analyzer can never emit `defect-killed` (CLAUDE.md invariant, M0.3).
+"""
+
+from __future__ import annotations
+
+from enum import Enum, IntEnum
+
+
+class EvidenceTier(IntEnum):
+    """§8.1 evidence ladder, weakest to strongest."""
+
+    BUILDER_CLAIM = 1
+    STATIC = 2
+    COVERAGE_CONFIRMED = 3
+    DEFECT_KILLED = 4
+    CI_CONFIRMED = 5
+
+
+class Component(str, Enum):
+    """The checker component authorized to produce a given evidence tier."""
+
+    BUILDER_DECLARATION = "builder_declaration"
+    STATIC_ANALYZER = "static_analyzer"
+    COVERAGE_RUNNER = "coverage_runner"
+    MUTATION_RUNNER = "mutation_runner"
+    CI_INGESTION = "ci_ingestion"
+
+
+_MAX_TIER_BY_COMPONENT: dict[Component, EvidenceTier] = {
+    Component.BUILDER_DECLARATION: EvidenceTier.BUILDER_CLAIM,
+    Component.STATIC_ANALYZER: EvidenceTier.STATIC,
+    Component.COVERAGE_RUNNER: EvidenceTier.COVERAGE_CONFIRMED,
+    Component.MUTATION_RUNNER: EvidenceTier.DEFECT_KILLED,
+    Component.CI_INGESTION: EvidenceTier.CI_CONFIRMED,
+}
+
+
+class UnauthorizedTierError(ValueError):
+    """Raised when a component attempts to produce a tier above its ceiling."""
+
+
+def authorize_tier(component: Component, tier: EvidenceTier) -> EvidenceTier:
+    max_tier = _MAX_TIER_BY_COMPONENT[component]
+    if tier > max_tier:
+        raise UnauthorizedTierError(
+            f"{component.value} is not authorized to produce tier {tier.name} "
+            f"(max: {max_tier.name})"
+        )
+    return tier

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -1,9 +1,10 @@
 """Review-state data model (§15).
 
 Typed, persisted review state: obligations, mappings, findings, and evidence
-tiers are explicit fields, not free text (CLAUDE.md invariant). `EvidenceTier`
-here is ordering-only; M0.3 adds the rule that a component may only raise a
-tier it is authorized to produce. Benchmark case is out of scope (M-B0).
+tiers are explicit fields, not free text (CLAUDE.md invariant). Findings also
+record which component produced them and are validated against that
+component's authorized tier ceiling (evidence_tier.py, M0.3). Benchmark case
+is out of scope (M-B0).
 
 Schemas are pydantic models: validation and round-trip (de)serialization come
 from the library rather than hand-rolled per class.
@@ -11,20 +12,27 @@ from the library rather than hand-rolled per class.
 
 from __future__ import annotations
 
-from enum import IntEnum
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from acceptance.evidence_tier import Component, EvidenceTier, authorize_tier
 
-class EvidenceTier(IntEnum):
-    """§8.1 evidence ladder, weakest to strongest."""
-
-    BUILDER_CLAIM = 1
-    STATIC = 2
-    COVERAGE_CONFIRMED = 3
-    DEFECT_KILLED = 4
-    CI_CONFIRMED = 5
+__all__ = [
+    "Component",
+    "EvidenceTier",
+    "Project",
+    "TaskSource",
+    "MandateInterpretation",
+    "BuilderDeclaration",
+    "ChangeSet",
+    "Obligation",
+    "TestEvidence",
+    "ExecutionEvidence",
+    "Link",
+    "Finding",
+    "Review",
+]
 
 
 class _Model(BaseModel):
@@ -137,12 +145,14 @@ class Link(_Model):
 
 class Finding(_Model):
     """Typed and linked (CLAUDE.md invariant): cannot be built without an
-    evidence tier and at least one link target."""
+    evidence tier and at least one link target, and the producing component
+    must be authorized for the claimed tier (§8.1, M0.3)."""
 
     type: str
     severity: str
     description: str
     evidence_tier: EvidenceTier
+    produced_by: Component
     links: list[Link]
     related_obligation: str | None = None
     supporting_evidence: list[str] = Field(default_factory=list)
@@ -155,6 +165,11 @@ class Finding(_Model):
         if not value:
             raise ValueError("Finding requires at least one link target")
         return value
+
+    @model_validator(mode="after")
+    def _require_authorized_tier(self) -> "Finding":
+        authorize_tier(self.produced_by, self.evidence_tier)
+        return self
 
 
 class Review(_Model):

--- a/tests/test_evidence_tier.py
+++ b/tests/test_evidence_tier.py
@@ -1,0 +1,43 @@
+import pytest
+
+from acceptance.evidence_tier import (
+    Component,
+    EvidenceTier,
+    UnauthorizedTierError,
+    authorize_tier,
+)
+
+
+def test_evidence_tier_ordering():
+    assert EvidenceTier.BUILDER_CLAIM < EvidenceTier.STATIC
+    assert EvidenceTier.STATIC < EvidenceTier.COVERAGE_CONFIRMED
+    assert EvidenceTier.COVERAGE_CONFIRMED < EvidenceTier.DEFECT_KILLED
+    assert EvidenceTier.DEFECT_KILLED < EvidenceTier.CI_CONFIRMED
+
+
+def test_static_analyzer_cannot_produce_defect_killed():
+    with pytest.raises(UnauthorizedTierError):
+        authorize_tier(Component.STATIC_ANALYZER, EvidenceTier.DEFECT_KILLED)
+
+
+@pytest.mark.parametrize(
+    ("component", "max_tier"),
+    [
+        (Component.BUILDER_DECLARATION, EvidenceTier.BUILDER_CLAIM),
+        (Component.STATIC_ANALYZER, EvidenceTier.STATIC),
+        (Component.COVERAGE_RUNNER, EvidenceTier.COVERAGE_CONFIRMED),
+        (Component.MUTATION_RUNNER, EvidenceTier.DEFECT_KILLED),
+        (Component.CI_INGESTION, EvidenceTier.CI_CONFIRMED),
+    ],
+)
+def test_component_authorized_up_to_its_own_ceiling(component, max_tier):
+    for tier in EvidenceTier:
+        if tier <= max_tier:
+            assert authorize_tier(component, tier) == tier
+        else:
+            with pytest.raises(UnauthorizedTierError):
+                authorize_tier(component, tier)
+
+
+def test_unauthorized_tier_error_is_a_value_error():
+    assert issubclass(UnauthorizedTierError, ValueError)

--- a/tests/test_review_state.py
+++ b/tests/test_review_state.py
@@ -5,6 +5,7 @@ import pytest
 from acceptance.review_state import (
     BuilderDeclaration,
     ChangeSet,
+    Component,
     EvidenceTier,
     ExecutionEvidence,
     Finding,
@@ -150,6 +151,7 @@ def test_finding_round_trips():
         severity="high",
         description="Test asserts only that a result exists.",
         evidence_tier=EvidenceTier.STATIC,
+        produced_by=Component.STATIC_ANALYZER,
         links=[Link(kind="test", ref="tests/test_bond.py:42")],
         related_obligation="Coupons use index + contractual spread.",
         supporting_evidence=["tests/test_bond.py::test_coupon_uses_spread"],
@@ -166,6 +168,7 @@ def test_finding_requires_evidence_tier():
             severity="high",
             description="...",
             evidence_tier=None,
+            produced_by=Component.STATIC_ANALYZER,
             links=[Link(kind="test", ref="tests/test_bond.py:42")],
         )
 
@@ -177,6 +180,7 @@ def test_finding_requires_at_least_one_link():
             severity="high",
             description="...",
             evidence_tier=EvidenceTier.STATIC,
+            produced_by=Component.STATIC_ANALYZER,
             links=[],
         )
 
@@ -187,6 +191,7 @@ def test_finding_cannot_be_constructed_without_evidence_tier_arg():
             type="weak_test_evidence",
             severity="high",
             description="...",
+            produced_by=Component.STATIC_ANALYZER,
             links=[Link(kind="test", ref="tests/test_bond.py:42")],
         )
 
@@ -198,14 +203,20 @@ def test_finding_cannot_be_constructed_without_links_arg():
             severity="high",
             description="...",
             evidence_tier=EvidenceTier.STATIC,
+            produced_by=Component.STATIC_ANALYZER,
         )
 
 
-def test_evidence_tier_ordering():
-    assert EvidenceTier.BUILDER_CLAIM < EvidenceTier.STATIC
-    assert EvidenceTier.STATIC < EvidenceTier.COVERAGE_CONFIRMED
-    assert EvidenceTier.COVERAGE_CONFIRMED < EvidenceTier.DEFECT_KILLED
-    assert EvidenceTier.DEFECT_KILLED < EvidenceTier.CI_CONFIRMED
+def test_finding_requires_authorized_producer():
+    with pytest.raises(ValueError):
+        Finding(
+            type="weak_test_evidence",
+            severity="high",
+            description="A static analyzer cannot claim a defect-killed tier.",
+            evidence_tier=EvidenceTier.DEFECT_KILLED,
+            produced_by=Component.STATIC_ANALYZER,
+            links=[Link(kind="test", ref="tests/test_bond.py:42")],
+        )
 
 
 def test_review_round_trips_empty():
@@ -228,6 +239,7 @@ def test_review_round_trips_populated():
         severity="high",
         description="...",
         evidence_tier=EvidenceTier.STATIC,
+        produced_by=Component.STATIC_ANALYZER,
         links=[Link(kind="code", ref="src/bond.py:10")],
     )
     review = Review(
@@ -259,6 +271,7 @@ def test_review_evidence_tier_summary_is_derived_not_stored():
         severity="high",
         description="...",
         evidence_tier=EvidenceTier.STATIC,
+        produced_by=Component.STATIC_ANALYZER,
         links=[Link(kind="code", ref="src/bond.py:10")],
     )
     review = Review(


### PR DESCRIPTION
Closes #3

## Summary
- New `src/acceptance/evidence_tier.py`: `EvidenceTier` moves here from `review_state.py` (re-exported there, so existing imports don't break), plus a new `Component` enum naming the five producers on the §8.1 ladder (builder declaration, static analyzer, coverage runner, mutation runner, CI ingestion).
- `authorize_tier(component, tier)` raises `UnauthorizedTierError` (a `ValueError`) if a component claims a tier above its authorized ceiling — e.g. the static analyzer can never claim `defect-killed`.
- `Finding` gains a required `produced_by: Component` field, validated against `evidence_tier` at construction time via a pydantic `model_validator`. This is the CLAUDE.md invariant that evidence-tier discipline is a data-model invariant, not a display choice.
- `Obligation.achieved_evidence_tier` is deliberately left untouched — the invariant text is specifically about *findings*; `Obligation`'s tier is a rollup whose provenance should trace through the `Finding`/evidence that established it, not a second, disconnected attribution field bolted directly onto the obligation.

## Test plan
- [x] `pytest -q` — 30 tests pass: new `tests/test_evidence_tier.py` (ordering, the literal "static analyzer can't produce defect-killed" acceptance check, and every component's authorized ceiling), plus `tests/test_review_state.py` updated for the new required `produced_by` field
- [x] `ruff check .` — clean
- [x] Manual smoke test: `acceptance check` still exits 0 with an empty structured `Review` against a real temp git repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)