### PR TITLE
M0.4: schema-constrained, replay-first LLM harness

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,5 +1,5 @@
 ## Deliverable
-an evidence-tier enum (builder-claim < static < coverage-confirmed < defect-killed < CI-confirmed) with an ordering and a rule that a tier can only be raised by the component authorized to produce it.
+a thin layer that issues schema-constrained model calls, validates responses against the target schema, and records every prompt/response for replay.
 
 ## Acceptance
-attempting to set `defect-killed` from the static analyzer raises; ordering comparisons match §8.1.
+a recorded transcript replays a full run with zero live model calls; a malformed model response is rejected with a typed error, not silently accepted.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Independent acceptance review for AI-assisted software changes."
 requires-python = ">=3.10"
 readme = "README.md"
-dependencies = ["pydantic>=2"]
+dependencies = ["pydantic>=2", "litellm>=1.50"]
 
 [project.optional-dependencies]
 dev = ["pytest", "ruff"]

--- a/src/acceptance/llm.py
+++ b/src/acceptance/llm.py
@@ -1,0 +1,233 @@
+"""LLM-orchestration harness (M0.4, plan §3.2 "LLM orchestration boundary").
+
+A thin layer between the checker's judgments and whatever model produces them:
+
+- **Schema-constrained.** Every call names a pydantic `response_model`; the
+  model is asked for that JSON schema and the reply is validated against it.
+  A malformed reply raises `SchemaValidationError` — never silently accepted.
+- **Provider-agnostic.** Requests go through LiteLLM, so the model is a
+  configuration string (`anthropic/claude-sonnet-5`, `openai/gpt-...`) and
+  providers can be compared on quality and cost without touching call sites.
+- **Replay-first.** Every prompt/response is recorded to a transcript store
+  keyed by request content. In `REPLAY` mode no live call is made at all — a
+  missing transcript is an error, not a silent fallback to the network.
+
+Transcripts deliberately record no wall-clock time and no run identifiers, so
+re-running the same input reproduces byte-identical state (M0.5's acceptance
+depends on this). LiteLLM is imported lazily inside the live path only, so
+replay-mode runs — including CI and this project's own tests — need neither
+the provider stack nor an API key.
+
+M0.5 owns the seed/temperature configuration layer; the fields exist here
+because they are part of a request's identity.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, TypeVar
+
+from pydantic import BaseModel, ValidationError
+
+DEFAULT_TRANSCRIPT_ROOT = Path(".acceptance/cache/transcripts")
+
+ResponseModelT = TypeVar("ResponseModelT", bound=BaseModel)
+
+
+class Mode(str, Enum):
+    """Whether calls may reach the network.
+
+    RECORD is record-*if-missing*: an already-recorded request is served from
+    its transcript rather than re-billed (§17 cost awareness). Delete a
+    transcript — or change the prompt or response model, which changes the
+    request key — to force a fresh call.
+    """
+
+    RECORD = "record"  # live call on a cache miss, then persist the transcript
+    REPLAY = "replay"  # transcripts only; never call a provider
+
+
+class LLMError(Exception):
+    """Base class for harness failures."""
+
+
+class SchemaValidationError(LLMError):
+    """A model response did not parse/validate against the target schema."""
+
+
+class TranscriptNotFoundError(LLMError):
+    """REPLAY mode found no recorded transcript for a request."""
+
+
+def _canonical_json(payload: Any) -> str:
+    """Stable JSON: sorted keys, no incidental whitespace."""
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def request_key(request: dict) -> str:
+    """Content-address a request.
+
+    The response schema is part of the key: changing a `response_model`
+    invalidates its old transcripts instead of replaying a stale shape.
+    """
+    return hashlib.sha256(_canonical_json(request).encode("utf-8")).hexdigest()
+
+
+class TranscriptStore:
+    """Content-addressed prompt/response records on disk."""
+
+    def __init__(self, root: Path | str = DEFAULT_TRANSCRIPT_ROOT) -> None:
+        self.root = Path(root)
+
+    def path_for(self, key: str) -> Path:
+        return self.root / f"{key}.json"
+
+    def read(self, key: str) -> dict | None:
+        path = self.path_for(key)
+        if not path.is_file():
+            return None
+        return json.loads(path.read_text())
+
+    def write(self, key: str, record: dict) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+        # Canonical form: identical records serialize byte-identically (M0.5).
+        self.path_for(key).write_text(_canonical_json(record) + "\n")
+
+
+def _default_completion_fn(**kwargs: Any) -> Any:
+    """Live provider call. Imported lazily so REPLAY never needs LiteLLM."""
+    import litellm
+
+    return litellm.completion(**kwargs)
+
+
+def _extract_content(response: Any) -> str:
+    """Pull the assistant text out of an OpenAI-shaped response."""
+    try:
+        content = response.choices[0].message.content
+    except (AttributeError, IndexError, KeyError) as exc:
+        raise SchemaValidationError(f"model response had no message content: {exc}") from exc
+    if not isinstance(content, str):
+        raise SchemaValidationError(f"model response content was {type(content).__name__}, not str")
+    return content
+
+
+def _extract_usage(response: Any) -> dict:
+    """Token usage and cost, recorded so providers can be compared."""
+    usage: dict[str, Any] = {}
+    raw = getattr(response, "usage", None)
+    if raw is not None:
+        for name in ("prompt_tokens", "completion_tokens", "total_tokens"):
+            value = getattr(raw, name, None)
+            if value is not None:
+                usage[name] = value
+
+    # Only price a response LiteLLM itself produced. Looking the module up in
+    # sys.modules rather than importing it keeps callers that inject their own
+    # completion_fn — tests, fixtures — free of the provider stack entirely.
+    litellm = sys.modules.get("litellm")
+    if litellm is not None:
+        try:
+            cost = litellm.completion_cost(completion_response=response)
+        except Exception:
+            # Unpriced/unknown model; never fail a call over a cost lookup.
+            cost = None
+        if cost is not None:
+            usage["cost_usd"] = cost
+    return usage
+
+
+class ModelClient:
+    """Issues schema-constrained model calls and records them for replay."""
+
+    def __init__(
+        self,
+        model: str,
+        mode: Mode = Mode.REPLAY,
+        store: TranscriptStore | None = None,
+        temperature: float = 0.0,
+        seed: int | None = None,
+        completion_fn: Callable[..., Any] | None = None,
+    ) -> None:
+        self.model = model
+        self.mode = mode
+        self.store = store if store is not None else TranscriptStore()
+        self.temperature = temperature
+        self.seed = seed
+        self._completion_fn = completion_fn or _default_completion_fn
+
+    def build_request(
+        self, messages: list[dict], response_model: type[BaseModel]
+    ) -> dict:
+        """The recorded, hashed description of a call."""
+        request: dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": self.temperature,
+            "response_schema": {
+                "name": response_model.__name__,
+                "schema": response_model.model_json_schema(),
+            },
+        }
+        if self.seed is not None:
+            request["seed"] = self.seed
+        return request
+
+    def complete(
+        self, messages: list[dict], response_model: type[ResponseModelT]
+    ) -> ResponseModelT:
+        """Return a validated `response_model`, from a live call or a transcript."""
+        request = self.build_request(messages, response_model)
+        key = request_key(request)
+        record = self.store.read(key)
+
+        if record is None:
+            if self.mode is Mode.REPLAY:
+                raise TranscriptNotFoundError(
+                    f"no recorded transcript for request {key} "
+                    f"(model={self.model}, response_model={response_model.__name__}); "
+                    "REPLAY mode does not fall back to a live call"
+                )
+            record = self._record_live_call(key, request)
+
+        return self._validate(record["response"], response_model)
+
+    def _record_live_call(self, key: str, request: dict) -> dict:
+        response = self._completion_fn(
+            model=request["model"],
+            messages=request["messages"],
+            temperature=request["temperature"],
+            # strict mode is the strongest constraint providers offer; response
+            # models must therefore be strict-compatible (every field required,
+            # no open-ended dicts). A model that isn't fails loudly on the live
+            # call rather than degrading to unconstrained text.
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": request["response_schema"]["name"],
+                    "schema": request["response_schema"]["schema"],
+                    "strict": True,
+                },
+            },
+            **({"seed": request["seed"]} if "seed" in request else {}),
+        )
+        record = {
+            "request": request,
+            "response": _extract_content(response),
+            "usage": _extract_usage(response),
+        }
+        self.store.write(key, record)
+        return record
+
+    @staticmethod
+    def _validate(content: str, response_model: type[ResponseModelT]) -> ResponseModelT:
+        try:
+            return response_model.model_validate_json(content)
+        except ValidationError as exc:
+            raise SchemaValidationError(
+                f"model response did not match {response_model.__name__}: {exc}"
+            ) from exc

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,257 @@
+import json
+import sys
+from types import SimpleNamespace
+
+import pytest
+from pydantic import BaseModel
+
+from acceptance.llm import (
+    Mode,
+    ModelClient,
+    SchemaValidationError,
+    TranscriptNotFoundError,
+    TranscriptStore,
+    request_key,
+)
+
+
+class Verdict(BaseModel):
+    """Stand-in for a real judgment schema (obligations land in M1)."""
+
+    supported: bool
+    rationale: str
+
+
+MESSAGES = [{"role": "user", "content": "Does the test discriminate?"}]
+
+
+def _fake_response(content: str):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+        usage=SimpleNamespace(prompt_tokens=11, completion_tokens=7, total_tokens=18),
+    )
+
+
+def _recorder(content: str):
+    """A completion_fn that returns `content` and counts its calls."""
+    calls = []
+
+    def completion_fn(**kwargs):
+        calls.append(kwargs)
+        return _fake_response(content)
+
+    completion_fn.calls = calls
+    return completion_fn
+
+
+def _exploding_completion_fn(**kwargs):
+    raise AssertionError("a live model call was issued during replay")
+
+
+@pytest.fixture
+def store(tmp_path):
+    return TranscriptStore(tmp_path / "transcripts")
+
+
+def test_record_mode_validates_and_persists_a_transcript(store):
+    completion_fn = _recorder('{"supported": true, "rationale": "boundary case asserted"}')
+    client = ModelClient(
+        model="anthropic/claude-sonnet-5",
+        mode=Mode.RECORD,
+        store=store,
+        completion_fn=completion_fn,
+    )
+
+    verdict = client.complete(MESSAGES, Verdict)
+
+    assert verdict == Verdict(supported=True, rationale="boundary case asserted")
+    assert len(completion_fn.calls) == 1
+    key = request_key(client.build_request(MESSAGES, Verdict))
+    assert store.path_for(key).is_file()
+
+
+def test_recorded_transcript_replays_with_zero_live_calls(store):
+    recorded = ModelClient(
+        model="anthropic/claude-sonnet-5",
+        mode=Mode.RECORD,
+        store=store,
+        completion_fn=_recorder('{"supported": false, "rationale": "no assertion on the result"}'),
+    )
+    original = recorded.complete(MESSAGES, Verdict)
+
+    replayed = ModelClient(
+        model="anthropic/claude-sonnet-5",
+        mode=Mode.REPLAY,
+        store=store,
+        completion_fn=_exploding_completion_fn,
+    )
+
+    assert replayed.complete(MESSAGES, Verdict) == original
+
+
+def test_record_mode_serves_an_existing_transcript_without_re_billing(store):
+    """RECORD is record-if-missing: an already-recorded request is not re-called."""
+    completion_fn = _recorder('{"supported": true, "rationale": "ok"}')
+    client = ModelClient(
+        model="anthropic/claude-sonnet-5",
+        mode=Mode.RECORD,
+        store=store,
+        completion_fn=completion_fn,
+    )
+
+    first = client.complete(MESSAGES, Verdict)
+    second = client.complete(MESSAGES, Verdict)
+
+    assert first == second
+    assert len(completion_fn.calls) == 1
+
+
+def test_replay_without_a_transcript_raises_rather_than_calling_live(store):
+    client = ModelClient(
+        model="anthropic/claude-sonnet-5",
+        mode=Mode.REPLAY,
+        store=store,
+        completion_fn=_exploding_completion_fn,
+    )
+
+    with pytest.raises(TranscriptNotFoundError):
+        client.complete(MESSAGES, Verdict)
+
+
+def test_malformed_json_is_rejected_with_a_typed_error(store):
+    client = ModelClient(
+        model="anthropic/claude-sonnet-5",
+        mode=Mode.RECORD,
+        store=store,
+        completion_fn=_recorder("I think the test looks fine, honestly."),
+    )
+
+    with pytest.raises(SchemaValidationError):
+        client.complete(MESSAGES, Verdict)
+
+
+def test_schema_violating_response_is_rejected_with_a_typed_error(store):
+    client = ModelClient(
+        model="anthropic/claude-sonnet-5",
+        mode=Mode.RECORD,
+        store=store,
+        completion_fn=_recorder('{"supported": "yes-ish"}'),
+    )
+
+    with pytest.raises(SchemaValidationError):
+        client.complete(MESSAGES, Verdict)
+
+
+def test_non_text_content_is_rejected_with_a_typed_error(store):
+    def completion_fn(**kwargs):
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=None))],
+            usage=None,
+        )
+
+    client = ModelClient(
+        model="anthropic/claude-sonnet-5",
+        mode=Mode.RECORD,
+        store=store,
+        completion_fn=completion_fn,
+    )
+
+    with pytest.raises(SchemaValidationError):
+        client.complete(MESSAGES, Verdict)
+
+
+def test_request_key_is_stable_across_clients(store):
+    def build():
+        client = ModelClient(model="anthropic/claude-sonnet-5", store=store)
+        return client.build_request(MESSAGES, Verdict)
+
+    assert request_key(build()) == request_key(build())
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"model": "openai/gpt-5"},
+        {"temperature": 0.7},
+        {"seed": 42},
+    ],
+)
+def test_request_key_distinguishes_call_parameters(store, kwargs):
+    base = ModelClient(model="anthropic/claude-sonnet-5", store=store)
+    varied = ModelClient(**{"model": "anthropic/claude-sonnet-5", "store": store, **kwargs})
+
+    assert request_key(base.build_request(MESSAGES, Verdict)) != request_key(
+        varied.build_request(MESSAGES, Verdict)
+    )
+
+
+def test_request_key_distinguishes_prompt_and_schema(store):
+    client = ModelClient(model="anthropic/claude-sonnet-5", store=store)
+
+    class OtherVerdict(BaseModel):
+        supported: bool
+
+    assert request_key(client.build_request(MESSAGES, Verdict)) != request_key(
+        client.build_request([{"role": "user", "content": "different"}], Verdict)
+    )
+    assert request_key(client.build_request(MESSAGES, Verdict)) != request_key(
+        client.build_request(MESSAGES, OtherVerdict)
+    )
+
+
+def test_transcripts_record_no_wall_clock_state(store):
+    """Determinism guard: re-running the same input must reproduce byte-identical
+    state, so transcripts carry no timestamps or run ids (M0.5)."""
+    client = ModelClient(
+        model="anthropic/claude-sonnet-5",
+        mode=Mode.RECORD,
+        store=store,
+        completion_fn=_recorder('{"supported": true, "rationale": "ok"}'),
+    )
+    client.complete(MESSAGES, Verdict)
+
+    key = request_key(client.build_request(MESSAGES, Verdict))
+    record = json.loads(store.path_for(key).read_text())
+
+    assert set(record) == {"request", "response", "usage"}
+    assert set(record["usage"]) <= {
+        "prompt_tokens",
+        "completion_tokens",
+        "total_tokens",
+        "cost_usd",
+    }
+
+
+def test_harness_does_not_import_the_provider_stack(store):
+    """Capability tests run off transcripts with no live calls (CLAUDE.md M0.4/M0.5),
+    so an injected completion_fn must never drag LiteLLM in."""
+    already_imported = "litellm" in sys.modules
+    client = ModelClient(
+        model="anthropic/claude-sonnet-5",
+        mode=Mode.RECORD,
+        store=store,
+        completion_fn=_recorder('{"supported": true, "rationale": "ok"}'),
+    )
+
+    client.complete(MESSAGES, Verdict)
+
+    assert ("litellm" in sys.modules) == already_imported
+
+
+def test_recorded_transcripts_are_byte_identical_for_the_same_call(tmp_path):
+    """Two recordings of the same request/response produce identical bytes."""
+    content = '{"supported": true, "rationale": "ok"}'
+    written = []
+    for name in ("first", "second"):
+        store = TranscriptStore(tmp_path / name)
+        client = ModelClient(
+            model="anthropic/claude-sonnet-5",
+            mode=Mode.RECORD,
+            store=store,
+            completion_fn=_recorder(content),
+        )
+        client.complete(MESSAGES, Verdict)
+        key = request_key(client.build_request(MESSAGES, Verdict))
+        written.append(store.path_for(key).read_bytes())
+
+    assert written[0] == written[1]


### PR DESCRIPTION
Closes #4

## Summary
New `src/acceptance/llm.py`: a thin `ModelClient` that issues schema-constrained model calls, validates responses against a pydantic `response_model`, and records every prompt/response for replay.

- **Schema-constrained.** The `response_model`'s JSON schema is sent as a strict `json_schema` response format; the reply is validated via `model_validate_json`. Malformed JSON, schema violations, and non-text content all raise `SchemaValidationError` — never silently accepted.
- **Provider-agnostic via LiteLLM** (resolves the §3.2 "LLM orchestration boundary" decision toward a multi-provider library). The model is a config string (`anthropic/claude-sonnet-5`, `openai/gpt-5`, …), so providers can be compared on quality and cost without touching call sites; token usage and `cost_usd` are recorded per call.
- **Replay-first.** Content-addressed transcripts under `.acceptance/cache/transcripts/` (already reserved in `.gitignore`). `REPLAY` never calls a provider; a missing transcript raises `TranscriptNotFoundError` rather than silently falling back to the network. `RECORD` is record-*if-missing* — it serves an existing transcript instead of re-billing (§17 cost awareness).

## Design notes
- **LiteLLM is imported lazily, on the live path only** (cost lookup via `sys.modules.get`). The full harness suite passes with litellm *not installed*, so replay-mode runs — CI and this project's own tests — need neither the provider stack nor an API key. A test pins this so it can't silently regress.
- Transcripts carry **no timestamps or run ids**, so re-running the same input reproduces byte-identical state — M0.5's determinism acceptance builds directly on this.
- **CI install time will grow** (litellm has a large dependency tree). The lazy-import design leaves the door open to move litellm to an optional `[live]` extra so CI installs only pydantic — flagged for M0.5 if it becomes annoying.
- Response models must be **strict-mode compatible** (all fields required, no open-ended dicts) or the live call errors loudly rather than degrading to unconstrained text. M1's obligation schemas will need to honor this.
- Seed/temperature are plain constructor fields (part of request identity); the configuration layer around them is M0.5.

## Test plan
- [x] `pytest -q` — 45 tests pass, including: record→validate→persist, recorded transcript replays with **zero live calls**, replay-without-transcript raises, malformed/schema-violating/non-text responses each rejected with a typed error, request-key stability and sensitivity (model/temperature/seed/prompt/schema), byte-identical transcripts, and the "provider stack never imported" guard
- [x] `ruff check .` — clean
- [x] Manual demo script exercised the full record → on-disk transcript → replay (network fenced off) → unrecorded-prompt-raises cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)