### PR TITLE
M0.5: determinism controls with byte-identical review state

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,5 +1,5 @@
 ## Deliverable
-a thin layer that issues schema-constrained model calls, validates responses against the target schema, and records every prompt/response for replay.
+configurable seed/temperature and a replay/record mode.
 
 ## Acceptance
-a recorded transcript replays a full run with zero live model calls; a malformed model response is rejected with a typed error, not silently accepted.
+two consecutive recorded runs over the same input produce byte-identical review state.

--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -1,8 +1,10 @@
 """`acceptance` CLI entrypoint.
 
-Stage 1, M0.1: parses `check --task --base --head`, validates its inputs, and
-exits cleanly with an empty structured Review. Requirement interpretation,
-diffing, and reporting land in later M0/M1/M2 milestones.
+Parses `check --task --base --head` plus the M0.5 determinism controls
+(`--model`, `--mode`, `--seed`, `--temperature`), validates its inputs, and
+exits cleanly with an empty structured Review stamped with how it was produced.
+Requirement interpretation, diffing, and the §16 report land in later
+milestones; the pipeline that actually consumes the model client is M0.6.
 """
 
 from __future__ import annotations
@@ -13,6 +15,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from acceptance.config import DEFAULT_MODEL, RunConfig
+from acceptance.llm import Mode
 from acceptance.review_state import Review
 
 
@@ -42,11 +46,18 @@ def _read_task(task_path: str) -> str:
     return path.read_text()
 
 
-def run_check(task: str, base: str, head: str) -> Review:
+def run_check(task: str, base: str, head: str, config: RunConfig) -> Review:
     _read_task(task)
     _resolve_revision(base)
     head_sha = _resolve_revision(head)
-    return Review(mode="local", reviewed_revision=head_sha)
+    # No-op pipeline for now: the analysis that consumes config.build_client()
+    # is M0.6+. What M0.5 delivers is that the review records how it was
+    # produced, so two runs of the same input are provably reproducible.
+    return Review(
+        mode="local",
+        reviewed_revision=head_sha,
+        provenance=config.provenance(),
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -57,6 +68,22 @@ def build_parser() -> argparse.ArgumentParser:
     check.add_argument("--task", required=True, help="Path to the task file.")
     check.add_argument("--base", required=True, help="Base Git revision.")
     check.add_argument("--head", required=True, help="Head Git revision.")
+    check.add_argument(
+        "--model",
+        default=DEFAULT_MODEL,
+        help=f"Model to route via LiteLLM (default: {DEFAULT_MODEL}).",
+    )
+    check.add_argument(
+        "--mode",
+        choices=[m.value for m in Mode],
+        default=Mode.REPLAY.value,
+        help="record (live call on cache miss) or replay (transcripts only). "
+        "Default: replay — never issues a live call.",
+    )
+    check.add_argument("--seed", type=int, default=None, help="Model seed (determinism).")
+    check.add_argument(
+        "--temperature", type=float, default=0.0, help="Model temperature (default: 0.0)."
+    )
 
     return parser
 
@@ -66,8 +93,14 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.command == "check":
+        config = RunConfig(
+            model=args.model,
+            mode=Mode(args.mode),
+            seed=args.seed,
+            temperature=args.temperature,
+        )
         try:
-            review = run_check(args.task, args.base, args.head)
+            review = run_check(args.task, args.base, args.head, config)
         except CliError as exc:
             print(f"acceptance: error: {exc}", file=sys.stderr)
             return 1

--- a/src/acceptance/config.py
+++ b/src/acceptance/config.py
@@ -1,0 +1,60 @@
+"""Run configuration & determinism controls (M0.5, plan §3.2 "determinism strategy").
+
+Stage 1 resolves the determinism strategy as **fixed seed/temperature + cached
+transcripts** (record-if-missing, then replay). This makes two recorded runs
+over the same input reproduce byte-identical review state: identical requests
+hit identical transcripts, and both requests and review state serialize
+canonically (serialization.py). The alternative from §3.2 — N-sample majority
+with disclosed variance — is deferred to the benchmark harness (M-B0.4), which
+layers variance reporting on top of these controls rather than replacing them.
+
+`RunConfig` is the single surface for those controls; it builds the
+`ModelClient` the pipeline calls and stamps a matching `ReviewProvenance` onto
+the review so a reader can tell how it was produced.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from acceptance.llm import DEFAULT_TRANSCRIPT_ROOT, Mode, ModelClient, TranscriptStore
+from acceptance.review_state import ReviewProvenance
+
+DEFAULT_MODEL = "anthropic/claude-sonnet-5"
+
+
+class RunConfig(BaseModel):
+    """Configurable model, determinism mode, seed, and temperature for a run.
+
+    Defaults to REPLAY so the CLI and CI never issue a live call — or need an
+    API key — unless a run explicitly opts into RECORD.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    model: str = DEFAULT_MODEL
+    mode: Mode = Mode.REPLAY
+    temperature: float = 0.0
+    seed: int | None = None
+    transcript_root: Path = Field(default=DEFAULT_TRANSCRIPT_ROOT)
+
+    def build_client(self, completion_fn: Callable[..., Any] | None = None) -> ModelClient:
+        return ModelClient(
+            model=self.model,
+            mode=self.mode,
+            store=TranscriptStore(self.transcript_root),
+            temperature=self.temperature,
+            seed=self.seed,
+            completion_fn=completion_fn,
+        )
+
+    def provenance(self) -> ReviewProvenance:
+        return ReviewProvenance(
+            determinism_mode=self.mode.value,
+            model=self.model,
+            temperature=self.temperature,
+            seed=self.seed,
+        )

--- a/src/acceptance/llm.py
+++ b/src/acceptance/llm.py
@@ -33,6 +33,8 @@ from typing import Any, Callable, TypeVar
 
 from pydantic import BaseModel, ValidationError
 
+from acceptance.serialization import canonical_json
+
 DEFAULT_TRANSCRIPT_ROOT = Path(".acceptance/cache/transcripts")
 
 ResponseModelT = TypeVar("ResponseModelT", bound=BaseModel)
@@ -63,18 +65,13 @@ class TranscriptNotFoundError(LLMError):
     """REPLAY mode found no recorded transcript for a request."""
 
 
-def _canonical_json(payload: Any) -> str:
-    """Stable JSON: sorted keys, no incidental whitespace."""
-    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
-
-
 def request_key(request: dict) -> str:
     """Content-address a request.
 
     The response schema is part of the key: changing a `response_model`
     invalidates its old transcripts instead of replaying a stale shape.
     """
-    return hashlib.sha256(_canonical_json(request).encode("utf-8")).hexdigest()
+    return hashlib.sha256(canonical_json(request).encode("utf-8")).hexdigest()
 
 
 class TranscriptStore:
@@ -95,7 +92,7 @@ class TranscriptStore:
     def write(self, key: str, record: dict) -> None:
         self.root.mkdir(parents=True, exist_ok=True)
         # Canonical form: identical records serialize byte-identically (M0.5).
-        self.path_for(key).write_text(_canonical_json(record) + "\n")
+        self.path_for(key).write_text(canonical_json(record) + "\n")
 
 
 def _default_completion_fn(**kwargs: Any) -> Any:

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -17,6 +17,7 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from acceptance.evidence_tier import Component, EvidenceTier, authorize_tier
+from acceptance.serialization import canonical_json
 
 __all__ = [
     "Component",
@@ -31,6 +32,7 @@ __all__ = [
     "ExecutionEvidence",
     "Link",
     "Finding",
+    "ReviewProvenance",
     "Review",
 ]
 
@@ -172,9 +174,24 @@ class Finding(_Model):
         return self
 
 
+class ReviewProvenance(_Model):
+    """How a review was produced (§13.6 trustworthiness). Stored so a reader
+    can tell what determinism controls were in force — a fixed-seed replay is
+    reproducible in a way a live sampled run is not, and M-B0.4's variance
+    disclosure reads this. Mode is stored as its string value, not the harness
+    `Mode` enum, so the data model stays independent of the LLM harness.
+    """
+
+    determinism_mode: Literal["record", "replay"]
+    model: str
+    temperature: float
+    seed: int | None = None
+
+
 class Review(_Model):
     mode: str
     reviewed_revision: str
+    provenance: ReviewProvenance | None = None
     mandate: MandateInterpretation | None = None
     declaration: BuilderDeclaration | None = None
     change_set: ChangeSet | None = None
@@ -182,6 +199,12 @@ class Review(_Model):
     findings: list[Finding] = Field(default_factory=list)
     limitations: list[str] = Field(default_factory=list)
     recommendation: str | None = None
+
+    def to_canonical_json(self) -> str:
+        """Byte-stable persisted form: identical review state serializes to
+        identical bytes across runs (M0.5 acceptance). Distinct from the
+        human-readable CLI report rendered in M0.6."""
+        return canonical_json(self.to_dict())
 
     def evidence_tier_summary(self) -> dict[str, int]:
         """Tier counts derived from obligations/findings, not stored — the

--- a/src/acceptance/serialization.py
+++ b/src/acceptance/serialization.py
@@ -1,0 +1,18 @@
+"""Byte-stable serialization.
+
+One definition of "canonical" shared by the transcript store (M0.4) and
+persisted review state (M0.5): sorted keys and tight separators, so identical
+data serializes to identical bytes across runs, processes, and tool versions.
+This is what makes M0.5's "two recorded runs produce byte-identical review
+state" a property of the format, not an accident of dict insertion order.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def canonical_json(payload: Any) -> str:
+    """Deterministic JSON: sorted keys, no incidental whitespace."""
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,69 @@ def test_check_exits_zero_with_empty_structured_review(git_repo, fixture_task_pa
     assert review["recommendation"] is None
 
 
+def test_check_defaults_to_replay_mode_provenance(git_repo, fixture_task_path, capsys):
+    exit_code = main(
+        ["check", "--task", fixture_task_path, "--base", git_repo["base"], "--head", git_repo["head"]]
+    )
+
+    assert exit_code == 0
+    review = json.loads(capsys.readouterr().out)
+    # Default mode is replay so the CLI never issues a live call unbidden.
+    assert review["provenance"]["determinism_mode"] == "replay"
+    assert review["provenance"]["temperature"] == 0.0
+    assert review["provenance"]["seed"] is None
+
+
+def test_check_records_determinism_flags_in_provenance(git_repo, fixture_task_path, capsys):
+    exit_code = main(
+        [
+            "check",
+            "--task", fixture_task_path,
+            "--base", git_repo["base"],
+            "--head", git_repo["head"],
+            "--model", "openai/gpt-5",
+            "--mode", "record",
+            "--seed", "7",
+            "--temperature", "0.4",
+        ]
+    )
+
+    assert exit_code == 0
+    provenance = json.loads(capsys.readouterr().out)["provenance"]
+    assert provenance == {
+        "determinism_mode": "record",
+        "model": "openai/gpt-5",
+        "temperature": 0.4,
+        "seed": 7,
+    }
+
+
+def test_check_rejects_unknown_mode(git_repo, fixture_task_path):
+    with pytest.raises(SystemExit):
+        main(
+            [
+                "check",
+                "--task", fixture_task_path,
+                "--base", git_repo["base"],
+                "--head", git_repo["head"],
+                "--mode", "live",
+            ]
+        )
+
+
+def test_two_runs_over_the_same_input_are_byte_identical(git_repo, fixture_task_path, capsys):
+    args = [
+        "check", "--task", fixture_task_path, "--base", git_repo["base"], "--head", git_repo["head"]
+    ]
+
+    assert main(args) == 0
+    first = capsys.readouterr().out
+    assert main(args) == 0
+    second = capsys.readouterr().out
+
+    assert first == second
+
+
 def test_check_fails_cleanly_on_missing_task_file(git_repo, capsys):
     exit_code = main(
         ["check", "--task", "does-not-exist.md", "--base", git_repo["base"], "--head", git_repo["head"]]

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -1,0 +1,107 @@
+"""M0.5 acceptance: two consecutive recorded runs over the same input produce
+byte-identical review state.
+
+The strong version of this claim is that determinism comes from *transcript
+reuse*, not from the model happening to agree with itself. These tests use a
+provider stub that returns a DIFFERENT answer on every live call, then show
+the second run still matches the first byte-for-byte because it replayed the
+first run's transcript.
+"""
+
+import json
+from types import SimpleNamespace
+
+from pydantic import BaseModel
+
+from acceptance.config import RunConfig
+from acceptance.llm import Mode
+from acceptance.review_state import Component, EvidenceTier, Finding, Link, Review
+
+
+class Judgment(BaseModel):
+    supported: bool
+    rationale: str
+
+
+MESSAGES = [{"role": "user", "content": "Is obligation 1 supported?"}]
+
+
+def _drifting_provider():
+    """A provider whose answer changes on every call — the adversary for a
+    determinism guarantee. If review state ever depends on the live call
+    instead of the transcript, two runs diverge and the test fails."""
+    counter = {"n": 0}
+
+    def completion_fn(**kwargs):
+        counter["n"] += 1
+        content = json.dumps({"supported": True, "rationale": f"call #{counter['n']}"})
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+            usage=SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+        )
+
+    completion_fn.counter = counter
+    return completion_fn
+
+
+def _produce_review(config: RunConfig, completion_fn) -> Review:
+    """A stand-in review flow: consult the model, fold the answer into a
+    Finding, stamp provenance. Mirrors what the real M0.6+ pipeline will do."""
+    client = config.build_client(completion_fn=completion_fn)
+    judgment = client.complete(MESSAGES, Judgment)
+    finding = Finding(
+        type="obligation_support",
+        severity="info",
+        description=judgment.rationale,
+        evidence_tier=EvidenceTier.STATIC,
+        produced_by=Component.STATIC_ANALYZER,
+        links=[Link(kind="requirement", ref="task.md:1")],
+    )
+    return Review(
+        mode="local",
+        reviewed_revision="deadbeef",
+        provenance=config.provenance(),
+        findings=[finding],
+    )
+
+
+def test_two_recorded_runs_are_byte_identical(tmp_path):
+    config = RunConfig(
+        model="anthropic/claude-sonnet-5",
+        mode=Mode.RECORD,
+        transcript_root=tmp_path / "transcripts",
+    )
+    provider = _drifting_provider()
+
+    first = _produce_review(config, provider).to_canonical_json()
+    second = _produce_review(config, provider).to_canonical_json()
+
+    # Byte-identical despite the provider drifting — run 2 replayed run 1.
+    assert first == second
+    assert provider.counter["n"] == 1
+
+
+def test_replay_reproduces_a_recorded_run_with_no_live_call(tmp_path):
+    root = tmp_path / "transcripts"
+    record_cfg = RunConfig(mode=Mode.RECORD, transcript_root=root)
+    recorded = _produce_review(record_cfg, _drifting_provider()).to_canonical_json()
+
+    def forbidden(**kwargs):
+        raise AssertionError("replay issued a live call")
+
+    replay_cfg = RunConfig(mode=Mode.REPLAY, transcript_root=root)
+    replayed = _produce_review(replay_cfg, forbidden).to_canonical_json()
+
+    # Provenance differs by mode (record vs replay), so the review state is not
+    # expected to be byte-identical here — but the model-derived content is.
+    assert json.loads(replayed)["findings"] == json.loads(recorded)["findings"]
+
+
+def test_canonical_json_is_sorted_and_stable():
+    review = Review(mode="local", reviewed_revision="abc", provenance=None)
+    once = review.to_canonical_json()
+    twice = review.to_canonical_json()
+
+    assert once == twice
+    # Sorted keys: `findings` precedes `mode` precedes `reviewed_revision`.
+    assert once.index('"findings"') < once.index('"mode"') < once.index('"reviewed_revision"')


### PR DESCRIPTION
Closes #5

## Summary
Resolves the §3.2 **determinism strategy** decision as *fixed seed/temperature + cached transcripts* (record-if-missing, then replay). The N-sample-majority-with-disclosed-variance alternative is explicitly deferred to the benchmark harness (M-B0.4, #10), which layers variance reporting on top of these controls.

- **`src/acceptance/config.py` — `RunConfig`**: the single surface for `model`, `mode` (record/replay), `seed`, `temperature`, and transcript root. Defaults to **REPLAY** so the CLI and CI never issue a live call — or need an API key — unbidden. Builds the `ModelClient` the pipeline calls and stamps a matching `ReviewProvenance`.
- **`src/acceptance/serialization.py` — `canonical_json`**: one definition of byte-stable JSON (sorted keys, tight separators) shared by the transcript store and review state. `llm.py`'s private `_canonical_json` is promoted here (small refactor to just-merged code).
- **`review_state.py`**: `ReviewProvenance` (determinism mode / model / seed / temperature) recorded on `Review`, serving §13.6 trustworthiness and M-B0.4 variance disclosure. `Review.to_canonical_json()` gives the byte-stable persisted form, kept distinct from the human-readable §16 report (M0.6). Mode is stored as its string value, so the data model stays independent of the LLM harness.
- **`cli.py`**: `--model` / `--mode` / `--seed` / `--temperature` build a `RunConfig`; existing no-flag invocations are unchanged. The no-op pipeline stamps provenance so runs are provably reproducible; the pipeline that actually consumes the client is M0.6.

## How the acceptance is proven
"Two consecutive recorded runs over the same input produce byte-identical review state" — proven the *strong* way: the determinism test records twice with a **drifting provider stub** (a different answer on every live call) and asserts byte-identical review state. That shows byte-identity comes from **transcript reuse**, not from the model happening to agree with itself. A replay run then reproduces a recorded run with a provider that raises on any live call. End-to-end, two CLI runs over the same input are byte-identical.

## Test plan
- [x] `pytest -q` — 52 tests pass (new `tests/test_determinism.py` for the byte-identity guarantee + `tests/test_cli.py` provenance/flag coverage)
- [x] `ruff check .` — clean
- [x] No pydantic protected-namespace warning from the `model` field (verified under `-W error::UserWarning`)
- [x] Manual end-to-end: two default (replay) CLI runs are byte-identical; `--model/--mode/--seed/--temperature` flow into the recorded provenance block

🤖 Generated with [Claude Code](https://claude.com/claude-code)