### PR TITLE
M0.6: end-to-end walking skeleton

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,5 +1,5 @@
 ## Deliverable
-configurable seed/temperature and a replay/record mode.
+end-to-end no-op pipeline: ingest task + diff → write an empty but well-formed Review to the state store → render an empty CLI report.
 
 ## Acceptance
-two consecutive recorded runs over the same input produce byte-identical review state.
+the §16 CLI shell renders with all sections present and empty; no unhandled exceptions.

--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -2,9 +2,10 @@
 
 Parses `check --task --base --head` plus the M0.5 determinism controls
 (`--model`, `--mode`, `--seed`, `--temperature`), validates its inputs, and
-exits cleanly with an empty structured Review stamped with how it was produced.
-Requirement interpretation, diffing, and the §16 report land in later
-milestones; the pipeline that actually consumes the model client is M0.6.
+runs the M0.6 walking-skeleton pipeline: ingest task + revisions → write an
+empty but well-formed Review to the state store → render the §16 report.
+Requirement interpretation, real diffing, and test analysis land in later
+milestones; the sections render present-and-empty until then.
 """
 
 from __future__ import annotations
@@ -17,7 +18,9 @@ from pathlib import Path
 
 from acceptance.config import DEFAULT_MODEL, RunConfig
 from acceptance.llm import Mode
-from acceptance.review_state import Review
+from acceptance.report import render_report
+from acceptance.review_state import ChangeSet, Review
+from acceptance.review_store import ReviewStore
 
 
 class CliError(Exception):
@@ -46,18 +49,27 @@ def _read_task(task_path: str) -> str:
     return path.read_text()
 
 
-def run_check(task: str, base: str, head: str, config: RunConfig) -> Review:
+def run_check(
+    task: str, base: str, head: str, config: RunConfig, store: ReviewStore
+) -> Review:
+    """Walking-skeleton pipeline: ingest → build empty Review → persist.
+
+    The obligation/coverage/test analysis that consumes config.build_client()
+    lands in M1+. What is real here is the end-to-end shape: a task and a
+    revision range in, a well-formed persisted Review out.
+    """
     _read_task(task)
-    _resolve_revision(base)
+    base_sha = _resolve_revision(base)
     head_sha = _resolve_revision(head)
-    # No-op pipeline for now: the analysis that consumes config.build_client()
-    # is M0.6+. What M0.5 delivers is that the review records how it was
-    # produced, so two runs of the same input are provably reproducible.
-    return Review(
+    review = Review(
         mode="local",
         reviewed_revision=head_sha,
         provenance=config.provenance(),
+        # Diff endpoints only; real change extraction (files, diffs) is M2.
+        change_set=ChangeSet(base_revision=base_sha, head_revision=head_sha),
     )
+    store.write(review)
+    return review
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -84,6 +96,11 @@ def build_parser() -> argparse.ArgumentParser:
     check.add_argument(
         "--temperature", type=float, default=0.0, help="Model temperature (default: 0.0)."
     )
+    check.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the structured Review as JSON instead of the §16 report.",
+    )
 
     return parser
 
@@ -100,11 +117,14 @@ def main(argv: list[str] | None = None) -> int:
             temperature=args.temperature,
         )
         try:
-            review = run_check(args.task, args.base, args.head, config)
+            review = run_check(args.task, args.base, args.head, config, ReviewStore())
         except CliError as exc:
             print(f"acceptance: error: {exc}", file=sys.stderr)
             return 1
-        print(json.dumps(review.to_dict(), indent=2))
+        if args.json:
+            print(json.dumps(review.to_dict(), indent=2))
+        else:
+            print(render_report(review))
         return 0
 
     parser.error(f"unknown command: {args.command}")

--- a/src/acceptance/report.py
+++ b/src/acceptance/report.py
@@ -1,0 +1,56 @@
+"""§16 CLI report rendering (M0.6).
+
+Renders a Review as the human-readable §16 shell — every section always
+present, empty ones shown as "(none)". This is the walking skeleton's output:
+with an empty Review it prints the full shape with nothing in it, and later
+milestones (M3 coverage classification, M5 test evidence, M7 verdict and
+next-instruction) fill the sections in.
+
+The completion status is INDETERMINATE for a review with no analyzed
+obligations — a first-class, valid outcome (§9.3), not a fabricated verdict.
+M7.2 adds the real computed verdict.
+"""
+
+from __future__ import annotations
+
+from acceptance.review_state import Review
+
+_EMPTY = "  (none)"
+
+# M3 replaces this with real ✓/✗/? coverage classification per obligation.
+_OBLIGATION_MARKER = "?"
+
+
+def render_report(review: Review) -> str:
+    lines: list[str] = [f"Task completion: {_completion_status(review)}", ""]
+
+    lines.append("Obligation coverage:")
+    if review.obligation_map:
+        lines += [f"  {_OBLIGATION_MARKER} {o.description}" for o in review.obligation_map]
+    else:
+        lines.append(_EMPTY)
+    lines.append("")
+
+    lines.append("Test evidence:")
+    if review.findings:
+        for finding in review.findings:
+            tier = finding.evidence_tier.name.lower().replace("_", "-")
+            lines.append(f"  - {finding.description} [{tier}]")
+    else:
+        lines.append(_EMPTY)
+    lines.append("")
+
+    lines.append("Unrequested changes:")
+    # Unrequested-change detection is M3.2; the section is present but empty.
+    lines.append(_EMPTY)
+    lines.append("")
+
+    lines.append(f"Recommended next instruction: {review.recommendation or '(none)'}")
+
+    return "\n".join(lines)
+
+
+def _completion_status(review: Review) -> str:
+    # M7.2 computes the real verdict from obligation/finding state; until then a
+    # review with nothing analyzed is honestly INDETERMINATE (§9.3).
+    return "INDETERMINATE"

--- a/src/acceptance/review_store.py
+++ b/src/acceptance/review_store.py
@@ -1,0 +1,39 @@
+"""Persisted review-state store (M0.6).
+
+The CLAUDE.md invariant is that review state is structured and persisted, not
+an unstructured transcript — and that the store exists early so later
+components write into it rather than inventing their own persistence. This is
+that store: it writes a Review to disk in the canonical byte-stable form
+(serialization.py) and reads it back, keyed by the reviewed revision so a
+re-run against the same head overwrites in place (the incremental-rerun
+scenario, M7.5).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from acceptance.review_state import Review
+
+DEFAULT_REVIEW_ROOT = Path(".acceptance/cache/reviews")
+
+
+class ReviewStore:
+    def __init__(self, root: Path | str = DEFAULT_REVIEW_ROOT) -> None:
+        self.root = Path(root)
+
+    def path_for(self, reviewed_revision: str) -> Path:
+        return self.root / f"{reviewed_revision}.json"
+
+    def write(self, review: Review) -> Path:
+        self.root.mkdir(parents=True, exist_ok=True)
+        path = self.path_for(review.reviewed_revision)
+        path.write_text(review.to_canonical_json() + "\n")
+        return path
+
+    def read(self, reviewed_revision: str) -> Review | None:
+        path = self.path_for(reviewed_revision)
+        if not path.is_file():
+            return None
+        return Review.from_dict(json.loads(path.read_text()))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,9 +5,9 @@ import pytest
 from acceptance.cli import main
 
 
-def test_check_exits_zero_with_empty_structured_review(git_repo, fixture_task_path, capsys):
+def test_check_json_emits_empty_structured_review(git_repo, fixture_task_path, capsys):
     exit_code = main(
-        ["check", "--task", fixture_task_path, "--base", git_repo["base"], "--head", git_repo["head"]]
+        ["check", "--json", "--task", fixture_task_path, "--base", git_repo["base"], "--head", git_repo["head"]]
     )
 
     assert exit_code == 0
@@ -16,7 +16,10 @@ def test_check_exits_zero_with_empty_structured_review(git_repo, fixture_task_pa
     assert review["reviewed_revision"] == git_repo["head"]
     assert review["mandate"] is None
     assert review["declaration"] is None
-    assert review["change_set"] is None
+    # Diff endpoints are ingested; file-level diffing is still M2.
+    assert review["change_set"]["base_revision"] == git_repo["base"]
+    assert review["change_set"]["head_revision"] == git_repo["head"]
+    assert review["change_set"]["changed_files"] == []
     assert review["obligation_map"] == []
     assert review["findings"] == []
     assert review["limitations"] == []
@@ -25,7 +28,7 @@ def test_check_exits_zero_with_empty_structured_review(git_repo, fixture_task_pa
 
 def test_check_defaults_to_replay_mode_provenance(git_repo, fixture_task_path, capsys):
     exit_code = main(
-        ["check", "--task", fixture_task_path, "--base", git_repo["base"], "--head", git_repo["head"]]
+        ["check", "--json", "--task", fixture_task_path, "--base", git_repo["base"], "--head", git_repo["head"]]
     )
 
     assert exit_code == 0
@@ -39,7 +42,7 @@ def test_check_defaults_to_replay_mode_provenance(git_repo, fixture_task_path, c
 def test_check_records_determinism_flags_in_provenance(git_repo, fixture_task_path, capsys):
     exit_code = main(
         [
-            "check",
+            "check", "--json",
             "--task", fixture_task_path,
             "--base", git_repo["base"],
             "--head", git_repo["head"],
@@ -84,6 +87,37 @@ def test_two_runs_over_the_same_input_are_byte_identical(git_repo, fixture_task_
     second = capsys.readouterr().out
 
     assert first == second
+
+
+def test_report_shell_renders_all_sections_present_and_empty(git_repo, fixture_task_path, capsys):
+    exit_code = main(
+        ["check", "--task", fixture_task_path, "--base", git_repo["base"], "--head", git_repo["head"]]
+    )
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    # Every §16 section present...
+    assert "Task completion: INDETERMINATE" in out
+    assert "Obligation coverage:" in out
+    assert "Test evidence:" in out
+    assert "Unrequested changes:" in out
+    assert "Recommended next instruction: (none)" in out
+    # ...and empty in the walking skeleton.
+    assert out.count("(none)") == 4  # 3 list sections + the next-instruction line
+
+
+def test_check_persists_the_review_to_the_store(git_repo, fixture_task_path):
+    from acceptance.review_store import ReviewStore
+
+    assert main(
+        ["check", "--task", fixture_task_path, "--base", git_repo["base"], "--head", git_repo["head"]]
+    ) == 0
+
+    # ReviewStore() defaults under the (chdir'd) repo; the review is keyed by head.
+    stored = ReviewStore().read(git_repo["head"])
+    assert stored is not None
+    assert stored.reviewed_revision == git_repo["head"]
+    assert stored.change_set.base_revision == git_repo["base"]
 
 
 def test_check_fails_cleanly_on_missing_task_file(git_repo, capsys):

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,55 @@
+from acceptance.report import render_report
+from acceptance.review_state import Component, EvidenceTier, Finding, Link, Obligation, Review
+
+
+def test_empty_review_renders_the_full_shell():
+    report = render_report(Review(mode="local", reviewed_revision="abc"))
+
+    assert report == (
+        "Task completion: INDETERMINATE\n"
+        "\n"
+        "Obligation coverage:\n"
+        "  (none)\n"
+        "\n"
+        "Test evidence:\n"
+        "  (none)\n"
+        "\n"
+        "Unrequested changes:\n"
+        "  (none)\n"
+        "\n"
+        "Recommended next instruction: (none)"
+    )
+
+
+def test_populated_review_lists_obligations_and_findings():
+    review = Review(
+        mode="local",
+        reviewed_revision="abc",
+        obligation_map=[
+            Obligation(
+                description="Coupons use index + spread.",
+                type="behavior",
+                source_text="...",
+                importance="critical",
+                explicit=True,
+                observable_behavior="...",
+            )
+        ],
+        findings=[
+            Finding(
+                type="weak_test_evidence",
+                severity="high",
+                description="Filter behavior unsupported",
+                evidence_tier=EvidenceTier.STATIC,
+                produced_by=Component.STATIC_ANALYZER,
+                links=[Link(kind="test", ref="tests/t.py:1")],
+            )
+        ],
+        recommendation=".acceptance/next-instruction.md",
+    )
+
+    report = render_report(review)
+
+    assert "  ? Coupons use index + spread." in report
+    assert "  - Filter behavior unsupported [static]" in report
+    assert "Recommended next instruction: .acceptance/next-instruction.md" in report

--- a/tests/test_review_store.py
+++ b/tests/test_review_store.py
@@ -1,0 +1,38 @@
+from acceptance.review_state import ChangeSet, Review
+from acceptance.review_store import ReviewStore
+
+
+def test_read_missing_revision_returns_none(tmp_path):
+    store = ReviewStore(tmp_path / "reviews")
+    assert store.read("deadbeef") is None
+
+
+def test_review_round_trips_through_the_store(tmp_path):
+    store = ReviewStore(tmp_path / "reviews")
+    review = Review(
+        mode="local",
+        reviewed_revision="head1",
+        change_set=ChangeSet(base_revision="base1", head_revision="head1"),
+    )
+
+    store.write(review)
+
+    assert store.read("head1") == review
+
+
+def test_rerun_over_the_same_head_overwrites_in_place(tmp_path):
+    store = ReviewStore(tmp_path / "reviews")
+    store.write(Review(mode="local", reviewed_revision="head1", recommendation="first"))
+    store.write(Review(mode="local", reviewed_revision="head1", recommendation="second"))
+
+    assert store.read("head1").recommendation == "second"
+    assert list((tmp_path / "reviews").glob("*.json")) == [store.path_for("head1")]
+
+
+def test_stored_form_is_canonical(tmp_path):
+    store = ReviewStore(tmp_path / "reviews")
+    review = Review(mode="local", reviewed_revision="head1")
+
+    path = store.write(review)
+
+    assert path.read_text() == review.to_canonical_json() + "\n"


### PR DESCRIPTION
Closes #6

## Summary
Wires the no-op pipeline end to end: **ingest task + revision range → write an empty but well-formed Review to the state store → render the §16 report.** This completes milestone M0.

- **`src/acceptance/review_store.py` — `ReviewStore`**: persists a `Review` in the canonical byte-stable form, keyed by reviewed revision so a re-run against the same head overwrites in place (the M7.5 incremental-rerun path). This is the persisted review-state store the CLAUDE.md invariant calls for — built before the capabilities that write into it. Lives under `.acceptance/cache/reviews/` (gitignored, verified).
- **`src/acceptance/report.py` — `render_report`**: the §16 shell — *Task completion, Obligation coverage, Test evidence, Unrequested changes, Recommended next instruction* — every section always present, empty ones shown as `(none)`. An unanalyzed review is honestly `INDETERMINATE` (§9.3), not a fabricated verdict; the real computed verdict and per-obligation ✓/✗/? markers come from M7.2 and M3.
- **`cli.py`**: `run_check` now ingests the diff endpoints into a `ChangeSet` (real file/diff extraction is M2), persists to the store, and returns the Review. Default output is the §16 report; `--json` emits the structured Review (existing structured-output tests moved to that flag).

## Test plan
- [x] `pytest -q` — 60 tests pass, including the acceptance (`test_report_shell_renders_all_sections_present_and_empty`: all five sections present, empty, no exception), store round-trip / overwrite-in-place / canonical-form tests, and report unit tests for both empty and populated reviews
- [x] `ruff check .` — clean
- [x] Manual end-to-end: the §16 report renders; the review is persisted to `.acceptance/cache/reviews/<head>.json`; `--json` shows the ingested diff endpoints and provenance
- [x] Confirmed the review-store path is gitignored — no run artifacts leak into the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)