### PR TITLE
M-B0.1: benchmark-case schema

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,5 +1,5 @@
 ## Deliverable
-end-to-end no-op pipeline: ingest task + diff → write an empty but well-formed Review to the state store → render an empty CLI report.
+a case type carrying source (dataset/PR/mutant/agent/archetype), inputs, ground-truth labels (gaps, decomposition, mappings, evidence classes), and slots for reviewer output + score.
 
 ## Acceptance
-the §16 CLI shell renders with all sections present and empty; no unhandled exceptions.
+a case serializes/deserializes; a case missing ground-truth labels fails validation.

--- a/src/acceptance/benchmark/__init__.py
+++ b/src/acceptance/benchmark/__init__.py
@@ -1,0 +1,1 @@
+"""Validation benchmark: case schema, checker-under-test runner, and scoring (M-B0)."""

--- a/src/acceptance/benchmark/case.py
+++ b/src/acceptance/benchmark/case.py
@@ -1,0 +1,108 @@
+"""Benchmark-case schema (§15 Benchmark case, §11.1 metrics; M-B0.1).
+
+A case pairs a real (or offline-mutated, or hand-curated) input with
+human-verified ground truth, so the checker's output can be scored against
+it. The four ground-truth categories on `GroundTruthLabels` map directly to
+§11.1's metrics:
+
+    gaps          -> gap-detection recall / false-alarm precision
+    decomposition -> obligation-decomposition accuracy
+    mappings      -> test-to-obligation mapping accuracy
+    evidence_classes -> evidence-classification agreement
+
+`reviewer_output` and `score` start empty and are filled in by later
+milestones (M-B0.2's checker-under-test runner, M-B0.3's scoring) — a case is
+valid the moment it carries real ground truth, before it has ever been run.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field, model_validator
+
+from acceptance.model_base import PersistableModel
+from acceptance.review_state import Review
+
+# §9.3 test-evidence strength classifications. Distinct from EvidenceTier
+# (evidence_tier.py), which grades *how* evidence was produced, not how
+# strong it is.
+EvidenceClassification = Literal[
+    "strongly_supported",
+    "partially_supported",
+    "nominally_supported",
+    "unsupported",
+    "requires_other_evidence",
+    "indeterminate",
+]
+
+
+class BenchmarkCaseSource(PersistableModel):
+    kind: Literal["dataset", "real_pr", "mutant", "agent_run", "archetype"]
+    identifier: str
+
+
+class BenchmarkCaseInputs(PersistableModel):
+    """What the checker-under-test runner (M-B0.2) feeds to the checker."""
+
+    repo: str
+    task_text: str
+    base_revision: str
+    head_revision: str
+    declaration_text: str | None = None
+
+
+class GroundTruthGap(PersistableModel):
+    description: str
+    obligation_ref: str | None = None
+    severity: str | None = None
+
+
+class GroundTruthDecompositionItem(PersistableModel):
+    description: str
+    explicit: bool
+
+
+class GroundTruthMapping(PersistableModel):
+    test_id: str
+    obligation_ref: str
+
+
+class GroundTruthEvidenceClass(PersistableModel):
+    obligation_ref: str
+    classification: EvidenceClassification
+
+
+class GroundTruthLabels(PersistableModel):
+    gaps: list[GroundTruthGap] = Field(default_factory=list)
+    decomposition: list[GroundTruthDecompositionItem] = Field(default_factory=list)
+    mappings: list[GroundTruthMapping] = Field(default_factory=list)
+    evidence_classes: list[GroundTruthEvidenceClass] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _require_at_least_one_label(self) -> "GroundTruthLabels":
+        if not (self.gaps or self.decomposition or self.mappings or self.evidence_classes):
+            raise ValueError(
+                "GroundTruthLabels requires at least one label "
+                "(gaps, decomposition, mappings, or evidence_classes)"
+            )
+        return self
+
+
+class BenchmarkScore(PersistableModel):
+    """§11.1 metrics computed for a case, once scored (M-B0.3)."""
+
+    gap_recall: float | None = None
+    gap_precision: float | None = None
+    decomposition_accuracy: float | None = None
+    mapping_accuracy: float | None = None
+    evidence_agreement: float | None = None
+
+
+class BenchmarkCase(PersistableModel):
+    case_id: str
+    source: BenchmarkCaseSource
+    inputs: BenchmarkCaseInputs
+    ground_truth: GroundTruthLabels
+    reviewer_output: Review | None = None
+    score: BenchmarkScore | None = None

--- a/src/acceptance/model_base.py
+++ b/src/acceptance/model_base.py
@@ -1,0 +1,23 @@
+"""Shared base for typed, persisted schemas across the checker and benchmark.
+
+One definition of "strict, round-trippable pydantic model" used by both
+review_state.py and benchmark/case.py, so serialization behaves identically
+everywhere rather than being redefined per module.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class PersistableModel(BaseModel):
+    """Strict fields (no silent extras), uniform to_dict()/from_dict()."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    def to_dict(self) -> dict:
+        return self.model_dump(mode="json")
+
+    @classmethod
+    def from_dict(cls, data: dict):
+        return cls.model_validate(data)

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -3,8 +3,9 @@
 Typed, persisted review state: obligations, mappings, findings, and evidence
 tiers are explicit fields, not free text (CLAUDE.md invariant). Findings also
 record which component produced them and are validated against that
-component's authorized tier ceiling (evidence_tier.py, M0.3). Benchmark case
-is out of scope (M-B0).
+component's authorized tier ceiling (evidence_tier.py, M0.3). The Benchmark
+case schema (M-B0.1) lives in benchmark/case.py and reuses Review here as its
+reviewer-output slot rather than duplicating it.
 
 Schemas are pydantic models: validation and round-trip (de)serialization come
 from the library rather than hand-rolled per class.
@@ -14,9 +15,10 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
 
 from acceptance.evidence_tier import Component, EvidenceTier, authorize_tier
+from acceptance.model_base import PersistableModel as _Model
 from acceptance.serialization import canonical_json
 
 __all__ = [
@@ -35,19 +37,6 @@ __all__ = [
     "ReviewProvenance",
     "Review",
 ]
-
-
-class _Model(BaseModel):
-    """Base for all review-state schemas: strict fields, uniform persistence."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    def to_dict(self) -> dict:
-        return self.model_dump(mode="json")
-
-    @classmethod
-    def from_dict(cls, data: dict):
-        return cls.model_validate(data)
 
 
 class Project(_Model):

--- a/tests/benchmark/test_case.py
+++ b/tests/benchmark/test_case.py
@@ -1,0 +1,115 @@
+import json
+
+import pytest
+
+from acceptance.benchmark.case import (
+    BenchmarkCase,
+    BenchmarkCaseInputs,
+    BenchmarkCaseSource,
+    BenchmarkScore,
+    GroundTruthDecompositionItem,
+    GroundTruthEvidenceClass,
+    GroundTruthGap,
+    GroundTruthLabels,
+    GroundTruthMapping,
+)
+from acceptance.review_state import Review
+
+
+def _round_trip(instance):
+    cls = type(instance)
+    persisted = json.loads(json.dumps(instance.to_dict()))
+    return cls.from_dict(persisted)
+
+
+def _case(**overrides) -> BenchmarkCase:
+    defaults = dict(
+        case_id="archetype-01",
+        source=BenchmarkCaseSource(kind="archetype", identifier="missed-obligation"),
+        inputs=BenchmarkCaseInputs(
+            repo="fixtures/archetype-01",
+            task_text="## Deliverable\nAdd CSV export.\n",
+            base_revision="abc123",
+            head_revision="def456",
+        ),
+        ground_truth=GroundTruthLabels(
+            gaps=[GroundTruthGap(description="Active filters not applied")]
+        ),
+    )
+    defaults.update(overrides)
+    return BenchmarkCase(**defaults)
+
+
+def test_benchmark_case_round_trips():
+    case = _case()
+    assert _round_trip(case) == case
+
+
+def test_benchmark_case_round_trips_with_reviewer_output_and_score():
+    case = _case(
+        reviewer_output=Review(mode="local", reviewed_revision="def456"),
+        score=BenchmarkScore(gap_recall=1.0, gap_precision=0.5),
+    )
+    assert _round_trip(case) == case
+
+
+def test_case_missing_ground_truth_entirely_fails_validation():
+    with pytest.raises(ValueError):
+        BenchmarkCase(
+            case_id="archetype-01",
+            source=BenchmarkCaseSource(kind="archetype", identifier="missed-obligation"),
+            inputs=BenchmarkCaseInputs(
+                repo="fixtures/archetype-01",
+                task_text="...",
+                base_revision="abc123",
+                head_revision="def456",
+            ),
+        )
+
+
+def test_empty_ground_truth_labels_fails_validation():
+    with pytest.raises(ValueError):
+        GroundTruthLabels()
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"gaps": [GroundTruthGap(description="Filter behavior unsupported")]},
+        {"decomposition": [GroundTruthDecompositionItem(description="CSV export", explicit=True)]},
+        {"mappings": [GroundTruthMapping(test_id="test_csv", obligation_ref="csv-export")]},
+        {
+            "evidence_classes": [
+                GroundTruthEvidenceClass(obligation_ref="csv-export", classification="unsupported")
+            ]
+        },
+    ],
+)
+def test_each_ground_truth_category_alone_is_sufficient(kwargs):
+    labels = GroundTruthLabels(**kwargs)
+    assert _round_trip(labels) == labels
+
+
+def test_ground_truth_evidence_classification_rejects_unknown_value():
+    with pytest.raises(ValueError):
+        GroundTruthLabels(
+            evidence_classes=[
+                GroundTruthEvidenceClass(obligation_ref="csv-export", classification="bogus")
+            ]
+        )
+
+
+def test_benchmark_case_source_round_trips():
+    source = BenchmarkCaseSource(kind="real_pr", identifier="https://github.com/org/repo/pull/1")
+    assert _round_trip(source) == source
+
+
+def test_benchmark_case_inputs_round_trips_with_declaration():
+    inputs = BenchmarkCaseInputs(
+        repo="org/repo",
+        task_text="...",
+        base_revision="abc123",
+        head_revision="def456",
+        declaration_text="## Mandate as understood\n...",
+    )
+    assert _round_trip(inputs) == inputs


### PR DESCRIPTION
Closes #7

## Summary
New `src/acceptance/benchmark/case.py`: `BenchmarkCase` (§15 Benchmark case), carrying source (`dataset`/`real_pr`/`mutant`/`agent_run`/`archetype`), inputs (repo, task text, revisions, optional declaration), ground-truth labels, and slots for reviewer output + score.

- **`GroundTruthLabels`** has the four categories the deliverable names, each mapping to one §11.1 metric: `gaps` (recall/precision), `decomposition` (obligation-decomposition accuracy), `mappings` (test-to-obligation mapping accuracy), `evidence_classes` (evidence-classification agreement, using the six §9.3 classifications — `strongly_supported` … `indeterminate` — a distinct scheme from `EvidenceTier`, which grades *how* evidence was produced rather than how strong it is).
- A validator requires **at least one** category to be non-empty, mirroring the `Finding.links` pattern from M0.2/M0.3: "missing ground-truth labels" means substantively empty, not just technically absent as a field.
- `reviewer_output` reuses `review_state.Review` directly rather than duplicating a parallel type — a case's reviewer output *is* a Review.
- Promotes the shared pydantic base (`extra="forbid"`, `to_dict`/`from_dict`) out of `review_state.py` into `model_base.py`, so `benchmark/case.py` shares identical persistence behavior with the checker's own schemas instead of redefining it — same pattern as `serialization.py`'s `canonical_json` in M0.5.

## Test plan
- [x] `pytest -q` — 71 tests pass: round-trip for `BenchmarkCase` and every nested type (including with `reviewer_output`/`score` populated), the acceptance ("a case missing ground-truth labels fails validation" — tested both as a missing field and as an all-empty `GroundTruthLabels`), each of the four ground-truth categories independently sufficient, and an unknown evidence classification rejected
- [x] `ruff check .` — clean
- [x] Manually verified `extra="forbid"` still holds on `review_state.Review` after the `model_base` refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)