### PR TITLE
M-B0.2: checker-under-test runner

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,5 +1,5 @@
 ## Deliverable
-a case type carrying source (dataset/PR/mutant/agent/archetype), inputs, ground-truth labels (gaps, decomposition, mappings, evidence classes), and slots for reviewer output + score.
+a runner that feeds a case's inputs through the current checker and captures its Review output against the case.
 
 ## Acceptance
-a case serializes/deserializes; a case missing ground-truth labels fails validation.
+running the empty skeleton over an archetype case yields a scored (all-miss) result without error.

--- a/src/acceptance/benchmark/runner.py
+++ b/src/acceptance/benchmark/runner.py
@@ -1,0 +1,51 @@
+"""Checker-under-test runner (M-B0.2).
+
+Feeds a BenchmarkCase's inputs through the current checker (M0.6's
+`run_check` pipeline) and returns a new case with `reviewer_output` and
+`score` filled in. Cases are treated as data, not mutated in place: the
+input case is untouched, and a copy carries the result.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from acceptance.benchmark.case import BenchmarkCase
+from acceptance.benchmark.scoring import score_case
+from acceptance.cli import run_check
+from acceptance.config import RunConfig
+from acceptance.review_store import ReviewStore
+
+
+def run_case(
+    case: BenchmarkCase,
+    config: RunConfig | None = None,
+    review_store: ReviewStore | None = None,
+) -> BenchmarkCase:
+    """Run the checker over `case.inputs` and return a scored copy of `case`."""
+    config = config if config is not None else RunConfig()
+    review_store = review_store if review_store is not None else ReviewStore()
+    repo = Path(case.inputs.repo)
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".md", delete=False, encoding="utf-8"
+    ) as task_file:
+        task_file.write(case.inputs.task_text)
+        task_path = Path(task_file.name)
+
+    try:
+        review = run_check(
+            task=str(task_path),
+            base=case.inputs.base_revision,
+            head=case.inputs.head_revision,
+            config=config,
+            store=review_store,
+            repo=repo,
+        )
+    finally:
+        task_path.unlink(missing_ok=True)
+
+    scored_case = case.model_copy(update={"reviewer_output": review})
+    scored_case = scored_case.model_copy(update={"score": score_case(scored_case)})
+    return scored_case

--- a/src/acceptance/benchmark/scoring.py
+++ b/src/acceptance/benchmark/scoring.py
@@ -1,0 +1,78 @@
+"""Minimal per-case scoring (M-B0.2).
+
+This is deliberately narrow: just enough to satisfy M-B0.2's own acceptance
+check ("running the empty skeleton over an archetype case yields a scored
+(all-miss) result"). It counts exact ref matches between a case's ground
+truth and its reviewer_output. M-B0.3 owns the real rubric — matching
+semantics beyond exact refs, aggregation into a report across a case set,
+and false-alarm/agreement scoring nuance — and supersedes this module rather
+than building alongside it.
+
+A ratio is `None` when it is mathematically undefined rather than a
+misleading 0.0 or 1.0: precision with zero reported findings, or evidence
+agreement with zero reported classifications, has nothing to be right or
+wrong about.
+"""
+
+from __future__ import annotations
+
+from acceptance.benchmark.case import BenchmarkCase, BenchmarkScore
+
+
+def score_case(case: BenchmarkCase) -> BenchmarkScore:
+    review = case.reviewer_output
+    if review is None:
+        raise ValueError("cannot score a case with no reviewer_output")
+    gt = case.ground_truth
+
+    reported_gap_refs = {
+        f.related_obligation for f in review.findings if f.related_obligation is not None
+    }
+    reported_obligation_refs = {o.description for o in review.obligation_map}
+    reported_mapping_refs = {
+        (t, o) for o in review.obligation_map for t in o.test_evidence
+    }
+    reported_evidence_refs = {
+        (f.related_obligation, f.evidence_tier.name)
+        for f in review.findings
+        if f.related_obligation is not None
+    }
+
+    return BenchmarkScore(
+        gap_recall=_recall(
+            ground_truth_refs={g.obligation_ref for g in gt.gaps if g.obligation_ref},
+            reported_refs=reported_gap_refs,
+        ),
+        gap_precision=_precision(
+            ground_truth_refs={g.obligation_ref for g in gt.gaps if g.obligation_ref},
+            reported_refs=reported_gap_refs,
+        ),
+        decomposition_accuracy=_recall(
+            ground_truth_refs={d.description for d in gt.decomposition},
+            reported_refs=reported_obligation_refs,
+        ),
+        mapping_accuracy=_recall(
+            ground_truth_refs={(m.test_id, m.obligation_ref) for m in gt.mappings},
+            reported_refs=reported_mapping_refs,
+        ),
+        evidence_agreement=_precision(
+            ground_truth_refs={
+                (e.obligation_ref, e.classification) for e in gt.evidence_classes
+            },
+            reported_refs=reported_evidence_refs,
+        ),
+    )
+
+
+def _recall(ground_truth_refs: set, reported_refs: set) -> float | None:
+    """Of the known ground-truth items, how many were reported?"""
+    if not ground_truth_refs:
+        return None
+    return len(ground_truth_refs & reported_refs) / len(ground_truth_refs)
+
+
+def _precision(ground_truth_refs: set, reported_refs: set) -> float | None:
+    """Of the reported items, how many were actually in ground truth?"""
+    if not reported_refs:
+        return None
+    return len(ground_truth_refs & reported_refs) / len(reported_refs)

--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -27,13 +27,14 @@ class CliError(Exception):
     """A user-facing CLI failure (bad input), not a bug."""
 
 
-def _resolve_revision(revision: str) -> str:
+def _resolve_revision(revision: str, repo: Path | None = None) -> str:
     try:
         result = subprocess.run(
             ["git", "rev-parse", "--verify", f"{revision}^{{commit}}"],
             capture_output=True,
             text=True,
             check=True,
+            cwd=repo,
         )
     except FileNotFoundError as exc:
         raise CliError("git executable not found") from exc
@@ -42,25 +43,38 @@ def _resolve_revision(revision: str) -> str:
     return result.stdout.strip()
 
 
-def _read_task(task_path: str) -> str:
+def _read_task(task_path: str, repo: Path | None = None) -> str:
     path = Path(task_path)
+    if repo is not None and not path.is_absolute():
+        path = repo / path
     if not path.is_file():
         raise CliError(f"task file not found: {task_path!r}")
     return path.read_text()
 
 
 def run_check(
-    task: str, base: str, head: str, config: RunConfig, store: ReviewStore
+    task: str,
+    base: str,
+    head: str,
+    config: RunConfig,
+    store: ReviewStore,
+    repo: Path | None = None,
 ) -> Review:
     """Walking-skeleton pipeline: ingest → build empty Review → persist.
+
+    `repo` is the git working tree to run against; it defaults to the current
+    directory (the CLI's own §16 invocation has no --repo flag and always
+    means "here"). The benchmark runner (M-B0.2) passes each case's own repo
+    explicitly instead, since it processes many cases without changing the
+    process's working directory.
 
     The obligation/coverage/test analysis that consumes config.build_client()
     lands in M1+. What is real here is the end-to-end shape: a task and a
     revision range in, a well-formed persisted Review out.
     """
-    _read_task(task)
-    base_sha = _resolve_revision(base)
-    head_sha = _resolve_revision(head)
+    _read_task(task, repo=repo)
+    base_sha = _resolve_revision(base, repo=repo)
+    head_sha = _resolve_revision(head, repo=repo)
     review = Review(
         mode="local",
         reviewed_revision=head_sha,

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -1,0 +1,61 @@
+from acceptance.benchmark.case import (
+    BenchmarkCase,
+    BenchmarkCaseInputs,
+    BenchmarkCaseSource,
+    GroundTruthGap,
+    GroundTruthLabels,
+)
+from acceptance.benchmark.runner import run_case
+from acceptance.config import RunConfig
+from acceptance.review_store import ReviewStore
+
+
+def test_running_the_empty_skeleton_over_an_archetype_case_yields_an_all_miss_score(
+    git_repo_elsewhere, tmp_path
+):
+    """M-B0.2 acceptance: running the empty skeleton over an archetype case
+    yields a scored (all-miss) result without error."""
+    case = BenchmarkCase(
+        case_id="archetype-01-missed-obligation",
+        source=BenchmarkCaseSource(kind="archetype", identifier="missed-obligation"),
+        inputs=BenchmarkCaseInputs(
+            repo=str(git_repo_elsewhere["path"]),
+            task_text="## Deliverable\nAdd CSV export with active filters.\n",
+            base_revision=git_repo_elsewhere["base"],
+            head_revision=git_repo_elsewhere["head"],
+        ),
+        ground_truth=GroundTruthLabels(
+            gaps=[GroundTruthGap(description="Active filters not applied", obligation_ref="filters")]
+        ),
+    )
+
+    result = run_case(
+        case,
+        config=RunConfig(),
+        review_store=ReviewStore(tmp_path / "reviews"),
+    )
+
+    assert result.reviewer_output is not None
+    assert result.reviewer_output.reviewed_revision == git_repo_elsewhere["head"]
+    assert result.score is not None
+    assert result.score.gap_recall == 0.0  # all-miss: the skeleton found nothing
+    assert result.score.gap_precision is None  # nothing reported to be right/wrong about
+
+
+def test_run_case_does_not_mutate_the_input_case(git_repo_elsewhere, tmp_path):
+    case = BenchmarkCase(
+        case_id="archetype-01",
+        source=BenchmarkCaseSource(kind="archetype", identifier="missed-obligation"),
+        inputs=BenchmarkCaseInputs(
+            repo=str(git_repo_elsewhere["path"]),
+            task_text="## Deliverable\n...\n",
+            base_revision=git_repo_elsewhere["base"],
+            head_revision=git_repo_elsewhere["head"],
+        ),
+        ground_truth=GroundTruthLabels(gaps=[GroundTruthGap(description="x")]),
+    )
+
+    run_case(case, config=RunConfig(), review_store=ReviewStore(tmp_path / "reviews"))
+
+    assert case.reviewer_output is None
+    assert case.score is None

--- a/tests/benchmark/test_scoring.py
+++ b/tests/benchmark/test_scoring.py
@@ -1,0 +1,76 @@
+import pytest
+
+from acceptance.benchmark.case import (
+    BenchmarkCase,
+    BenchmarkCaseInputs,
+    BenchmarkCaseSource,
+    GroundTruthDecompositionItem,
+    GroundTruthEvidenceClass,
+    GroundTruthGap,
+    GroundTruthLabels,
+    GroundTruthMapping,
+)
+from acceptance.benchmark.scoring import score_case
+from acceptance.review_state import Review
+
+
+def _archetype_case(**overrides) -> BenchmarkCase:
+    defaults = dict(
+        case_id="archetype-01-missed-obligation",
+        source=BenchmarkCaseSource(kind="archetype", identifier="missed-obligation"),
+        inputs=BenchmarkCaseInputs(
+            repo="fixtures/archetype-01",
+            task_text="## Deliverable\nAdd CSV export with active filters.\n",
+            base_revision="abc123",
+            head_revision="def456",
+        ),
+        ground_truth=GroundTruthLabels(
+            gaps=[GroundTruthGap(description="Active filters not applied", obligation_ref="filters")],
+            decomposition=[
+                GroundTruthDecompositionItem(description="CSV generation", explicit=True),
+                GroundTruthDecompositionItem(description="Active filters applied", explicit=True),
+            ],
+            mappings=[GroundTruthMapping(test_id="test_csv_basic", obligation_ref="csv-generation")],
+            evidence_classes=[
+                GroundTruthEvidenceClass(obligation_ref="csv-generation", classification="strongly_supported")
+            ],
+        ),
+    )
+    defaults.update(overrides)
+    return BenchmarkCase(**defaults)
+
+
+def test_score_case_raises_without_reviewer_output():
+    case = _archetype_case()
+    with pytest.raises(ValueError):
+        score_case(case)
+
+
+def test_empty_review_yields_an_all_miss_score():
+    case = _archetype_case(
+        reviewer_output=Review(mode="local", reviewed_revision="def456")
+    )
+
+    score = score_case(case)
+
+    # Ground truth exists but nothing was reported: real, computable zeros.
+    assert score.gap_recall == 0.0
+    assert score.decomposition_accuracy == 0.0
+    assert score.mapping_accuracy == 0.0
+    # Nothing was reported to be right or wrong about: undefined, not 0.0/1.0.
+    assert score.gap_precision is None
+    assert score.evidence_agreement is None
+
+
+def test_recall_and_precision_are_none_when_ground_truth_is_empty():
+    case = _archetype_case(
+        ground_truth=GroundTruthLabels(gaps=[GroundTruthGap(description="only gaps present")]),
+        reviewer_output=Review(mode="local", reviewed_revision="def456"),
+    )
+
+    score = score_case(case)
+
+    # No ground-truth decomposition/mappings/evidence_classes to score against.
+    assert score.decomposition_accuracy is None
+    assert score.mapping_accuracy is None
+    assert score.evidence_agreement is None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,9 +15,7 @@ def _rev_parse(repo: Path, revision: str) -> str:
     return result.stdout.strip()
 
 
-@pytest.fixture
-def git_repo(tmp_path, monkeypatch):
-    repo = tmp_path / "repo"
+def _make_git_repo(repo: Path) -> dict:
     repo.mkdir()
     _git(repo, "init", "-q")
     _git(repo, "config", "user.email", "test@example.com")
@@ -33,8 +31,21 @@ def git_repo(tmp_path, monkeypatch):
     _git(repo, "commit", "-q", "-m", "head")
     head_sha = _rev_parse(repo, "HEAD")
 
-    monkeypatch.chdir(repo)
     return {"path": repo, "base": base_sha, "head": head_sha}
+
+
+@pytest.fixture
+def git_repo(tmp_path, monkeypatch):
+    info = _make_git_repo(tmp_path / "repo")
+    monkeypatch.chdir(info["path"])
+    return info
+
+
+@pytest.fixture
+def git_repo_elsewhere(tmp_path):
+    """A git repo the test process is NOT chdir'd into — proves callers that
+    pass an explicit repo path don't depend on the current working directory."""
+    return _make_git_repo(tmp_path / "repo")
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,9 @@ import json
 
 import pytest
 
-from acceptance.cli import main
+from acceptance.cli import main, run_check
+from acceptance.config import RunConfig
+from acceptance.review_store import ReviewStore
 
 
 def test_check_json_emits_empty_structured_review(git_repo, fixture_task_path, capsys):
@@ -141,3 +143,36 @@ def test_check_fails_cleanly_on_unresolvable_revision(git_repo, fixture_task_pat
 def test_check_requires_all_flags(fixture_task_path):
     with pytest.raises(SystemExit):
         main(["check", "--task", fixture_task_path])
+
+
+def test_run_check_accepts_an_explicit_repo_independent_of_cwd(
+    git_repo_elsewhere, fixture_task_path, tmp_path
+):
+    """M-B0.2: the runner passes each case's repo as data, not via chdir."""
+    review = run_check(
+        task=fixture_task_path,
+        base=git_repo_elsewhere["base"],
+        head=git_repo_elsewhere["head"],
+        config=RunConfig(),
+        store=ReviewStore(tmp_path / "reviews"),
+        repo=git_repo_elsewhere["path"],
+    )
+
+    assert review.reviewed_revision == git_repo_elsewhere["head"]
+    assert review.change_set.base_revision == git_repo_elsewhere["base"]
+
+
+def test_run_check_rejects_a_revision_missing_from_the_given_repo(
+    git_repo_elsewhere, fixture_task_path, tmp_path
+):
+    from acceptance.cli import CliError
+
+    with pytest.raises(CliError):
+        run_check(
+            task=fixture_task_path,
+            base="not-a-real-revision",
+            head=git_repo_elsewhere["head"],
+            config=RunConfig(),
+            store=ReviewStore(tmp_path / "reviews"),
+            repo=git_repo_elsewhere["path"],
+        )


### PR DESCRIPTION
Closes #8

## Summary
New `src/acceptance/benchmark/runner.py`: `run_case(case)` materializes a `BenchmarkCase`'s task text to a temp file, runs it through M0.6's `run_check` pipeline against the case's own repo, and returns a **new** case (via `model_copy` — input untouched) with `reviewer_output` and a computed `score`.

- **`cli.py`** — `run_check`, `_resolve_revision`, and `_read_task` gain an explicit `repo: Path | None = None` parameter (default `None` preserves existing CLI behavior exactly; the §16 invocation has no `--repo` flag and always means "here"). The runner needs each case's repo as *data* rather than the process's working directory — `chdir`-ing around a set of cases would be global, non-reentrant state a runner has no business touching.
- **`src/acceptance/benchmark/scoring.py`** — `score_case` is deliberately minimal: exact-ref-match recall/precision against ground truth, just enough for M-B0.2's own acceptance ("scored (all-miss) result"). M-B0.3 owns the real rubric (matching semantics beyond exact refs, cross-case aggregation into a report, agreement-scoring nuance) and **supersedes** this module rather than extending it — flagged in the module docstring. A ratio is `None` rather than a misleading `0.0`/`1.0` when it's mathematically undefined: precision with zero reported findings, or agreement with zero reported classifications, has nothing to be right or wrong about.

## Test plan
- [x] `pytest -q` — 78 tests pass: the literal acceptance (`test_running_the_empty_skeleton_over_an_archetype_case_yields_an_all_miss_score`), `run_case` doesn't mutate its input, `run_check`'s new `repo=` param proven **independent of CWD** via a new `git_repo_elsewhere` fixture (a repo the test process is deliberately *not* chdir'd into), plus scoring unit tests for the all-miss and undefined-ratio cases
- [x] `ruff check .` — clean
- [x] Manual standalone script (outside the test harness): empty skeleton over an archetype-shaped case → `reviewer_output` populated, `gap_recall: 0.0` (real, computable), `gap_precision`/`evidence_agreement`: `None` (honestly undefined) — no exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)