### PR TITLE
M-B0.3: real scorer suite and pooled case-set report

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,5 +1,5 @@
 ## Deliverable
-a runner that feeds a case's inputs through the current checker and captures its Review output against the case.
+scorers for gap-detection (recall), false-alarm (precision), obligation-decomposition accuracy, test-to-obligation mapping accuracy, and evidence-classification agreement; a single-command report over a case set.
 
 ## Acceptance
-running the empty skeleton over an archetype case yields a scored (all-miss) result without error.
+on a synthetic set with known labels, computed metrics match hand-calculated expected values.

--- a/src/acceptance/benchmark/scoring.py
+++ b/src/acceptance/benchmark/scoring.py
@@ -1,78 +1,186 @@
-"""Minimal per-case scoring (M-B0.2).
+"""Benchmark scoring & report (M-B0.3, §11.1).
 
-This is deliberately narrow: just enough to satisfy M-B0.2's own acceptance
-check ("running the empty skeleton over an archetype case yields a scored
-(all-miss) result"). It counts exact ref matches between a case's ground
-truth and its reviewer_output. M-B0.3 owns the real rubric — matching
-semantics beyond exact refs, aggregation into a report across a case set,
-and false-alarm/agreement scoring nuance — and supersedes this module rather
-than building alongside it.
+Real scorer suite superseding M-B0.2's provisional score_case: gap-detection
+recall, false-alarm precision, obligation-decomposition accuracy,
+test-to-obligation mapping accuracy, and evidence-classification agreement.
 
-A ratio is `None` when it is mathematically undefined rather than a
-misleading 0.0 or 1.0: precision with zero reported findings, or evidence
-agreement with zero reported classifications, has nothing to be right or
-wrong about.
+Matching is exact-ref against the structured ground-truth refs from M-B0.1's
+schema (GroundTruthGap.obligation_ref, GroundTruthMapping.test_id +
+obligation_ref, etc.) against the corresponding fields on the reviewer's
+Review — no fuzzy/NLP matching, since the ground-truth schema is already
+structured rather than free text.
+
+`evidence_agreement` is always computed with reported_total=0: Finding
+(review_state.py) has no field for a §9.3 test-strength classification yet
+— that's M5.3's job. M-B0.2's version compared Finding.evidence_tier (how
+evidence was PRODUCED: builder-claim/static/coverage-confirmed/...) against
+GroundTruthEvidenceClass.classification (how STRONG it is:
+strongly_supported/unsupported/...) — two disjoint vocabularies that could
+never usefully match. Being explicit that nothing is reported yet gives a
+real, meaningful 0.0 ("the reviewer can't express this yet") rather than a
+number that happens to read as zero for the wrong reason.
+
+score_case and score_case_set pool the same per-case match counts; the case
+set aggregates by pooling raw counts across all cases before dividing
+(micro-averaging) rather than averaging each case's own ratio. That avoids
+both macro- vs micro-averaging ambiguity and the awkwardness of averaging
+in the presence of a per-case None (a case with no ground truth in a
+category contributes no counts, rather than needing to be excluded from an
+average). A macro-averaged variant (e.g. for per-source-type breakdowns) may
+be worth adding later, but pooled counts stay the default so small or
+no-op-heavy cases can't dilute the headline figures.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+from pydantic import Field
+
 from acceptance.benchmark.case import BenchmarkCase, BenchmarkScore
+from acceptance.model_base import PersistableModel
 
 
-def score_case(case: BenchmarkCase) -> BenchmarkScore:
+@dataclass(frozen=True)
+class _MatchCounts:
+    matched: int
+    ground_truth_total: int
+    reported_total: int
+
+    @staticmethod
+    def zero() -> "_MatchCounts":
+        return _MatchCounts(0, 0, 0)
+
+    def __add__(self, other: "_MatchCounts") -> "_MatchCounts":
+        return _MatchCounts(
+            self.matched + other.matched,
+            self.ground_truth_total + other.ground_truth_total,
+            self.reported_total + other.reported_total,
+        )
+
+    def recall(self) -> float | None:
+        if not self.ground_truth_total:
+            return None
+        return self.matched / self.ground_truth_total
+
+    def precision(self) -> float | None:
+        if not self.reported_total:
+            return None
+        return self.matched / self.reported_total
+
+
+def _gap_counts(case: BenchmarkCase) -> _MatchCounts:
     review = case.reviewer_output
-    if review is None:
-        raise ValueError("cannot score a case with no reviewer_output")
-    gt = case.ground_truth
-
-    reported_gap_refs = {
+    ground_truth_refs = {g.obligation_ref for g in case.ground_truth.gaps if g.obligation_ref}
+    reported_refs = {
         f.related_obligation for f in review.findings if f.related_obligation is not None
     }
-    reported_obligation_refs = {o.description for o in review.obligation_map}
-    reported_mapping_refs = {
-        (t, o) for o in review.obligation_map for t in o.test_evidence
-    }
-    reported_evidence_refs = {
-        (f.related_obligation, f.evidence_tier.name)
-        for f in review.findings
-        if f.related_obligation is not None
-    }
-
-    return BenchmarkScore(
-        gap_recall=_recall(
-            ground_truth_refs={g.obligation_ref for g in gt.gaps if g.obligation_ref},
-            reported_refs=reported_gap_refs,
-        ),
-        gap_precision=_precision(
-            ground_truth_refs={g.obligation_ref for g in gt.gaps if g.obligation_ref},
-            reported_refs=reported_gap_refs,
-        ),
-        decomposition_accuracy=_recall(
-            ground_truth_refs={d.description for d in gt.decomposition},
-            reported_refs=reported_obligation_refs,
-        ),
-        mapping_accuracy=_recall(
-            ground_truth_refs={(m.test_id, m.obligation_ref) for m in gt.mappings},
-            reported_refs=reported_mapping_refs,
-        ),
-        evidence_agreement=_precision(
-            ground_truth_refs={
-                (e.obligation_ref, e.classification) for e in gt.evidence_classes
-            },
-            reported_refs=reported_evidence_refs,
-        ),
+    return _MatchCounts(
+        matched=len(ground_truth_refs & reported_refs),
+        ground_truth_total=len(ground_truth_refs),
+        reported_total=len(reported_refs),
     )
 
 
-def _recall(ground_truth_refs: set, reported_refs: set) -> float | None:
-    """Of the known ground-truth items, how many were reported?"""
-    if not ground_truth_refs:
-        return None
-    return len(ground_truth_refs & reported_refs) / len(ground_truth_refs)
+def _decomposition_counts(case: BenchmarkCase) -> _MatchCounts:
+    review = case.reviewer_output
+    ground_truth_refs = {d.description for d in case.ground_truth.decomposition}
+    reported_refs = {o.description for o in review.obligation_map}
+    return _MatchCounts(
+        matched=len(ground_truth_refs & reported_refs),
+        ground_truth_total=len(ground_truth_refs),
+        reported_total=len(reported_refs),
+    )
 
 
-def _precision(ground_truth_refs: set, reported_refs: set) -> float | None:
-    """Of the reported items, how many were actually in ground truth?"""
-    if not reported_refs:
-        return None
-    return len(ground_truth_refs & reported_refs) / len(reported_refs)
+def _mapping_counts(case: BenchmarkCase) -> _MatchCounts:
+    review = case.reviewer_output
+    ground_truth_refs = {(m.test_id, m.obligation_ref) for m in case.ground_truth.mappings}
+    reported_refs = {
+        (test_id, obligation.description)
+        for obligation in review.obligation_map
+        for test_id in obligation.test_evidence
+    }
+    return _MatchCounts(
+        matched=len(ground_truth_refs & reported_refs),
+        ground_truth_total=len(ground_truth_refs),
+        reported_total=len(reported_refs),
+    )
+
+
+def _evidence_counts(case: BenchmarkCase) -> _MatchCounts:
+    # reported_total is always 0: Finding has no §9.3 classification field
+    # yet (M5.3). See module docstring — this is deliberate, not a stub.
+    ground_truth_refs = {
+        (e.obligation_ref, e.classification) for e in case.ground_truth.evidence_classes
+    }
+    return _MatchCounts(matched=0, ground_truth_total=len(ground_truth_refs), reported_total=0)
+
+
+def _all_counts(case: BenchmarkCase) -> tuple[_MatchCounts, _MatchCounts, _MatchCounts, _MatchCounts]:
+    if case.reviewer_output is None:
+        raise ValueError(f"case {case.case_id!r} has no reviewer_output; run it first")
+    return (
+        _gap_counts(case),
+        _decomposition_counts(case),
+        _mapping_counts(case),
+        _evidence_counts(case),
+    )
+
+
+def _score_from_counts(
+    gap: _MatchCounts,
+    decomposition: _MatchCounts,
+    mapping: _MatchCounts,
+    evidence: _MatchCounts,
+) -> BenchmarkScore:
+    return BenchmarkScore(
+        gap_recall=gap.recall(),
+        gap_precision=gap.precision(),
+        decomposition_accuracy=decomposition.recall(),
+        mapping_accuracy=mapping.recall(),
+        evidence_agreement=evidence.recall(),
+    )
+
+
+def score_case(case: BenchmarkCase) -> BenchmarkScore:
+    return _score_from_counts(*_all_counts(case))
+
+
+class BenchmarkReport(PersistableModel):
+    """Aggregate §11.1 metrics over a case set, pooled by raw match counts
+    (micro-averaged) — the "single-command report over a case set"."""
+
+    case_count: int
+    gap_recall: float | None = None
+    gap_precision: float | None = None
+    decomposition_accuracy: float | None = None
+    mapping_accuracy: float | None = None
+    evidence_agreement: float | None = None
+    per_case: list[BenchmarkScore] = Field(default_factory=list)
+
+
+def score_case_set(cases: list[BenchmarkCase]) -> BenchmarkReport:
+    gap_total = _MatchCounts.zero()
+    decomposition_total = _MatchCounts.zero()
+    mapping_total = _MatchCounts.zero()
+    evidence_total = _MatchCounts.zero()
+    per_case: list[BenchmarkScore] = []
+
+    for case in cases:
+        gap, decomposition, mapping, evidence = _all_counts(case)
+        gap_total += gap
+        decomposition_total += decomposition
+        mapping_total += mapping
+        evidence_total += evidence
+        per_case.append(_score_from_counts(gap, decomposition, mapping, evidence))
+
+    return BenchmarkReport(
+        case_count=len(cases),
+        gap_recall=gap_total.recall(),
+        gap_precision=gap_total.precision(),
+        decomposition_accuracy=decomposition_total.recall(),
+        mapping_accuracy=mapping_total.recall(),
+        evidence_agreement=evidence_total.recall(),
+        per_case=per_case,
+    )

--- a/tests/benchmark/test_scoring.py
+++ b/tests/benchmark/test_scoring.py
@@ -57,9 +57,11 @@ def test_empty_review_yields_an_all_miss_score():
     assert score.gap_recall == 0.0
     assert score.decomposition_accuracy == 0.0
     assert score.mapping_accuracy == 0.0
+    # evidence_agreement is a real 0.0 too: Finding has no §9.3 classification
+    # field yet (M5.3), so nothing can ever be reported for this metric.
+    assert score.evidence_agreement == 0.0
     # Nothing was reported to be right or wrong about: undefined, not 0.0/1.0.
     assert score.gap_precision is None
-    assert score.evidence_agreement is None
 
 
 def test_recall_and_precision_are_none_when_ground_truth_is_empty():

--- a/tests/benchmark/test_scoring_report.py
+++ b/tests/benchmark/test_scoring_report.py
@@ -1,0 +1,191 @@
+"""M-B0.3 acceptance: on a synthetic set with known labels, computed metrics
+match hand-calculated expected values.
+
+Case A: gap ground truth {filters, row-limit}; reviewer reports {filters}.
+  -> gap: matched=1, gt=2, reported=1
+Case B: gap ground truth {csv-escaping}; reviewer reports {csv-escaping, unrelated}.
+  -> gap: matched=1, gt=1, reported=2
+Pooled: matched=2, gt=3, reported=3 -> gap_recall = 2/3, gap_precision = 2/3
+
+Case A decomposition ground truth {"CSV generation", "Active filters applied"};
+  reviewer reports {"CSV generation"}. -> matched=1, gt=2
+Case B decomposition ground truth {"Escape special characters"};
+  reviewer reports {"Escape special characters"}. -> matched=1, gt=1
+Pooled: matched=2, gt=3 -> decomposition_accuracy = 2/3
+
+Case A mapping ground truth {(test_csv, "CSV generation")}; reviewer reports
+  the same pair via Obligation.test_evidence. -> matched=1, gt=1
+Case B mapping ground truth {(test_escape, escaping)}; reviewer reports nothing.
+  -> matched=0, gt=1
+Pooled: matched=1, gt=2 -> mapping_accuracy = 1/2
+
+evidence_classes: Case A has 1 ground-truth label, Case B has none.
+Pooled ground truth=1, matched=0 (Finding can't express a classification yet)
+  -> evidence_agreement = 0/1 = 0.0
+"""
+
+import pytest
+
+from acceptance.benchmark.case import (
+    BenchmarkCase,
+    BenchmarkCaseInputs,
+    BenchmarkCaseSource,
+    GroundTruthDecompositionItem,
+    GroundTruthEvidenceClass,
+    GroundTruthGap,
+    GroundTruthLabels,
+    GroundTruthMapping,
+)
+from acceptance.benchmark.scoring import score_case_set
+from acceptance.evidence_tier import Component, EvidenceTier
+from acceptance.review_state import Finding, Link, Obligation, Review
+
+
+def _inputs() -> BenchmarkCaseInputs:
+    return BenchmarkCaseInputs(
+        repo="fixtures/synthetic",
+        task_text="## Deliverable\n...\n",
+        base_revision="abc123",
+        head_revision="def456",
+    )
+
+
+def _case_a() -> BenchmarkCase:
+    return BenchmarkCase(
+        case_id="synthetic-a",
+        source=BenchmarkCaseSource(kind="archetype", identifier="synthetic-a"),
+        inputs=_inputs(),
+        ground_truth=GroundTruthLabels(
+            gaps=[
+                GroundTruthGap(description="filters missing", obligation_ref="filters"),
+                GroundTruthGap(description="row limit missing", obligation_ref="row-limit"),
+            ],
+            decomposition=[
+                GroundTruthDecompositionItem(description="CSV generation", explicit=True),
+                GroundTruthDecompositionItem(description="Active filters applied", explicit=True),
+            ],
+            mappings=[GroundTruthMapping(test_id="test_csv", obligation_ref="CSV generation")],
+            evidence_classes=[
+                GroundTruthEvidenceClass(
+                    obligation_ref="CSV generation", classification="strongly_supported"
+                )
+            ],
+        ),
+        reviewer_output=Review(
+            mode="local",
+            reviewed_revision="def456",
+            obligation_map=[
+                Obligation(
+                    description="CSV generation",
+                    type="behavior",
+                    source_text="...",
+                    importance="critical",
+                    explicit=True,
+                    observable_behavior="...",
+                    test_evidence=["test_csv"],
+                )
+            ],
+            findings=[
+                Finding(
+                    type="missed_obligation",
+                    severity="high",
+                    description="Filters not applied",
+                    evidence_tier=EvidenceTier.STATIC,
+                    produced_by=Component.STATIC_ANALYZER,
+                    links=[Link(kind="requirement", ref="task.md:1")],
+                    related_obligation="filters",
+                )
+            ],
+        ),
+    )
+
+
+def _case_b() -> BenchmarkCase:
+    return BenchmarkCase(
+        case_id="synthetic-b",
+        source=BenchmarkCaseSource(kind="archetype", identifier="synthetic-b"),
+        inputs=_inputs(),
+        ground_truth=GroundTruthLabels(
+            gaps=[GroundTruthGap(description="csv escaping missing", obligation_ref="csv-escaping")],
+            decomposition=[
+                GroundTruthDecompositionItem(description="Escape special characters", explicit=True)
+            ],
+            mappings=[GroundTruthMapping(test_id="test_escape", obligation_ref="escaping")],
+        ),
+        reviewer_output=Review(
+            mode="local",
+            reviewed_revision="def456",
+            obligation_map=[
+                Obligation(
+                    description="Escape special characters",
+                    type="behavior",
+                    source_text="...",
+                    importance="critical",
+                    explicit=True,
+                    observable_behavior="...",
+                    # No test_evidence: the mapping ground truth goes unmatched.
+                )
+            ],
+            findings=[
+                Finding(
+                    type="missed_obligation",
+                    severity="high",
+                    description="CSV escaping not handled",
+                    evidence_tier=EvidenceTier.STATIC,
+                    produced_by=Component.STATIC_ANALYZER,
+                    links=[Link(kind="requirement", ref="task.md:2")],
+                    related_obligation="csv-escaping",
+                ),
+                Finding(
+                    type="missed_obligation",
+                    severity="low",
+                    description="Spurious, unrelated finding",
+                    evidence_tier=EvidenceTier.STATIC,
+                    produced_by=Component.STATIC_ANALYZER,
+                    links=[Link(kind="requirement", ref="task.md:3")],
+                    related_obligation="unrelated",
+                ),
+            ],
+        ),
+    )
+
+
+def test_pooled_report_matches_hand_calculated_values():
+    report = score_case_set([_case_a(), _case_b()])
+
+    assert report.case_count == 2
+    assert report.gap_recall == 2 / 3
+    assert report.gap_precision == 2 / 3
+    assert report.decomposition_accuracy == 2 / 3
+    assert report.mapping_accuracy == 1 / 2
+    assert report.evidence_agreement == 0.0
+
+
+def test_report_includes_per_case_scores():
+    report = score_case_set([_case_a(), _case_b()])
+
+    assert len(report.per_case) == 2
+    # Case A alone: gap matched=1, gt=2, reported=1.
+    assert report.per_case[0].gap_recall == 0.5
+    assert report.per_case[0].gap_precision == 1.0
+    # Case B alone: gap matched=1, gt=1, reported=2.
+    assert report.per_case[1].gap_recall == 1.0
+    assert report.per_case[1].gap_precision == 0.5
+
+
+def test_empty_case_set_yields_no_metrics():
+    report = score_case_set([])
+
+    assert report.case_count == 0
+    assert report.gap_recall is None
+    assert report.gap_precision is None
+    assert report.decomposition_accuracy is None
+    assert report.mapping_accuracy is None
+    assert report.evidence_agreement is None
+    assert report.per_case == []
+
+
+def test_case_set_raises_if_any_case_has_no_reviewer_output():
+    unrun_case = _case_a().model_copy(update={"reviewer_output": None})
+    with pytest.raises(ValueError):
+        score_case_set([unrun_case])


### PR DESCRIPTION
Closes #9

## Summary
Supersedes M-B0.2's provisional `score_case` (as its own docstring said it would) with the real §11.1 scorer suite: gap-detection recall/precision, obligation-decomposition accuracy, test-to-obligation mapping accuracy, and evidence-classification agreement. Adds `score_case_set(cases) -> BenchmarkReport` — the "single-command report over a case set."

- **Pooled counts, not averaged ratios.** The report pools raw match counts across all cases before dividing (micro-averaging) rather than averaging each case's own ratio — avoids both macro- vs. micro-averaging ambiguity and the awkwardness of averaging in the presence of a per-case `None`. A macro-averaged variant (e.g. per-source-type breakdowns) may be worth adding later; pooled counts stay the default so small/no-op-heavy cases can't dilute the headline figures.
- **Fixes a real correctness bug in M-B0.2's `evidence_agreement`.** It compared `Finding.evidence_tier` (how evidence was *produced* — builder-claim/static/coverage-confirmed/...) against `GroundTruthEvidenceClass.classification` (how *strong* it is — strongly_supported/unsupported/...) — two disjoint vocabularies that could never usefully match, while `reported_total` counted Findings that don't actually assert any classification at all. `Finding` has no field for a §9.3 classification yet (M5.3's job), so `evidence_agreement` now honestly computes `reported_total=0` — a real, meaningful `0.0` when ground truth exists ("the reviewer can't express this yet"), not a number that happened to read as zero for the wrong reason.
- **"Single-command"** means one Python call producing the structured `BenchmarkReport` — no CLI/argparse wiring or text rendering here, consistent with M-B0.2 not adding CLI wiring for the runner either. That's a natural fit for the later `M-B*.report` milestone.

## Test plan
- [x] `pytest -q` — 82 tests pass. The acceptance is a hand-calculated synthetic two-case set (`tests/benchmark/test_scoring_report.py`, full arithmetic traced in the module docstring): pooled `gap_recall = gap_precision = 2/3`, `decomposition_accuracy = 2/3`, `mapping_accuracy = 1/2`, `evidence_agreement = 0.0`. Plus: per-case scores preserved in the report, empty case set → all-`None` metrics, a case missing `reviewer_output` raises rather than being silently skipped.
- [x] `ruff check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)