### PR TITLE
M-B0.4: variance disclosure

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,5 +1,5 @@
 ## Deliverable
-scorers for gap-detection (recall), false-alarm (precision), obligation-decomposition accuracy, test-to-obligation mapping accuracy, and evidence-classification agreement; a single-command report over a case set.
+report records determinism mode and, if sampling, variance across N runs.
 
 ## Acceptance
-on a synthetic set with known labels, computed metrics match hand-calculated expected values.
+report output includes the determinism mode and (when sampled) a spread figure per metric.

--- a/src/acceptance/benchmark/scoring.py
+++ b/src/acceptance/benchmark/scoring.py
@@ -29,11 +29,23 @@ category contributes no counts, rather than needing to be excluded from an
 average). A macro-averaged variant (e.g. for per-source-type breakdowns) may
 be worth adding later, but pooled counts stay the default so small or
 no-op-heavy cases can't dilute the headline figures.
+
+Variance disclosure (M-B0.4, §3.2's deferred "N-sample majority" alternative
+to M0.5's fixed-seed strategy): every BenchmarkReport discloses its
+determinism_mode (from the underlying cases' ReviewProvenance — kept as the
+same plain string literal M0.5 used, independent of the LLM harness's Mode
+enum). disclose_variance() then takes N such reports over repeated runs of
+the same case set and computes a mean and spread per metric. It takes
+already-computed reports rather than orchestrating the N runs itself: the
+checker is still the M0.6 no-op skeleton, so there is no real variance yet
+for a runner to produce — this function is ready the moment M1+ makes the
+pipeline genuinely sampled, without speculative orchestration plumbing now.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal
 
 from pydantic import Field
 
@@ -152,6 +164,7 @@ class BenchmarkReport(PersistableModel):
     (micro-averaged) — the "single-command report over a case set"."""
 
     case_count: int
+    determinism_mode: Literal["record", "replay"] | None = None
     gap_recall: float | None = None
     gap_precision: float | None = None
     decomposition_accuracy: float | None = None
@@ -160,12 +173,33 @@ class BenchmarkReport(PersistableModel):
     per_case: list[BenchmarkScore] = Field(default_factory=list)
 
 
+def _case_determinism_mode(case: BenchmarkCase) -> str:
+    # reviewer_output is already known non-None here: _all_counts checks it
+    # before this is called.
+    provenance = case.reviewer_output.provenance
+    if provenance is None:
+        raise ValueError(
+            f"case {case.case_id!r} has reviewer_output with no provenance; "
+            "cannot disclose determinism mode"
+        )
+    return provenance.determinism_mode
+
+
+def _reconcile_determinism_modes(modes: set[str]) -> str | None:
+    if not modes:
+        return None
+    if len(modes) > 1:
+        raise ValueError(f"case set mixes determinism modes: {sorted(modes)}")
+    return next(iter(modes))
+
+
 def score_case_set(cases: list[BenchmarkCase]) -> BenchmarkReport:
     gap_total = _MatchCounts.zero()
     decomposition_total = _MatchCounts.zero()
     mapping_total = _MatchCounts.zero()
     evidence_total = _MatchCounts.zero()
     per_case: list[BenchmarkScore] = []
+    modes: set[str] = set()
 
     for case in cases:
         gap, decomposition, mapping, evidence = _all_counts(case)
@@ -174,13 +208,78 @@ def score_case_set(cases: list[BenchmarkCase]) -> BenchmarkReport:
         mapping_total += mapping
         evidence_total += evidence
         per_case.append(_score_from_counts(gap, decomposition, mapping, evidence))
+        modes.add(_case_determinism_mode(case))
 
     return BenchmarkReport(
         case_count=len(cases),
+        determinism_mode=_reconcile_determinism_modes(modes),
         gap_recall=gap_total.recall(),
         gap_precision=gap_total.precision(),
         decomposition_accuracy=decomposition_total.recall(),
         mapping_accuracy=mapping_total.recall(),
         evidence_agreement=evidence_total.recall(),
         per_case=per_case,
+    )
+
+
+_METRIC_FIELDS = (
+    "gap_recall",
+    "gap_precision",
+    "decomposition_accuracy",
+    "mapping_accuracy",
+    "evidence_agreement",
+)
+
+
+class MetricStats(PersistableModel):
+    mean: float | None = None
+    # max - min across non-None samples; None if fewer than 2 contributed
+    # (not enough samples to show variation — not a fabricated 0.0).
+    spread: float | None = None
+
+
+class SampledBenchmarkReport(PersistableModel):
+    """N-run variance disclosure (M-B0.4): a mean and spread per §11.1
+    metric across repeated runs of the same case set, plus each run's own
+    report for traceability."""
+
+    sample_count: int
+    determinism_mode: Literal["record", "replay"]
+    gap_recall: MetricStats
+    gap_precision: MetricStats
+    decomposition_accuracy: MetricStats
+    mapping_accuracy: MetricStats
+    evidence_agreement: MetricStats
+    runs: list[BenchmarkReport] = Field(default_factory=list)
+
+
+def _metric_stats(values: list[float | None]) -> MetricStats:
+    present = [v for v in values if v is not None]
+    if not present:
+        return MetricStats(mean=None, spread=None)
+    return MetricStats(
+        mean=sum(present) / len(present),
+        spread=(max(present) - min(present)) if len(present) >= 2 else None,
+    )
+
+
+def disclose_variance(reports: list[BenchmarkReport]) -> SampledBenchmarkReport:
+    if not reports:
+        raise ValueError("disclose_variance requires at least one report")
+
+    modes = {r.determinism_mode for r in reports}
+    if len(modes) > 1 or None in modes:
+        raise ValueError(
+            "reports must share a single known determinism mode, got "
+            f"{sorted(m or 'unknown' for m in modes)}"
+        )
+    (mode,) = modes
+
+    stats = {field: _metric_stats([getattr(r, field) for r in reports]) for field in _METRIC_FIELDS}
+
+    return SampledBenchmarkReport(
+        sample_count=len(reports),
+        determinism_mode=mode,
+        runs=reports,
+        **stats,
     )

--- a/tests/benchmark/test_scoring_report.py
+++ b/tests/benchmark/test_scoring_report.py
@@ -38,7 +38,7 @@ from acceptance.benchmark.case import (
 )
 from acceptance.benchmark.scoring import score_case_set
 from acceptance.evidence_tier import Component, EvidenceTier
-from acceptance.review_state import Finding, Link, Obligation, Review
+from acceptance.review_state import Finding, Link, Obligation, Review, ReviewProvenance
 
 
 def _inputs() -> BenchmarkCaseInputs:
@@ -47,6 +47,12 @@ def _inputs() -> BenchmarkCaseInputs:
         task_text="## Deliverable\n...\n",
         base_revision="abc123",
         head_revision="def456",
+    )
+
+
+def _provenance() -> ReviewProvenance:
+    return ReviewProvenance(
+        determinism_mode="replay", model="anthropic/claude-sonnet-5", temperature=0.0
     )
 
 
@@ -74,6 +80,7 @@ def _case_a() -> BenchmarkCase:
         reviewer_output=Review(
             mode="local",
             reviewed_revision="def456",
+            provenance=_provenance(),
             obligation_map=[
                 Obligation(
                     description="CSV generation",
@@ -115,6 +122,7 @@ def _case_b() -> BenchmarkCase:
         reviewer_output=Review(
             mode="local",
             reviewed_revision="def456",
+            provenance=_provenance(),
             obligation_map=[
                 Obligation(
                     description="Escape special characters",
@@ -154,6 +162,7 @@ def test_pooled_report_matches_hand_calculated_values():
     report = score_case_set([_case_a(), _case_b()])
 
     assert report.case_count == 2
+    assert report.determinism_mode == "replay"
     assert report.gap_recall == 2 / 3
     assert report.gap_precision == 2 / 3
     assert report.decomposition_accuracy == 2 / 3
@@ -177,6 +186,7 @@ def test_empty_case_set_yields_no_metrics():
     report = score_case_set([])
 
     assert report.case_count == 0
+    assert report.determinism_mode is None
     assert report.gap_recall is None
     assert report.gap_precision is None
     assert report.decomposition_accuracy is None
@@ -189,3 +199,27 @@ def test_case_set_raises_if_any_case_has_no_reviewer_output():
     unrun_case = _case_a().model_copy(update={"reviewer_output": None})
     with pytest.raises(ValueError):
         score_case_set([unrun_case])
+
+
+def test_case_set_raises_if_a_case_has_no_provenance():
+    case = _case_a()
+    unstamped = case.model_copy(
+        update={"reviewer_output": case.reviewer_output.model_copy(update={"provenance": None})}
+    )
+    with pytest.raises(ValueError):
+        score_case_set([unstamped])
+
+
+def test_case_set_raises_on_mixed_determinism_modes():
+    case_a = _case_a()
+    recorded_provenance = _provenance().model_copy(update={"determinism_mode": "record"})
+    case_a_recorded = case_a.model_copy(
+        update={
+            "reviewer_output": case_a.reviewer_output.model_copy(
+                update={"provenance": recorded_provenance}
+            )
+        }
+    )
+
+    with pytest.raises(ValueError):
+        score_case_set([case_a_recorded, _case_b()])

--- a/tests/benchmark/test_variance.py
+++ b/tests/benchmark/test_variance.py
@@ -1,0 +1,90 @@
+"""M-B0.4 acceptance: report output includes the determinism mode and (when
+sampled) a spread figure per metric.
+
+disclose_variance() takes already-computed BenchmarkReports rather than
+running anything itself — the pipeline is still the M0.6 no-op skeleton, so
+there's no real sampled variance to produce yet. These reports stand in for
+three repetitions of the same case set under a live/sampled configuration.
+
+gap_recall across 3 runs: 0.5, 0.6, 0.7 -> mean = 0.6, spread = 0.7-0.5 = 0.2
+gap_precision: 0.4, 0.4, 0.4            -> mean = 0.4, spread = 0.0
+decomposition_accuracy: None, 0.5, 0.5  -> only 2 contribute: mean = 0.5, spread = 0.0
+mapping_accuracy: always None            -> mean = None, spread = None
+evidence_agreement: 0.0 (single value)   -> not used here; covered separately
+"""
+
+import pytest
+
+from acceptance.benchmark.scoring import BenchmarkReport, disclose_variance
+
+
+def _report(**metrics) -> BenchmarkReport:
+    return BenchmarkReport(case_count=2, determinism_mode="record", **metrics)
+
+
+def test_disclose_variance_matches_hand_calculated_values():
+    reports = [
+        _report(gap_recall=0.5, gap_precision=0.4, decomposition_accuracy=None),
+        _report(gap_recall=0.6, gap_precision=0.4, decomposition_accuracy=0.5),
+        _report(gap_recall=0.7, gap_precision=0.4, decomposition_accuracy=0.5),
+    ]
+
+    disclosure = disclose_variance(reports)
+
+    assert disclosure.sample_count == 3
+    assert disclosure.determinism_mode == "record"
+
+    assert disclosure.gap_recall.mean == pytest.approx(0.6)
+    assert disclosure.gap_recall.spread == pytest.approx(0.2)
+
+    assert disclosure.gap_precision.mean == pytest.approx(0.4)
+    assert disclosure.gap_precision.spread == pytest.approx(0.0)
+
+    # Only 2 of 3 runs reported a value; the None is excluded, not treated as 0.
+    assert disclosure.decomposition_accuracy.mean == pytest.approx(0.5)
+    assert disclosure.decomposition_accuracy.spread == pytest.approx(0.0)
+
+    # Never reported in any run: no mean, no spread.
+    assert disclosure.mapping_accuracy.mean is None
+    assert disclosure.mapping_accuracy.spread is None
+
+    assert disclosure.runs == reports
+
+
+def test_a_metric_present_in_only_one_run_has_no_spread():
+    reports = [_report(evidence_agreement=0.3), _report(evidence_agreement=None)]
+
+    disclosure = disclose_variance(reports)
+
+    # Not enough samples to show variation: undefined, not a fabricated 0.0.
+    assert disclosure.evidence_agreement.mean == pytest.approx(0.3)
+    assert disclosure.evidence_agreement.spread is None
+
+
+def test_single_report_disclosure_has_no_spread_anywhere():
+    disclosure = disclose_variance([_report(gap_recall=0.6, gap_precision=1.0)])
+
+    assert disclosure.sample_count == 1
+    assert disclosure.gap_recall.mean == pytest.approx(0.6)
+    assert disclosure.gap_recall.spread is None
+    assert disclosure.gap_precision.spread is None
+
+
+def test_disclose_variance_requires_at_least_one_report():
+    with pytest.raises(ValueError):
+        disclose_variance([])
+
+
+def test_disclose_variance_rejects_mixed_determinism_modes():
+    reports = [
+        _report(gap_recall=0.5),
+        BenchmarkReport(case_count=2, determinism_mode="replay", gap_recall=0.6),
+    ]
+    with pytest.raises(ValueError):
+        disclose_variance(reports)
+
+
+def test_disclose_variance_rejects_reports_with_unknown_mode():
+    reports = [_report(gap_recall=0.5), BenchmarkReport(case_count=2, gap_recall=0.6)]
+    with pytest.raises(ValueError):
+        disclose_variance(reports)


### PR DESCRIPTION
Closes #10

## Summary
`BenchmarkReport` now discloses `determinism_mode` **unconditionally**, derived from the underlying cases' `ReviewProvenance` (kept as the same plain string literal M0.5 used, independent of the LLM harness's `Mode` enum). `score_case_set` raises if a case's `reviewer_output` has no provenance, or if cases in a set disagree on mode — a report can't coherently claim one mode if the runs behind it didn't share it.

Adds `disclose_variance(reports) -> SampledBenchmarkReport`: takes N already-computed `BenchmarkReport`s over repeated runs of the same case set and computes a **mean and spread** (max − min) per §11.1 metric. Spread is `None` when fewer than 2 non-`None` samples contribute for a metric — not enough samples to show variation, not a fabricated `0.0`.

**Scoping note**, per the deliverable's own phrasing ("*and, if sampling*, variance across N runs"): determinism mode is always disclosed; the spread is only computed when sampling actually happened. `disclose_variance` deliberately takes reports as input rather than orchestrating the N runs itself — the pipeline is still the M0.6 no-op skeleton, so there's no real sampled variance for a runner to produce yet. This is ready the moment M1+ makes the pipeline genuinely sampled, without speculative orchestration plumbing built ahead of need.

## Test plan
- [x] `pytest -q` — 90 tests pass. The acceptance is a hand-calculated 3-run synthetic disclosure (`tests/benchmark/test_variance.py`, arithmetic in the module docstring): `gap_recall` `0.5/0.6/0.7` → `mean 0.6`, `spread 0.2`; a metric present in only 2 of 3 runs correctly excludes the missing value from both mean and spread rather than treating it as `0`. Plus: single-report disclosure has no spread anywhere, missing/mixed determinism modes raise, and `score_case_set` correctly disc­loses mode on an ordinary (non-sampled) report.
- [x] `ruff check .` — clean
- [x] Manual standalone confirmation of both halves of the acceptance (mode always present; spread only under sampling)

This completes milestone **M-B0 (Benchmark harness & case schema)** — all four tasks (M-B0.1–M-B0.4) done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)