### PR TITLE
M-B5a.1: nine archetype fixture repos

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,5 +1,5 @@
 ## Deliverable
-report records determinism mode and, if sampling, variance across N runs.
+nine minimal Git fixture repos, each a real task file + base/head diff + tests reproducing the archetype (missed obligation, qualifier missed, superficial test, non-discriminating input, circular expected result, mocked-out behavior, declaration mismatch, unrequested change, revision cycle).
 
 ## Acceptance
-report output includes the determinism mode and (when sampled) a spread figure per metric.
+each fixture builds; `git diff base head` is non-empty; pytest runs (pass/fail as the archetype intends).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,12 @@ where = ["src"]
 [tool.ruff]
 target-version = "py310"
 line-length = 100
+# Archetype fixtures deliberately contain weak/imperfect code (circular tests,
+# superficial assertions); they are data, not code held to our own standards.
+extend-exclude = ["tests/fixtures"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# tests/fixtures holds archetype fixture data (its own task/base/head trees and
+# test_*.py files) that materialize into throwaway repos — never our own suite.
+addopts = "--ignore=tests/fixtures"

--- a/src/acceptance/benchmark/fixtures.py
+++ b/src/acceptance/benchmark/fixtures.py
@@ -1,0 +1,120 @@
+"""Archetype fixture materialization (M-B5a.1).
+
+The archetype scenarios (§13.5 #1–9) are hand-built ground truth: each is a
+tiny task + a base/head change embodying one way a *plausible* review can go
+wrong — the kind of mistake a capable coding agent actually makes, not a
+strawman. They can't be stored as real nested git repos (git won't track a
+nested .git), so each is kept as reviewable source trees under
+`tests/fixtures/archetypes/<NN-name>/`:
+
+    task.md          the change mandate (the checker's task-file input)
+    declaration.md   optional builder declaration (only where an archetype needs one)
+    base/            source tree before the change
+    head/            source tree after the change (implementation + tests)
+    meta.json        scenario number, name, intended pytest outcome, summary
+
+`materialize_archetype` turns one of those into a real two-commit git repo on
+demand, which is exactly the shape M-B0.2's runner consumes (repo +
+base/head revisions). Commit timestamps are fixed, so the same fixture always
+materializes to the same base/head SHAs — reproducible, in the spirit of M0.5.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from acceptance.model_base import PersistableModel
+
+# Fixed identity + timestamps so materialization is deterministic (stable SHAs).
+_FIXTURE_NAME = "Archetype Fixtures"
+_FIXTURE_EMAIL = "fixtures@example.com"
+_FIXTURE_DATE = "2020-01-02T03:04:05+00:00"
+
+
+class ArchetypeMeta(PersistableModel):
+    scenario: int
+    name: str
+    intended_pytest: Literal["pass", "fail"]
+    summary: str
+
+
+@dataclass(frozen=True)
+class MaterializedFixture:
+    repo_path: Path
+    base_sha: str
+    head_sha: str
+    meta: ArchetypeMeta
+
+
+def load_meta(fixture_dir: Path) -> ArchetypeMeta:
+    import json
+
+    return ArchetypeMeta.from_dict(json.loads((fixture_dir / "meta.json").read_text()))
+
+
+def materialize_archetype(fixture_dir: Path, dest: Path) -> MaterializedFixture:
+    """Build a two-commit git repo (base then head) from a fixture directory."""
+    meta = load_meta(fixture_dir)
+    repo = dest
+    repo.mkdir(parents=True, exist_ok=True)
+
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.name", _FIXTURE_NAME)
+    _git(repo, "config", "user.email", _FIXTURE_EMAIL)
+
+    _replace_worktree(repo, fixture_dir / "base")
+    _git(repo, "add", "-A")
+    _commit(repo, "base")
+    base_sha = _rev_parse(repo, "HEAD")
+
+    _replace_worktree(repo, fixture_dir / "head")
+    _git(repo, "add", "-A")
+    _commit(repo, "head")
+    head_sha = _rev_parse(repo, "HEAD")
+
+    return MaterializedFixture(repo_path=repo, base_sha=base_sha, head_sha=head_sha, meta=meta)
+
+
+def _replace_worktree(repo: Path, tree: Path) -> None:
+    """Clear the working tree (keeping .git) and copy `tree` into it, so a
+    file removed between base and head is staged as a deletion by `git add -A`."""
+    for entry in repo.iterdir():
+        if entry.name == ".git":
+            continue
+        if entry.is_dir():
+            shutil.rmtree(entry)
+        else:
+            entry.unlink()
+    shutil.copytree(tree, repo, dirs_exist_ok=True)
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    )
+
+
+def _commit(repo: Path, message: str) -> None:
+    env_dates = {"GIT_AUTHOR_DATE": _FIXTURE_DATE, "GIT_COMMITTER_DATE": _FIXTURE_DATE}
+    subprocess.run(
+        ["git", "commit", "-q", "-m", message],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**_os_environ(), **env_dates},
+    )
+
+
+def _rev_parse(repo: Path, revision: str) -> str:
+    return _git(repo, "rev-parse", revision).stdout.strip()
+
+
+def _os_environ() -> dict:
+    import os
+
+    return dict(os.environ)

--- a/tests/benchmark/test_fixtures.py
+++ b/tests/benchmark/test_fixtures.py
@@ -1,0 +1,87 @@
+"""M-B5a.1 acceptance: each archetype fixture builds, has a non-empty
+base->head diff, and its pytest suite runs with the intended outcome.
+
+The nine archetypes are the §13.5 #1-9 demonstration scenarios; each embodies
+a plausible mistake a capable coding agent could actually make, hidden behind
+a green test suite — which is exactly what the checker must learn to catch.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from acceptance.benchmark.fixtures import load_meta, materialize_archetype
+
+ARCHETYPES_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "archetypes"
+
+FIXTURE_DIRS = sorted(p for p in ARCHETYPES_DIR.iterdir() if p.is_dir())
+
+EXPECTED_NAMES = {
+    "01-missed-obligation",
+    "02-qualifier-missed",
+    "03-superficial-test",
+    "04-non-discriminating-input",
+    "05-circular-expected-result",
+    "06-mocked-out-behavior",
+    "07-declaration-mismatch",
+    "08-unrequested-change",
+    "09-revision-cycle",
+}
+
+
+def test_all_nine_archetypes_are_present():
+    assert {p.name for p in FIXTURE_DIRS} == EXPECTED_NAMES
+
+
+@pytest.fixture(params=FIXTURE_DIRS, ids=lambda p: p.name)
+def fixture_dir(request):
+    return request.param
+
+
+def test_fixture_has_task_and_meta(fixture_dir):
+    assert (fixture_dir / "task.md").is_file()
+    assert (fixture_dir / "base").is_dir()
+    assert (fixture_dir / "head").is_dir()
+    meta = load_meta(fixture_dir)
+    assert f"{meta.scenario:02d}-{meta.name}" == fixture_dir.name
+
+
+def test_materializes_with_a_non_empty_diff(fixture_dir, tmp_path):
+    fixture = materialize_archetype(fixture_dir, tmp_path / "repo")
+
+    assert fixture.base_sha != fixture.head_sha
+    diff = subprocess.run(
+        ["git", "diff", "--name-only", fixture.base_sha, fixture.head_sha],
+        cwd=fixture.repo_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert diff.stdout.strip(), "git diff base head must be non-empty"
+
+
+def test_materialization_is_deterministic(fixture_dir, tmp_path):
+    first = materialize_archetype(fixture_dir, tmp_path / "a")
+    second = materialize_archetype(fixture_dir, tmp_path / "b")
+
+    # Fixed identity + commit dates => stable SHAs across materializations.
+    assert first.base_sha == second.base_sha
+    assert first.head_sha == second.head_sha
+
+
+def test_head_pytest_runs_with_the_intended_outcome(fixture_dir, tmp_path):
+    fixture = materialize_archetype(fixture_dir, tmp_path / "repo")
+
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider"],
+        cwd=fixture.repo_path,
+        capture_output=True,
+        text=True,
+    )
+
+    if fixture.meta.intended_pytest == "pass":
+        assert result.returncode == 0, result.stdout + result.stderr
+    else:
+        assert result.returncode != 0, result.stdout + result.stderr

--- a/tests/fixtures/archetypes/01-missed-obligation/base/receipt.py
+++ b/tests/fixtures/archetypes/01-missed-obligation/base/receipt.py
@@ -1,0 +1,2 @@
+def format_line(name, quantity, unit_price):
+    raise NotImplementedError

--- a/tests/fixtures/archetypes/01-missed-obligation/head/receipt.py
+++ b/tests/fixtures/archetypes/01-missed-obligation/head/receipt.py
@@ -1,0 +1,3 @@
+def format_line(name, quantity, unit_price):
+    total = quantity * unit_price
+    return f"{name} x{quantity} @ ${unit_price:.2f} = ${total:.2f}"

--- a/tests/fixtures/archetypes/01-missed-obligation/head/test_receipt.py
+++ b/tests/fixtures/archetypes/01-missed-obligation/head/test_receipt.py
@@ -1,0 +1,9 @@
+from receipt import format_line
+
+
+def test_positive_line():
+    assert format_line("Widget", 3, 2.5) == "Widget x3 @ $2.50 = $7.50"
+
+
+def test_two_decimal_formatting():
+    assert format_line("Gadget", 1, 4) == "Gadget x1 @ $4.00 = $4.00"

--- a/tests/fixtures/archetypes/01-missed-obligation/meta.json
+++ b/tests/fixtures/archetypes/01-missed-obligation/meta.json
@@ -1,0 +1,6 @@
+{
+  "scenario": 1,
+  "name": "missed-obligation",
+  "intended_pytest": "pass",
+  "summary": "The task lists four formatting rules; the implementation delivers three and silently omits the fourth (returns shown in parentheses). The suite is green because no test covers the missed rule."
+}

--- a/tests/fixtures/archetypes/01-missed-obligation/task.md
+++ b/tests/fixtures/archetypes/01-missed-obligation/task.md
@@ -1,0 +1,12 @@
+# Task: Receipt line formatter
+
+Implement `format_line(name, quantity, unit_price)` in `receipt.py`, returning a
+single formatted line string.
+
+Requirements:
+
+1. Show the item name, the quantity, and the unit price.
+2. Include the line total (quantity × unit price).
+3. Format every money value as USD with exactly two decimals and a leading `$`.
+4. For returns (a negative quantity), show the quantity and the line total in
+   parentheses rather than with a minus sign — e.g. `(2)` and `($5.00)`.

--- a/tests/fixtures/archetypes/02-qualifier-missed/base/pricing.py
+++ b/tests/fixtures/archetypes/02-qualifier-missed/base/pricing.py
@@ -1,0 +1,2 @@
+def parse_price(text):
+    return float(text)

--- a/tests/fixtures/archetypes/02-qualifier-missed/head/pricing.py
+++ b/tests/fixtures/archetypes/02-qualifier-missed/head/pricing.py
@@ -1,0 +1,6 @@
+SYMBOLS = {"$": "USD", "£": "GBP", "€": "EUR"}
+
+
+def parse_price(text):
+    symbol = text[0]
+    return float(text[1:]), SYMBOLS[symbol]

--- a/tests/fixtures/archetypes/02-qualifier-missed/head/test_pricing.py
+++ b/tests/fixtures/archetypes/02-qualifier-missed/head/test_pricing.py
@@ -1,0 +1,9 @@
+from pricing import parse_price
+
+
+def test_dollar_symbol():
+    assert parse_price("$12.50") == (12.50, "USD")
+
+
+def test_euro_symbol():
+    assert parse_price("€3.00") == (3.00, "EUR")

--- a/tests/fixtures/archetypes/02-qualifier-missed/meta.json
+++ b/tests/fixtures/archetypes/02-qualifier-missed/meta.json
@@ -1,0 +1,6 @@
+{
+  "scenario": 2,
+  "name": "qualifier-missed",
+  "intended_pytest": "pass",
+  "summary": "The new currency-symbol feature is implemented and tested, but the stated backward-compatibility qualifier (plain numeric strings must keep working and default to USD) is neither implemented nor tested."
+}

--- a/tests/fixtures/archetypes/02-qualifier-missed/task.md
+++ b/tests/fixtures/archetypes/02-qualifier-missed/task.md
@@ -1,0 +1,12 @@
+# Task: Add currency support to price parsing
+
+Extend `parse_price(text)` in `pricing.py` to accept an optional leading
+currency symbol and return `(amount, currency_code)`.
+
+Requirements:
+
+1. Parse a leading currency symbol into its ISO code: `$` → `USD`, `£` → `GBP`,
+   `€` → `EUR`.
+2. Parse the remaining numeric amount as a float.
+3. Existing callers pass plain numeric strings with no symbol; those must keep
+   working and default to `USD`.

--- a/tests/fixtures/archetypes/03-superficial-test/base/loan.py
+++ b/tests/fixtures/archetypes/03-superficial-test/base/loan.py
@@ -1,0 +1,2 @@
+def amortize(principal, annual_rate, months):
+    raise NotImplementedError

--- a/tests/fixtures/archetypes/03-superficial-test/head/loan.py
+++ b/tests/fixtures/archetypes/03-superficial-test/head/loan.py
@@ -1,0 +1,7 @@
+def amortize(principal, annual_rate, months):
+    monthly_rate = annual_rate / 12
+    if monthly_rate == 0:
+        payment = principal / months
+    else:
+        payment = principal * monthly_rate / (1 - (1 + monthly_rate) ** -months)
+    return [round(payment, 2) for _ in range(months)]

--- a/tests/fixtures/archetypes/03-superficial-test/head/test_loan.py
+++ b/tests/fixtures/archetypes/03-superficial-test/head/test_loan.py
@@ -1,0 +1,8 @@
+from loan import amortize
+
+
+def test_returns_a_payment_for_each_month():
+    schedule = amortize(1200.0, 0.06, 12)
+    assert isinstance(schedule, list)
+    assert len(schedule) == 12
+    assert all(payment > 0 for payment in schedule)

--- a/tests/fixtures/archetypes/03-superficial-test/meta.json
+++ b/tests/fixtures/archetypes/03-superficial-test/meta.json
@@ -1,0 +1,6 @@
+{
+  "scenario": 3,
+  "name": "superficial-test",
+  "intended_pytest": "pass",
+  "summary": "The amortization function is implemented, but its only test checks the return is a list of the right length with positive values — never the actual payment amounts or that the loan is paid off. Green, but the test establishes almost nothing."
+}

--- a/tests/fixtures/archetypes/03-superficial-test/task.md
+++ b/tests/fixtures/archetypes/03-superficial-test/task.md
@@ -1,0 +1,6 @@
+# Task: Monthly amortization schedule
+
+Implement `amortize(principal, annual_rate, months)` in `loan.py`, returning a
+list of monthly payment amounts (floats) that fully pay off the loan using
+standard fixed-payment amortization. Each payment should be equal, and the
+schedule should have one entry per month.

--- a/tests/fixtures/archetypes/04-non-discriminating-input/base/billing.py
+++ b/tests/fixtures/archetypes/04-non-discriminating-input/base/billing.py
@@ -1,0 +1,2 @@
+def prorate(monthly_price, days_used, days_in_month):
+    raise NotImplementedError

--- a/tests/fixtures/archetypes/04-non-discriminating-input/head/billing.py
+++ b/tests/fixtures/archetypes/04-non-discriminating-input/head/billing.py
@@ -1,0 +1,3 @@
+def prorate(monthly_price, days_used, days_in_month):
+    daily_rate = monthly_price / days_in_month
+    return round(daily_rate * days_used, 2)

--- a/tests/fixtures/archetypes/04-non-discriminating-input/head/test_billing.py
+++ b/tests/fixtures/archetypes/04-non-discriminating-input/head/test_billing.py
@@ -1,0 +1,7 @@
+from billing import prorate
+
+
+def test_half_of_a_month():
+    # 30-day month: price / 30 and price / days_in_month coincide here, so this
+    # input cannot distinguish the correct rate from a hard-coded /30.
+    assert prorate(30.0, 15, 30) == 15.0

--- a/tests/fixtures/archetypes/04-non-discriminating-input/meta.json
+++ b/tests/fixtures/archetypes/04-non-discriminating-input/meta.json
@@ -1,0 +1,6 @@
+{
+  "scenario": 4,
+  "name": "non-discriminating-input",
+  "intended_pytest": "pass",
+  "summary": "Prorate is implemented correctly, but the only test uses a 30-day month, where the correct daily rate (price / days_in_month) and a plausible hard-coded price/30 both give the same answer. The test can't tell a correct implementation from that common bug."
+}

--- a/tests/fixtures/archetypes/04-non-discriminating-input/task.md
+++ b/tests/fixtures/archetypes/04-non-discriminating-input/task.md
@@ -1,0 +1,5 @@
+# Task: Prorate a monthly subscription
+
+Implement `prorate(monthly_price, days_used, days_in_month)` in `billing.py`.
+Charge for the days used at the daily rate, where the daily rate is
+`monthly_price / days_in_month`. Round the result to two decimals.

--- a/tests/fixtures/archetypes/05-circular-expected-result/base/orders.py
+++ b/tests/fixtures/archetypes/05-circular-expected-result/base/orders.py
@@ -1,0 +1,2 @@
+def order_total(subtotal, tax_rate):
+    raise NotImplementedError

--- a/tests/fixtures/archetypes/05-circular-expected-result/head/orders.py
+++ b/tests/fixtures/archetypes/05-circular-expected-result/head/orders.py
@@ -1,0 +1,6 @@
+def _apply_tax(subtotal, tax_rate):
+    return subtotal * (1 + tax_rate)
+
+
+def order_total(subtotal, tax_rate):
+    return round(_apply_tax(subtotal, tax_rate), 2)

--- a/tests/fixtures/archetypes/05-circular-expected-result/head/test_orders.py
+++ b/tests/fixtures/archetypes/05-circular-expected-result/head/test_orders.py
@@ -1,0 +1,9 @@
+from orders import _apply_tax, order_total
+
+
+def test_total_applies_tax():
+    subtotal, tax_rate = 100.0, 0.08
+    # Expected is built from the same production helper the function uses, so a
+    # bug in _apply_tax would appear identically on both sides.
+    expected = round(_apply_tax(subtotal, tax_rate), 2)
+    assert order_total(subtotal, tax_rate) == expected

--- a/tests/fixtures/archetypes/05-circular-expected-result/meta.json
+++ b/tests/fixtures/archetypes/05-circular-expected-result/meta.json
@@ -1,0 +1,6 @@
+{
+  "scenario": 5,
+  "name": "circular-expected-result",
+  "intended_pytest": "pass",
+  "summary": "The test builds its expected value by calling the same production helper (_apply_tax) that the function under test uses. A bug in that helper would corrupt both sides of the assertion equally, so the test can never fail."
+}

--- a/tests/fixtures/archetypes/05-circular-expected-result/task.md
+++ b/tests/fixtures/archetypes/05-circular-expected-result/task.md
@@ -1,0 +1,4 @@
+# Task: Order total with tax
+
+Implement `order_total(subtotal, tax_rate)` in `orders.py`, returning the
+subtotal plus tax (`subtotal * tax_rate`), rounded to two decimals.

--- a/tests/fixtures/archetypes/06-mocked-out-behavior/base/coupon.py
+++ b/tests/fixtures/archetypes/06-mocked-out-behavior/base/coupon.py
@@ -1,0 +1,2 @@
+def coupon(nominal, rate_source, date):
+    raise NotImplementedError

--- a/tests/fixtures/archetypes/06-mocked-out-behavior/head/coupon.py
+++ b/tests/fixtures/archetypes/06-mocked-out-behavior/head/coupon.py
@@ -1,0 +1,3 @@
+def coupon(nominal, rate_source, date):
+    rate = rate_source.rate_for(date)
+    return round(nominal * rate, 4)

--- a/tests/fixtures/archetypes/06-mocked-out-behavior/head/test_coupon.py
+++ b/tests/fixtures/archetypes/06-mocked-out-behavior/head/test_coupon.py
@@ -1,0 +1,11 @@
+from unittest.mock import Mock
+
+from coupon import coupon
+
+
+def test_coupon_uses_selected_rate():
+    source = Mock()
+    # rate_for is mocked to a constant regardless of the date, so this test
+    # never establishes that the rate for THIS date is the one selected.
+    source.rate_for.return_value = 0.05
+    assert coupon(1000.0, source, "2020-01-26") == 50.0

--- a/tests/fixtures/archetypes/06-mocked-out-behavior/meta.json
+++ b/tests/fixtures/archetypes/06-mocked-out-behavior/meta.json
@@ -1,0 +1,6 @@
+{
+  "scenario": 6,
+  "name": "mocked-out-behavior",
+  "intended_pytest": "pass",
+  "summary": "The requirement is that the coupon uses the rate selected for the given date. The test mocks rate_for to return a fixed value regardless of date, then asserts the coupon equals nominal times that value — establishing the multiplication, but nothing about the date-based selection it claims to cover."
+}

--- a/tests/fixtures/archetypes/06-mocked-out-behavior/task.md
+++ b/tests/fixtures/archetypes/06-mocked-out-behavior/task.md
@@ -1,0 +1,6 @@
+# Task: Coupon uses the selected index rate
+
+Implement `coupon(nominal, rate_source, date)` in `coupon.py`. It must select
+the index rate for `date` by calling `rate_source.rate_for(date)`, then return
+`nominal * selected_rate` rounded to four decimals. The core behavior under
+review is that the rate chosen corresponds to the given `date`.

--- a/tests/fixtures/archetypes/07-declaration-mismatch/base/users.py
+++ b/tests/fixtures/archetypes/07-declaration-mismatch/base/users.py
@@ -1,0 +1,2 @@
+def get_user(users, user_id):
+    raise NotImplementedError

--- a/tests/fixtures/archetypes/07-declaration-mismatch/declaration.md
+++ b/tests/fixtures/archetypes/07-declaration-mismatch/declaration.md
@@ -1,0 +1,13 @@
+# Builder declaration
+
+## Mandate as understood
+Provide a lookup that returns a user record by its id.
+
+## Implementation summary
+Added `get_user(users, user_id)`, which returns the matching user record.
+
+## Test evidence
+Covered the happy path: an existing id returns the expected record.
+
+## Known limitations
+Raises `KeyError` with a clear message when the id is not present.

--- a/tests/fixtures/archetypes/07-declaration-mismatch/head/test_users.py
+++ b/tests/fixtures/archetypes/07-declaration-mismatch/head/test_users.py
@@ -1,0 +1,6 @@
+from users import get_user
+
+
+def test_existing_id_returns_the_record():
+    users = {1: {"name": "Ada"}}
+    assert get_user(users, 1) == {"name": "Ada"}

--- a/tests/fixtures/archetypes/07-declaration-mismatch/head/users.py
+++ b/tests/fixtures/archetypes/07-declaration-mismatch/head/users.py
@@ -1,0 +1,2 @@
+def get_user(users, user_id):
+    return users.get(user_id)

--- a/tests/fixtures/archetypes/07-declaration-mismatch/meta.json
+++ b/tests/fixtures/archetypes/07-declaration-mismatch/meta.json
@@ -1,0 +1,6 @@
+{
+  "scenario": 7,
+  "name": "declaration-mismatch",
+  "intended_pytest": "pass",
+  "summary": "The builder declaration claims get_user raises KeyError with a clear message when the id is missing, but the implementation returns None on a miss and no test exercises the missing-id path. The declaration overstates what the code does."
+}

--- a/tests/fixtures/archetypes/07-declaration-mismatch/task.md
+++ b/tests/fixtures/archetypes/07-declaration-mismatch/task.md
@@ -1,0 +1,4 @@
+# Task: Look up a user by id
+
+Implement `get_user(users, user_id)` in `users.py`, returning the user record
+(a dict) that matches `user_id` from the `users` mapping.

--- a/tests/fixtures/archetypes/08-unrequested-change/base/cart.py
+++ b/tests/fixtures/archetypes/08-unrequested-change/base/cart.py
@@ -1,0 +1,2 @@
+def checkout(items):
+    return sum(item["price"] for item in items)

--- a/tests/fixtures/archetypes/08-unrequested-change/head/cart.py
+++ b/tests/fixtures/archetypes/08-unrequested-change/head/cart.py
@@ -1,0 +1,7 @@
+def apply_discount(total, percent):
+    return round(total * (1 - percent / 100), 2)
+
+
+def checkout(items, *, tax_rate=0.0):
+    subtotal = sum(item["price"] for item in items)
+    return round(subtotal * (1 + tax_rate), 2)

--- a/tests/fixtures/archetypes/08-unrequested-change/head/test_cart.py
+++ b/tests/fixtures/archetypes/08-unrequested-change/head/test_cart.py
@@ -1,0 +1,9 @@
+from cart import apply_discount, checkout
+
+
+def test_apply_discount():
+    assert apply_discount(100.0, 10) == 90.0
+
+
+def test_checkout_default_unchanged():
+    assert checkout([{"price": 2.0}, {"price": 3.0}]) == 5.0

--- a/tests/fixtures/archetypes/08-unrequested-change/meta.json
+++ b/tests/fixtures/archetypes/08-unrequested-change/meta.json
@@ -1,0 +1,6 @@
+{
+  "scenario": 8,
+  "name": "unrequested-change",
+  "intended_pytest": "pass",
+  "summary": "The task only asked for a new apply_discount function. The change also alters the existing public checkout function — adding a tax_rate parameter and changing its rounding — which the task never mentioned. Tests stay green because checkout's default still returns the old value."
+}

--- a/tests/fixtures/archetypes/08-unrequested-change/task.md
+++ b/tests/fixtures/archetypes/08-unrequested-change/task.md
@@ -1,0 +1,5 @@
+# Task: Add a discount to the cart
+
+Add `apply_discount(total, percent)` to `cart.py`, returning the total reduced
+by the given percentage and rounded to two decimals. This is the only change
+requested; existing behavior should be left as-is.

--- a/tests/fixtures/archetypes/09-revision-cycle/base/rounding.py
+++ b/tests/fixtures/archetypes/09-revision-cycle/base/rounding.py
@@ -1,0 +1,6 @@
+import math
+
+
+def round_half_even(x):
+    # First pass: naive rounding — ties round up, not to even.
+    return math.floor(x + 0.5)

--- a/tests/fixtures/archetypes/09-revision-cycle/base/test_rounding.py
+++ b/tests/fixtures/archetypes/09-revision-cycle/base/test_rounding.py
@@ -1,0 +1,6 @@
+from rounding import round_half_even
+
+
+def test_rounds_to_nearest():
+    # Non-discriminating: not a tie, so round-half-up and round-half-even agree.
+    assert round_half_even(2.3) == 2

--- a/tests/fixtures/archetypes/09-revision-cycle/head/rounding.py
+++ b/tests/fixtures/archetypes/09-revision-cycle/head/rounding.py
@@ -1,0 +1,12 @@
+import math
+
+
+def round_half_even(x):
+    floor = math.floor(x)
+    remainder = x - floor
+    if remainder < 0.5:
+        return floor
+    if remainder > 0.5:
+        return floor + 1
+    # Exact tie: round to the even neighbour.
+    return floor if floor % 2 == 0 else floor + 1

--- a/tests/fixtures/archetypes/09-revision-cycle/head/test_rounding.py
+++ b/tests/fixtures/archetypes/09-revision-cycle/head/test_rounding.py
@@ -1,0 +1,11 @@
+from rounding import round_half_even
+
+
+def test_rounds_to_nearest():
+    assert round_half_even(2.3) == 2
+
+
+def test_ties_round_to_even():
+    # The discriminating case the first pass was missing.
+    assert round_half_even(2.5) == 2
+    assert round_half_even(3.5) == 4

--- a/tests/fixtures/archetypes/09-revision-cycle/meta.json
+++ b/tests/fixtures/archetypes/09-revision-cycle/meta.json
@@ -1,0 +1,6 @@
+{
+  "scenario": 9,
+  "name": "revision-cycle",
+  "intended_pytest": "pass",
+  "summary": "Base is a first pass whose only test (2.3 -> 2) does not exercise a tie, so it can't tell banker's rounding from round-half-up — the gap a prior review would flag. Head is the next iteration: it fixes the implementation to round ties to even and adds a discriminating tie test, so a re-review flips the finding from unsupported to supported."
+}

--- a/tests/fixtures/archetypes/09-revision-cycle/task.md
+++ b/tests/fixtures/archetypes/09-revision-cycle/task.md
@@ -1,0 +1,5 @@
+# Task: Round half to even
+
+Implement `round_half_even(x)` in `rounding.py`, rounding to the nearest
+integer with ties going to the even neighbour (banker's rounding). For example
+`2.5` rounds to `2` and `3.5` rounds to `4`.


### PR DESCRIPTION
Closes #11

## Summary
Adds the §13.5 #1–9 demonstration scenarios as hand-built ground truth under `tests/fixtures/archetypes/<NN-name>/`, each a `task.md` + `base/` and `head/` source trees (+ `declaration.md` for #7, `meta.json` throughout). `src/acceptance/benchmark/fixtures.py` materializes any of them into a real two-commit git repo on demand — the exact shape M-B0.2's runner consumes (`repo` + base/head revisions) — with fixed identity and commit dates so the same fixture always yields the same base/head SHAs (reproducible, in the spirit of M0.5).

Every archetype is a mistake a capable coding agent could actually make, hidden behind a **green** suite — which is the whole point, since the checker's job is to catch what a passing suite hides:

| # | archetype | the plausible mistake |
|---|---|---|
| 1 | missed-obligation | a 4th formatting rule, stated plainly, silently omitted |
| 2 | qualifier-missed | new feature added; the backward-compat clause dropped |
| 3 | superficial-test | asserts list shape/positivity, never the payment values |
| 4 | non-discriminating-input | tests a 30-day month, where `/days_in_month` and a `/30` bug agree |
| 5 | circular-expected-result | expected value built from the same production helper |
| 6 | mocked-out-behavior | mocks the rate selection the requirement is about |
| 7 | declaration-mismatch | declaration claims a `KeyError` path the code lacks |
| 8 | unrequested-change | also alters `checkout`'s public signature, unasked |
| 9 | revision-cycle | first pass misses a tie case; head adds the discriminating test |

## Faithfulness check
Fixtures 4 and 5 aren't strawmen — I ran their weak tests against a **plausible wrong implementation** (a hard-coded `/30`; a tax helper missing the `+1`) and confirmed the tests still **pass**. That's the crux: a green suite that establishes nothing.

## Notes
- Excludes `tests/fixtures/` from our own pytest collection and ruff — the fixture `test_*.py` files collide by basename and deliberately contain imperfect code; they are data, not our suite.

## Test plan
- [x] `pytest -q` — 127 tests pass. Acceptance in `tests/benchmark/test_fixtures.py`: all nine present, each materializes with a non-empty `git diff base head`, materialization is deterministic (stable SHAs), and each head suite runs green as `meta.json` intends.
- [x] `ruff check .` — clean
- [x] Manual faithfulness check on #4 and #5 (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)