### PR TITLE
M-B5a.2: archetype ground-truth labels on an obligation tree

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,5 +1,5 @@
 ## Deliverable
-nine minimal Git fixture repos, each a real task file + base/head diff + tests reproducing the archetype (missed obligation, qualifier missed, superficial test, non-discriminating input, circular expected result, mocked-out behavior, declaration mismatch, unrequested change, revision cycle).
+a labeled benchmark case per fixture with the expected finding(s) and expected obligation decomposition.
 
 ## Acceptance
-each fixture builds; `git diff base head` is non-empty; pytest runs (pass/fail as the archetype intends).
+each case validates; labels reviewed for correctness `[human]`.

--- a/src/acceptance/benchmark/case.py
+++ b/src/acceptance/benchmark/case.py
@@ -1,18 +1,31 @@
-"""Benchmark-case schema (§15 Benchmark case, §11.1 metrics; M-B0.1).
+"""Benchmark-case schema (§15 Benchmark case, §11.1 metrics; M-B0.1, revised M-B5a.2).
 
 A case pairs a real (or offline-mutated, or hand-curated) input with
 human-verified ground truth, so the checker's output can be scored against
-it. The four ground-truth categories on `GroundTruthLabels` map directly to
-§11.1's metrics:
+it.
 
-    gaps          -> gap-detection recall / false-alarm precision
-    decomposition -> obligation-decomposition accuracy
-    mappings      -> test-to-obligation mapping accuracy
-    evidence_classes -> evidence-classification agreement
+The ground truth is an **obligation tree**: the obligation is the spine
+(CLAUDE.md — "obligations are the spine everything maps to"), and each one
+carries its own stable `id`, the tests relevant to it (`candidate_tests`), how
+strong that evidence is (`evidence_class`, a §9.3 class), and why
+(`evidence_rationale`). `gaps` are the findings a good reviewer should raise,
+each linked to the obligation it concerns. This mirrors exactly the tree the
+tool must show a user — obligation -> candidate tests -> evidence strength (with
+a reason) — and makes the §11.1 metrics fall out of it:
 
-`reviewer_output` and `score` start empty and are filled in by later
-milestones (M-B0.2's checker-under-test runner, M-B0.3's scoring) — a case is
-valid the moment it carries real ground truth, before it has ever been run.
+    obligations                 -> obligation-decomposition accuracy
+    obligation.candidate_tests  -> test-to-obligation mapping accuracy
+    obligation.evidence_class   -> evidence-classification agreement
+    gaps                        -> gap-detection recall / false-alarm precision
+
+Identifiers, not prose, are the join keys: `obligation_id` on a gap and the
+test ids in `candidate_tests` are validated to resolve, so ground truth can't
+carry a dangling reference, an obligation with no evidence class, or a weak
+result with no stated reason.
+
+`reviewer_output` and `score` start empty and are filled in by the runner
+(M-B0.2) and scorer (M-B0.3) — a case is valid the moment it carries real
+ground truth, before it has ever been run.
 """
 
 from __future__ import annotations
@@ -64,40 +77,72 @@ class BenchmarkCaseInputs(PersistableModel):
     declaration_text: str | None = None
 
 
-class GroundTruthGap(PersistableModel):
+class GroundTruthObligation(PersistableModel):
+    """One obligation in the expected decomposition, with the tests a reviewer
+    would examine for it, its evidence strength, and why — a node in the
+    obligation tree.
+
+    `candidate_tests` are the tests relevant to this obligation (§9.1 "candidate
+    tests"); a test can be a candidate yet establish nothing (mocked, circular,
+    non-discriminating), which is exactly what `evidence_class` records.
+    `evidence_rationale` states *why* the class is what it is — required so a
+    weak or negative result can never appear without an explanation (§13.6)."""
+
+    id: str
     description: str
-    obligation_ref: str | None = None
+    explicit: bool
+    evidence_class: EvidenceClassification
+    evidence_rationale: str
+    candidate_tests: list[str] = Field(default_factory=list)  # test ids (pytest nodeids)
+
+
+class GroundTruthGap(PersistableModel):
+    """A finding a good reviewer should raise. `obligation_id` links it to the
+    obligation it concerns, or is None when the gap is not about a task
+    obligation (e.g. a declaration overclaim the task never requested)."""
+
+    id: str
+    description: str
+    obligation_id: str | None = None
     severity: str | None = None
 
 
-class GroundTruthDecompositionItem(PersistableModel):
-    description: str
-    explicit: bool
-
-
-class GroundTruthMapping(PersistableModel):
-    test_id: str
-    obligation_ref: str
-
-
-class GroundTruthEvidenceClass(PersistableModel):
-    obligation_ref: str
-    classification: EvidenceClassification
-
-
 class GroundTruthLabels(PersistableModel):
+    obligations: list[GroundTruthObligation] = Field(default_factory=list)
     gaps: list[GroundTruthGap] = Field(default_factory=list)
-    decomposition: list[GroundTruthDecompositionItem] = Field(default_factory=list)
-    mappings: list[GroundTruthMapping] = Field(default_factory=list)
-    evidence_classes: list[GroundTruthEvidenceClass] = Field(default_factory=list)
 
     @model_validator(mode="after")
-    def _require_at_least_one_label(self) -> "GroundTruthLabels":
-        if not (self.gaps or self.decomposition or self.mappings or self.evidence_classes):
-            raise ValueError(
-                "GroundTruthLabels requires at least one label "
-                "(gaps, decomposition, mappings, or evidence_classes)"
-            )
+    def _check_tree_integrity(self) -> "GroundTruthLabels":
+        if not self.obligations:
+            raise ValueError("GroundTruthLabels requires at least one obligation")
+
+        obligation_ids = [o.id for o in self.obligations]
+        if any(not oid.strip() for oid in obligation_ids):
+            raise ValueError("every obligation id must be a non-empty string")
+        if len(set(obligation_ids)) != len(obligation_ids):
+            raise ValueError("obligation ids must be unique")
+
+        gap_ids = [g.id for g in self.gaps]
+        if any(not gid.strip() for gid in gap_ids):
+            raise ValueError("every gap id must be a non-empty string")
+        if len(set(gap_ids)) != len(gap_ids):
+            raise ValueError("gap ids must be unique")
+
+        known = set(obligation_ids)
+        for gap in self.gaps:
+            if gap.obligation_id is not None and gap.obligation_id not in known:
+                raise ValueError(
+                    f"gap {gap.id!r} references unknown obligation {gap.obligation_id!r}"
+                )
+        for obligation in self.obligations:
+            if any(not test_id.strip() for test_id in obligation.candidate_tests):
+                raise ValueError(
+                    f"obligation {obligation.id!r} has an empty test id in candidate_tests"
+                )
+            if not obligation.evidence_rationale.strip():
+                raise ValueError(
+                    f"obligation {obligation.id!r} must have a non-empty evidence_rationale"
+                )
         return self
 
 

--- a/src/acceptance/benchmark/fixtures.py
+++ b/src/acceptance/benchmark/fixtures.py
@@ -12,21 +12,36 @@ nested .git), so each is kept as reviewable source trees under
     base/            source tree before the change
     head/            source tree after the change (implementation + tests)
     meta.json        scenario number, name, intended pytest outcome, summary
+    labels.json      human-verified ground truth (decomposition, gaps, mappings,
+                     evidence classes) — the §11.2 archetype layer (M-B5a.2)
 
 `materialize_archetype` turns one of those into a real two-commit git repo on
 demand, which is exactly the shape M-B0.2's runner consumes (repo +
 base/head revisions). Commit timestamps are fixed, so the same fixture always
 materializes to the same base/head SHAs — reproducible, in the spirit of M0.5.
+
+`build_benchmark_case` goes one step further, assembling a full labeled
+BenchmarkCase (M-B0.1 schema): the inputs come from materialization, the
+ground truth from labels.json. The case is built on demand rather than
+persisted whole, because its inputs carry the materialized repo's real
+revisions; labels.json is the persisted, reviewable artifact.
 """
 
 from __future__ import annotations
 
+import json
 import shutil
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
+from acceptance.benchmark.case import (
+    BenchmarkCase,
+    BenchmarkCaseInputs,
+    BenchmarkCaseSource,
+    GroundTruthLabels,
+)
 from acceptance.model_base import PersistableModel
 
 # Fixed identity + timestamps so materialization is deterministic (stable SHAs).
@@ -51,9 +66,31 @@ class MaterializedFixture:
 
 
 def load_meta(fixture_dir: Path) -> ArchetypeMeta:
-    import json
-
     return ArchetypeMeta.from_dict(json.loads((fixture_dir / "meta.json").read_text()))
+
+
+def load_labels(fixture_dir: Path) -> GroundTruthLabels:
+    return GroundTruthLabels.from_dict(json.loads((fixture_dir / "labels.json").read_text()))
+
+
+def build_benchmark_case(fixture_dir: Path, dest: Path) -> BenchmarkCase:
+    """Materialize a fixture and assemble its labeled BenchmarkCase."""
+    fixture = materialize_archetype(fixture_dir, dest)
+    declaration_path = fixture_dir / "declaration.md"
+    return BenchmarkCase(
+        case_id=fixture_dir.name,
+        source=BenchmarkCaseSource(kind="archetype", identifier=fixture.meta.name),
+        inputs=BenchmarkCaseInputs(
+            repo=str(fixture.repo_path),
+            task_text=(fixture_dir / "task.md").read_text(),
+            base_revision=fixture.base_sha,
+            head_revision=fixture.head_sha,
+            declaration_text=(
+                declaration_path.read_text() if declaration_path.is_file() else None
+            ),
+        ),
+        ground_truth=load_labels(fixture_dir),
+    )
 
 
 def materialize_archetype(fixture_dir: Path, dest: Path) -> MaterializedFixture:

--- a/src/acceptance/benchmark/scoring.py
+++ b/src/acceptance/benchmark/scoring.py
@@ -1,45 +1,27 @@
-"""Benchmark scoring & report (M-B0.3, §11.1).
+"""Benchmark scoring & report (M-B0.3, §11.1; ground-truth tree revised M-B5a.2).
 
-Real scorer suite superseding M-B0.2's provisional score_case: gap-detection
-recall, false-alarm precision, obligation-decomposition accuracy,
-test-to-obligation mapping accuracy, and evidence-classification agreement.
+The §11.1 metrics fall out of the obligation tree (case.py): decomposition
+accuracy from the obligations, mapping accuracy from each obligation's
+candidate_tests edges, evidence agreement from each obligation's evidence
+class, and gap recall/precision from the gaps.
 
-Matching is exact-ref against the structured ground-truth refs from M-B0.1's
-schema (GroundTruthGap.obligation_ref, GroundTruthMapping.test_id +
-obligation_ref, etc.) against the corresponding fields on the reviewer's
-Review — no fuzzy/NLP matching, since the ground-truth schema is already
-structured rather than free text.
+Ground truth identifies obligations by a stable id; the reviewer's Review
+(review_state.py) does not yet — its obligations are identified only by
+description, and its Findings carry no §9.3 classification (that is the M1
+obligation-schema and M5.3 strength-classification work). So the cross-join
+to reviewer output is by description for now, and evidence agreement scores
+with reported_total=0 until a reviewer can express a classification. When M1
+gives reviewer obligations ids, these joins move to ids; the ground-truth
+tree is already the anchor for that.
 
-`evidence_agreement` is always computed with reported_total=0: Finding
-(review_state.py) has no field for a §9.3 test-strength classification yet
-— that's M5.3's job. M-B0.2's version compared Finding.evidence_tier (how
-evidence was PRODUCED: builder-claim/static/coverage-confirmed/...) against
-GroundTruthEvidenceClass.classification (how STRONG it is:
-strongly_supported/unsupported/...) — two disjoint vocabularies that could
-never usefully match. Being explicit that nothing is reported yet gives a
-real, meaningful 0.0 ("the reviewer can't express this yet") rather than a
-number that happens to read as zero for the wrong reason.
+Aggregation pools raw match counts across cases before dividing
+(micro-averaging), so small or no-op-heavy cases can't dilute the headline
+figures; a macro-averaged variant may be added later. A ratio is None when
+undefined (no ground truth, or nothing reported) rather than a misleading 0.0.
 
-score_case and score_case_set pool the same per-case match counts; the case
-set aggregates by pooling raw counts across all cases before dividing
-(micro-averaging) rather than averaging each case's own ratio. That avoids
-both macro- vs micro-averaging ambiguity and the awkwardness of averaging
-in the presence of a per-case None (a case with no ground truth in a
-category contributes no counts, rather than needing to be excluded from an
-average). A macro-averaged variant (e.g. for per-source-type breakdowns) may
-be worth adding later, but pooled counts stay the default so small or
-no-op-heavy cases can't dilute the headline figures.
-
-Variance disclosure (M-B0.4, §3.2's deferred "N-sample majority" alternative
-to M0.5's fixed-seed strategy): every BenchmarkReport discloses its
-determinism_mode (from the underlying cases' ReviewProvenance — kept as the
-same plain string literal M0.5 used, independent of the LLM harness's Mode
-enum). disclose_variance() then takes N such reports over repeated runs of
-the same case set and computes a mean and spread per metric. It takes
-already-computed reports rather than orchestrating the N runs itself: the
-checker is still the M0.6 no-op skeleton, so there is no real variance yet
-for a runner to produce — this function is ready the moment M1+ makes the
-pipeline genuinely sampled, without speculative orchestration plumbing now.
+Variance disclosure: every BenchmarkReport discloses its determinism_mode
+(from the cases' ReviewProvenance); disclose_variance() computes a mean and
+spread per metric across N runs of the same case set.
 """
 
 from __future__ import annotations
@@ -81,50 +63,59 @@ class _MatchCounts:
         return self.matched / self.reported_total
 
 
-def _gap_counts(case: BenchmarkCase) -> _MatchCounts:
-    review = case.reviewer_output
-    ground_truth_refs = {g.obligation_ref for g in case.ground_truth.gaps if g.obligation_ref}
-    reported_refs = {
-        f.related_obligation for f in review.findings if f.related_obligation is not None
-    }
+def _counts(ground_truth_refs: set, reported_refs: set) -> _MatchCounts:
     return _MatchCounts(
         matched=len(ground_truth_refs & reported_refs),
         ground_truth_total=len(ground_truth_refs),
         reported_total=len(reported_refs),
     )
+
+
+def _gap_counts(case: BenchmarkCase) -> _MatchCounts:
+    review = case.reviewer_output
+    obligation_desc = {o.id: o.description for o in case.ground_truth.obligations}
+    # A gap is keyed by the obligation it concerns (so "found" means the checker
+    # flagged a finding for that obligation); an obligation-less gap (e.g. a
+    # declaration overclaim) is keyed by its own id and is unmatchable until the
+    # declaration-comparison capability (M6) can produce it.
+    ground_truth_refs = {
+        obligation_desc.get(gap.obligation_id, gap.id) for gap in case.ground_truth.gaps
+    }
+    reported_refs = {
+        f.related_obligation for f in review.findings if f.related_obligation is not None
+    }
+    return _counts(ground_truth_refs, reported_refs)
 
 
 def _decomposition_counts(case: BenchmarkCase) -> _MatchCounts:
     review = case.reviewer_output
-    ground_truth_refs = {d.description for d in case.ground_truth.decomposition}
+    ground_truth_refs = {o.description for o in case.ground_truth.obligations}
     reported_refs = {o.description for o in review.obligation_map}
-    return _MatchCounts(
-        matched=len(ground_truth_refs & reported_refs),
-        ground_truth_total=len(ground_truth_refs),
-        reported_total=len(reported_refs),
-    )
+    return _counts(ground_truth_refs, reported_refs)
 
 
 def _mapping_counts(case: BenchmarkCase) -> _MatchCounts:
     review = case.reviewer_output
-    ground_truth_refs = {(m.test_id, m.obligation_ref) for m in case.ground_truth.mappings}
+    ground_truth_refs = {
+        (obligation.description, test_id)
+        for obligation in case.ground_truth.obligations
+        for test_id in obligation.candidate_tests
+    }
     reported_refs = {
-        (test_id, obligation.description)
+        (obligation.description, test_id)
         for obligation in review.obligation_map
         for test_id in obligation.test_evidence
     }
-    return _MatchCounts(
-        matched=len(ground_truth_refs & reported_refs),
-        ground_truth_total=len(ground_truth_refs),
-        reported_total=len(reported_refs),
-    )
+    return _counts(ground_truth_refs, reported_refs)
 
 
 def _evidence_counts(case: BenchmarkCase) -> _MatchCounts:
-    # reported_total is always 0: Finding has no §9.3 classification field
-    # yet (M5.3). See module docstring — this is deliberate, not a stub.
+    # Every obligation carries an evidence class, so the denominator is the full
+    # decomposition. reported_total is 0 until a reviewer Obligation can express
+    # a §9.3 classification (M5.3); matched is therefore 0 for now.
     ground_truth_refs = {
-        (e.obligation_ref, e.classification) for e in case.ground_truth.evidence_classes
+        (obligation.description, obligation.evidence_class)
+        for obligation in case.ground_truth.obligations
     }
     return _MatchCounts(matched=0, ground_truth_total=len(ground_truth_refs), reported_total=0)
 
@@ -174,8 +165,6 @@ class BenchmarkReport(PersistableModel):
 
 
 def _case_determinism_mode(case: BenchmarkCase) -> str:
-    # reviewer_output is already known non-None here: _all_counts checks it
-    # before this is called.
     provenance = case.reviewer_output.provenance
     if provenance is None:
         raise ValueError(

--- a/tests/benchmark/test_case.py
+++ b/tests/benchmark/test_case.py
@@ -7,11 +7,9 @@ from acceptance.benchmark.case import (
     BenchmarkCaseInputs,
     BenchmarkCaseSource,
     BenchmarkScore,
-    GroundTruthDecompositionItem,
-    GroundTruthEvidenceClass,
     GroundTruthGap,
     GroundTruthLabels,
-    GroundTruthMapping,
+    GroundTruthObligation,
 )
 from acceptance.review_state import Review
 
@@ -20,6 +18,40 @@ def _round_trip(instance):
     cls = type(instance)
     persisted = json.loads(json.dumps(instance.to_dict()))
     return cls.from_dict(persisted)
+
+
+def _obligation(**overrides) -> GroundTruthObligation:
+    defaults = dict(
+        id="csv-generation",
+        description="CSV generation",
+        explicit=True,
+        evidence_class="strongly_supported",
+        evidence_rationale="The test asserts the generated CSV exactly.",
+        candidate_tests=["test_csv.py::test_basic"],
+    )
+    defaults.update(overrides)
+    return GroundTruthObligation(**defaults)
+
+
+def _labels(**overrides) -> GroundTruthLabels:
+    defaults = dict(
+        obligations=[
+            _obligation(),
+            _obligation(id="filters", description="Active filters applied",
+                        evidence_class="unsupported",
+                        evidence_rationale="No test exercises filtering.", candidate_tests=[]),
+        ],
+        gaps=[
+            GroundTruthGap(
+                id="gap-filters",
+                description="Active filters not applied",
+                obligation_id="filters",
+                severity="high",
+            )
+        ],
+    )
+    defaults.update(overrides)
+    return GroundTruthLabels(**defaults)
 
 
 def _case(**overrides) -> BenchmarkCase:
@@ -32,9 +64,7 @@ def _case(**overrides) -> BenchmarkCase:
             base_revision="abc123",
             head_revision="def456",
         ),
-        ground_truth=GroundTruthLabels(
-            gaps=[GroundTruthGap(description="Active filters not applied")]
-        ),
+        ground_truth=_labels(),
     )
     defaults.update(overrides)
     return BenchmarkCase(**defaults)
@@ -53,7 +83,17 @@ def test_benchmark_case_round_trips_with_reviewer_output_and_score():
     assert _round_trip(case) == case
 
 
-def test_case_missing_ground_truth_entirely_fails_validation():
+def test_labels_round_trip():
+    labels = _labels()
+    assert _round_trip(labels) == labels
+
+
+def test_case_with_no_obligations_fails_validation():
+    with pytest.raises(ValueError):
+        GroundTruthLabels(obligations=[], gaps=[])
+
+
+def test_case_requires_ground_truth():
     with pytest.raises(ValueError):
         BenchmarkCase(
             case_id="archetype-01",
@@ -67,36 +107,51 @@ def test_case_missing_ground_truth_entirely_fails_validation():
         )
 
 
-def test_empty_ground_truth_labels_fails_validation():
-    with pytest.raises(ValueError):
-        GroundTruthLabels()
-
-
-@pytest.mark.parametrize(
-    "kwargs",
-    [
-        {"gaps": [GroundTruthGap(description="Filter behavior unsupported")]},
-        {"decomposition": [GroundTruthDecompositionItem(description="CSV export", explicit=True)]},
-        {"mappings": [GroundTruthMapping(test_id="test_csv", obligation_ref="csv-export")]},
-        {
-            "evidence_classes": [
-                GroundTruthEvidenceClass(obligation_ref="csv-export", classification="unsupported")
-            ]
-        },
-    ],
-)
-def test_each_ground_truth_category_alone_is_sufficient(kwargs):
-    labels = GroundTruthLabels(**kwargs)
-    assert _round_trip(labels) == labels
-
-
-def test_ground_truth_evidence_classification_rejects_unknown_value():
+def test_gap_referencing_unknown_obligation_fails_validation():
     with pytest.raises(ValueError):
         GroundTruthLabels(
-            evidence_classes=[
-                GroundTruthEvidenceClass(obligation_ref="csv-export", classification="bogus")
-            ]
+            obligations=[_obligation()],
+            gaps=[GroundTruthGap(id="g1", description="x", obligation_id="does-not-exist")],
         )
+
+
+def test_gap_with_no_obligation_id_is_allowed():
+    labels = GroundTruthLabels(
+        obligations=[_obligation()],
+        gaps=[GroundTruthGap(id="g1", description="a declaration overclaim", obligation_id=None)],
+    )
+    assert labels.gaps[0].obligation_id is None
+
+
+def test_duplicate_obligation_ids_fail_validation():
+    with pytest.raises(ValueError):
+        GroundTruthLabels(obligations=[_obligation(), _obligation()])
+
+
+def test_duplicate_gap_ids_fail_validation():
+    with pytest.raises(ValueError):
+        GroundTruthLabels(
+            obligations=[_obligation()],
+            gaps=[
+                GroundTruthGap(id="g1", description="a"),
+                GroundTruthGap(id="g1", description="b"),
+            ],
+        )
+
+
+def test_empty_candidate_test_id_fails_validation():
+    with pytest.raises(ValueError):
+        GroundTruthLabels(obligations=[_obligation(candidate_tests=[""])])
+
+
+def test_missing_evidence_rationale_fails_validation():
+    with pytest.raises(ValueError):
+        GroundTruthLabels(obligations=[_obligation(evidence_rationale="  ")])
+
+
+def test_unknown_evidence_classification_is_rejected():
+    with pytest.raises(ValueError):
+        _obligation(evidence_class="bogus")
 
 
 def test_benchmark_case_source_round_trips():

--- a/tests/benchmark/test_labels.py
+++ b/tests/benchmark/test_labels.py
@@ -1,0 +1,143 @@
+"""M-B5a.2 acceptance: each archetype has a valid labeled BenchmarkCase whose
+ground truth is an obligation tree — each obligation carrying its candidate
+tests, evidence strength, and the reason for that strength — plus the expected
+gap(s).
+
+The label *correctness* is a human-review gate (`[human]` on the issue); these
+tests establish that every case is present, well-formed, internally consistent
+(every reference resolves, every obligation has an evidence class and a
+rationale), that the candidate_tests ids name real tests in the fixture, and
+that the full fixture -> labeled case -> run -> score loop works against the
+(no-op) checker.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from acceptance.benchmark.case import BenchmarkCase, GroundTruthLabels
+from acceptance.benchmark.fixtures import build_benchmark_case, load_labels, materialize_archetype
+from acceptance.benchmark.runner import run_case
+from acceptance.benchmark.scoring import score_case_set
+from acceptance.config import RunConfig
+from acceptance.review_store import ReviewStore
+
+ARCHETYPES_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "archetypes"
+FIXTURE_DIRS = sorted(p for p in ARCHETYPES_DIR.iterdir() if p.is_dir())
+
+
+@pytest.fixture(params=FIXTURE_DIRS, ids=lambda p: p.name)
+def fixture_dir(request):
+    return request.param
+
+
+def _collected_test_ids(repo: Path) -> set[str]:
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "--collect-only", "-q", "-p", "no:cacheprovider"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    # Lines look like "test_receipt.py::test_positive_line"; a trailing summary
+    # line ("2 tests collected in ...") is filtered out by the "::" check.
+    return {line.strip() for line in result.stdout.splitlines() if "::" in line}
+
+
+def test_every_fixture_has_labels(fixture_dir):
+    assert (fixture_dir / "labels.json").is_file()
+    labels = load_labels(fixture_dir)
+    assert isinstance(labels, GroundTruthLabels)
+    assert labels.obligations, "each fixture must label its obligation decomposition"
+
+
+def test_every_obligation_has_an_evidence_class_and_rationale(fixture_dir):
+    # Structural in the schema (both are required), asserted here as the
+    # completeness guarantee the labels must meet: no result without a reason.
+    labels = load_labels(fixture_dir)
+    for obligation in labels.obligations:
+        assert obligation.evidence_class
+        assert obligation.evidence_rationale.strip()
+
+
+def test_non_strong_obligations_are_each_flagged_by_a_gap(fixture_dir):
+    """Anything short of strongly_supported is a deficiency that weighs against
+    acceptance — a partial/nominal/unsupported obligation can only be accepted
+    with a caveat, so each must be raised as a gap. Only strongly_supported
+    obligations may go unflagged."""
+    labels = load_labels(fixture_dir)
+    flagged = {g.obligation_id for g in labels.gaps if g.obligation_id is not None}
+    for obligation in labels.obligations:
+        if obligation.evidence_class != "strongly_supported":
+            assert obligation.id in flagged, (
+                f"{fixture_dir.name}: obligation {obligation.id!r} is "
+                f"{obligation.evidence_class} but no gap references it"
+            )
+
+
+def test_build_benchmark_case_validates(fixture_dir, tmp_path):
+    case = build_benchmark_case(fixture_dir, tmp_path / "repo")
+
+    assert isinstance(case, BenchmarkCase)
+    assert case.case_id == fixture_dir.name
+    assert case.source.kind == "archetype"
+    assert case.inputs.base_revision != case.inputs.head_revision
+    assert case.inputs.task_text.strip()
+    assert case.ground_truth.obligations
+
+
+def test_candidate_test_ids_name_real_tests(fixture_dir, tmp_path):
+    """Every test id a label maps to an obligation must be a real pytest node
+    in the fixture's head — no dangling test references."""
+    fixture = materialize_archetype(fixture_dir, tmp_path / "repo")
+    real_test_ids = _collected_test_ids(fixture.repo_path)
+    labels = load_labels(fixture_dir)
+
+    labeled = {t for o in labels.obligations for t in o.candidate_tests}
+    unknown = labeled - real_test_ids
+    assert not unknown, f"labels reference tests that do not exist: {sorted(unknown)}"
+
+
+def test_declaration_mismatch_case_carries_the_declaration(tmp_path):
+    fixture_dir = ARCHETYPES_DIR / "07-declaration-mismatch"
+    case = build_benchmark_case(fixture_dir, tmp_path / "repo")
+    assert case.inputs.declaration_text is not None
+    assert "KeyError" in case.inputs.declaration_text
+    # The gap here is a declaration-vs-code discrepancy, not a task obligation.
+    assert case.ground_truth.gaps[0].obligation_id is None
+
+
+def test_revision_cycle_is_a_true_negative(tmp_path):
+    """#9 head closes the earlier gap, so its ground truth has no gap — a
+    precision (false-alarm) check for the checker, not a recall check."""
+    fixture_dir = ARCHETYPES_DIR / "09-revision-cycle"
+    case = build_benchmark_case(fixture_dir, tmp_path / "repo")
+    assert case.ground_truth.gaps == []
+    ties = next(o for o in case.ground_truth.obligations if o.id == "ties-to-even")
+    assert ties.evidence_class == "strongly_supported"
+
+
+def test_full_loop_scores_the_noop_checker_as_all_miss(tmp_path):
+    """fixture -> labeled case -> run the (no-op) checker -> score. The empty
+    skeleton finds nothing, so every recall metric over the labels is 0.0."""
+    cases = []
+    for i, fixture_dir in enumerate(FIXTURE_DIRS):
+        case = build_benchmark_case(fixture_dir, tmp_path / f"repo-{i}")
+        cases.append(
+            run_case(
+                case,
+                config=RunConfig(),
+                review_store=ReviewStore(tmp_path / f"reviews-{i}"),
+            )
+        )
+
+    report = score_case_set(cases)
+
+    assert report.case_count == len(FIXTURE_DIRS)
+    assert report.gap_recall == 0.0  # eight fixtures label a gap; none found
+    assert report.decomposition_accuracy == 0.0  # obligations labeled everywhere; none found
+    assert report.mapping_accuracy == 0.0  # coverage edges labeled; none found
+    assert report.evidence_agreement == 0.0
+    assert report.determinism_mode == "replay"

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -4,10 +4,32 @@ from acceptance.benchmark.case import (
     BenchmarkCaseSource,
     GroundTruthGap,
     GroundTruthLabels,
+    GroundTruthObligation,
 )
 from acceptance.benchmark.runner import run_case
 from acceptance.config import RunConfig
 from acceptance.review_store import ReviewStore
+
+
+def _labels() -> GroundTruthLabels:
+    return GroundTruthLabels(
+        obligations=[
+            GroundTruthObligation(
+                id="filters",
+                description="Active filters are applied to the export",
+                explicit=True,
+                evidence_class="unsupported",
+                evidence_rationale="No test exercises filtering.",
+            )
+        ],
+        gaps=[
+            GroundTruthGap(
+                id="gap-filters",
+                description="Active filters not applied",
+                obligation_id="filters",
+            )
+        ],
+    )
 
 
 def test_running_the_empty_skeleton_over_an_archetype_case_yields_an_all_miss_score(
@@ -24,9 +46,7 @@ def test_running_the_empty_skeleton_over_an_archetype_case_yields_an_all_miss_sc
             base_revision=git_repo_elsewhere["base"],
             head_revision=git_repo_elsewhere["head"],
         ),
-        ground_truth=GroundTruthLabels(
-            gaps=[GroundTruthGap(description="Active filters not applied", obligation_ref="filters")]
-        ),
+        ground_truth=_labels(),
     )
 
     result = run_case(
@@ -52,7 +72,7 @@ def test_run_case_does_not_mutate_the_input_case(git_repo_elsewhere, tmp_path):
             base_revision=git_repo_elsewhere["base"],
             head_revision=git_repo_elsewhere["head"],
         ),
-        ground_truth=GroundTruthLabels(gaps=[GroundTruthGap(description="x")]),
+        ground_truth=_labels(),
     )
 
     run_case(case, config=RunConfig(), review_store=ReviewStore(tmp_path / "reviews"))

--- a/tests/benchmark/test_scoring.py
+++ b/tests/benchmark/test_scoring.py
@@ -4,11 +4,9 @@ from acceptance.benchmark.case import (
     BenchmarkCase,
     BenchmarkCaseInputs,
     BenchmarkCaseSource,
-    GroundTruthDecompositionItem,
-    GroundTruthEvidenceClass,
     GroundTruthGap,
     GroundTruthLabels,
-    GroundTruthMapping,
+    GroundTruthObligation,
 )
 from acceptance.benchmark.scoring import score_case
 from acceptance.review_state import Review
@@ -25,14 +23,31 @@ def _archetype_case(**overrides) -> BenchmarkCase:
             head_revision="def456",
         ),
         ground_truth=GroundTruthLabels(
-            gaps=[GroundTruthGap(description="Active filters not applied", obligation_ref="filters")],
-            decomposition=[
-                GroundTruthDecompositionItem(description="CSV generation", explicit=True),
-                GroundTruthDecompositionItem(description="Active filters applied", explicit=True),
+            obligations=[
+                GroundTruthObligation(
+                    id="csv-generation",
+                    description="CSV generation",
+                    explicit=True,
+                    evidence_class="strongly_supported",
+                    evidence_rationale="The test asserts the generated CSV exactly.",
+                    candidate_tests=["test_csv.py::test_basic"],
+                ),
+                GroundTruthObligation(
+                    id="filters",
+                    description="Active filters applied",
+                    explicit=True,
+                    evidence_class="unsupported",
+                    evidence_rationale="No test exercises filtering.",
+                    candidate_tests=[],
+                ),
             ],
-            mappings=[GroundTruthMapping(test_id="test_csv_basic", obligation_ref="csv-generation")],
-            evidence_classes=[
-                GroundTruthEvidenceClass(obligation_ref="csv-generation", classification="strongly_supported")
+            gaps=[
+                GroundTruthGap(
+                    id="gap-filters",
+                    description="Active filters not applied",
+                    obligation_id="filters",
+                    severity="high",
+                )
             ],
         ),
     )
@@ -47,9 +62,7 @@ def test_score_case_raises_without_reviewer_output():
 
 
 def test_empty_review_yields_an_all_miss_score():
-    case = _archetype_case(
-        reviewer_output=Review(mode="local", reviewed_revision="def456")
-    )
+    case = _archetype_case(reviewer_output=Review(mode="local", reviewed_revision="def456"))
 
     score = score_case(case)
 
@@ -57,22 +70,33 @@ def test_empty_review_yields_an_all_miss_score():
     assert score.gap_recall == 0.0
     assert score.decomposition_accuracy == 0.0
     assert score.mapping_accuracy == 0.0
-    # evidence_agreement is a real 0.0 too: Finding has no §9.3 classification
-    # field yet (M5.3), so nothing can ever be reported for this metric.
+    # evidence_agreement is a real 0.0: a reviewer Obligation has no §9.3
+    # classification field yet (M5.3), so nothing can be reported for it.
     assert score.evidence_agreement == 0.0
     # Nothing was reported to be right or wrong about: undefined, not 0.0/1.0.
     assert score.gap_precision is None
 
 
-def test_recall_and_precision_are_none_when_ground_truth_is_empty():
+def test_metrics_are_none_when_their_ground_truth_is_empty():
+    # An obligation with no candidate test and a case with no gaps: mapping has
+    # no ground-truth edges, and gaps have none, so both are undefined.
     case = _archetype_case(
-        ground_truth=GroundTruthLabels(gaps=[GroundTruthGap(description="only gaps present")]),
+        ground_truth=GroundTruthLabels(
+            obligations=[
+                GroundTruthObligation(
+                    id="only", description="only obligation", explicit=True,
+                    evidence_class="unsupported", evidence_rationale="No test at all.",
+                    candidate_tests=[],
+                )
+            ],
+            gaps=[],
+        ),
         reviewer_output=Review(mode="local", reviewed_revision="def456"),
     )
 
     score = score_case(case)
 
-    # No ground-truth decomposition/mappings/evidence_classes to score against.
-    assert score.decomposition_accuracy is None
-    assert score.mapping_accuracy is None
-    assert score.evidence_agreement is None
+    assert score.gap_recall is None  # no labeled gaps
+    assert score.mapping_accuracy is None  # no candidate_tests edges
+    assert score.decomposition_accuracy == 0.0  # one obligation, none reported
+    assert score.evidence_agreement == 0.0  # one obligation with an evidence class

--- a/tests/benchmark/test_scoring_report.py
+++ b/tests/benchmark/test_scoring_report.py
@@ -1,27 +1,32 @@
 """M-B0.3 acceptance: on a synthetic set with known labels, computed metrics
-match hand-calculated expected values.
+match hand-calculated expected values. Recomputed for the M-B5a.2 obligation
+tree (each obligation carries its covered_by tests and evidence class).
 
-Case A: gap ground truth {filters, row-limit}; reviewer reports {filters}.
-  -> gap: matched=1, gt=2, reported=1
-Case B: gap ground truth {csv-escaping}; reviewer reports {csv-escaping, unrelated}.
-  -> gap: matched=1, gt=1, reported=2
-Pooled: matched=2, gt=3, reported=3 -> gap_recall = 2/3, gap_precision = 2/3
+Two cases with hand-authored reviewer output. Match keys: obligations by
+description, mappings by (obligation description, test id), gaps by the
+description of the obligation they concern, evidence agreement always
+reported_total=0 (no reviewer §9.3 classification yet).
 
-Case A decomposition ground truth {"CSV generation", "Active filters applied"};
-  reviewer reports {"CSV generation"}. -> matched=1, gt=2
-Case B decomposition ground truth {"Escape special characters"};
-  reviewer reports {"Escape special characters"}. -> matched=1, gt=1
-Pooled: matched=2, gt=3 -> decomposition_accuracy = 2/3
+Case A ground truth: obligations {Alpha [T1], Beta []}, gap on Beta.
+       reviewer: reports obligation Alpha (but not its T1 mapping); flags Beta.
+  gap:           matched 1, gt 1, reported 1
+  decomposition: matched 1 (Alpha), gt 2, reported 1
+  mapping:       matched 0, gt 1 (Alpha,T1), reported 0
+  evidence:      gt 2, reported 0
 
-Case A mapping ground truth {(test_csv, "CSV generation")}; reviewer reports
-  the same pair via Obligation.test_evidence. -> matched=1, gt=1
-Case B mapping ground truth {(test_escape, escaping)}; reviewer reports nothing.
-  -> matched=0, gt=1
-Pooled: matched=1, gt=2 -> mapping_accuracy = 1/2
+Case B ground truth: obligations {Gamma [T2]}, no gaps (true negative).
+       reviewer: reports Gamma with its T2 mapping + a spurious Delta;
+                 raises a spurious Epsilon finding.
+  gap:           matched 0, gt 0, reported 1
+  decomposition: matched 1 (Gamma), gt 1, reported 2 (Gamma, Delta)
+  mapping:       matched 1 (Gamma,T2), gt 1, reported 1
+  evidence:      gt 1, reported 0
 
-evidence_classes: Case A has 1 ground-truth label, Case B has none.
-Pooled ground truth=1, matched=0 (Finding can't express a classification yet)
-  -> evidence_agreement = 0/1 = 0.0
+Pooled:
+  gap_recall    = 1/1 = 1.0     gap_precision = 1/2 = 0.5
+  decomposition = 2/3
+  mapping       = 1/2 = 0.5
+  evidence      = 0/3 = 0.0
 """
 
 import pytest
@@ -30,11 +35,9 @@ from acceptance.benchmark.case import (
     BenchmarkCase,
     BenchmarkCaseInputs,
     BenchmarkCaseSource,
-    GroundTruthDecompositionItem,
-    GroundTruthEvidenceClass,
     GroundTruthGap,
     GroundTruthLabels,
-    GroundTruthMapping,
+    GroundTruthObligation,
 )
 from acceptance.benchmark.scoring import score_case_set
 from acceptance.evidence_tier import Component, EvidenceTier
@@ -56,53 +59,56 @@ def _provenance() -> ReviewProvenance:
     )
 
 
+def _reviewer_obligation(description: str, test_evidence: list[str]) -> Obligation:
+    return Obligation(
+        description=description,
+        type="behavior",
+        source_text="...",
+        importance="critical",
+        explicit=True,
+        observable_behavior="...",
+        test_evidence=test_evidence,
+    )
+
+
+def _finding(related_obligation: str) -> Finding:
+    return Finding(
+        type="missed_obligation",
+        severity="high",
+        description=f"gap on {related_obligation}",
+        evidence_tier=EvidenceTier.STATIC,
+        produced_by=Component.STATIC_ANALYZER,
+        links=[Link(kind="requirement", ref="task.md:1")],
+        related_obligation=related_obligation,
+    )
+
+
 def _case_a() -> BenchmarkCase:
     return BenchmarkCase(
         case_id="synthetic-a",
         source=BenchmarkCaseSource(kind="archetype", identifier="synthetic-a"),
         inputs=_inputs(),
         ground_truth=GroundTruthLabels(
-            gaps=[
-                GroundTruthGap(description="filters missing", obligation_ref="filters"),
-                GroundTruthGap(description="row limit missing", obligation_ref="row-limit"),
+            obligations=[
+                GroundTruthObligation(
+                    id="alpha", description="Alpha", explicit=True,
+                    evidence_class="strongly_supported", evidence_rationale="asserted",
+                    candidate_tests=["T1"],
+                ),
+                GroundTruthObligation(
+                    id="beta", description="Beta", explicit=True,
+                    evidence_class="unsupported", evidence_rationale="no test",
+                    candidate_tests=[],
+                ),
             ],
-            decomposition=[
-                GroundTruthDecompositionItem(description="CSV generation", explicit=True),
-                GroundTruthDecompositionItem(description="Active filters applied", explicit=True),
-            ],
-            mappings=[GroundTruthMapping(test_id="test_csv", obligation_ref="CSV generation")],
-            evidence_classes=[
-                GroundTruthEvidenceClass(
-                    obligation_ref="CSV generation", classification="strongly_supported"
-                )
-            ],
+            gaps=[GroundTruthGap(id="gap-beta", description="Beta missing", obligation_id="beta")],
         ),
         reviewer_output=Review(
             mode="local",
             reviewed_revision="def456",
             provenance=_provenance(),
-            obligation_map=[
-                Obligation(
-                    description="CSV generation",
-                    type="behavior",
-                    source_text="...",
-                    importance="critical",
-                    explicit=True,
-                    observable_behavior="...",
-                    test_evidence=["test_csv"],
-                )
-            ],
-            findings=[
-                Finding(
-                    type="missed_obligation",
-                    severity="high",
-                    description="Filters not applied",
-                    evidence_tier=EvidenceTier.STATIC,
-                    produced_by=Component.STATIC_ANALYZER,
-                    links=[Link(kind="requirement", ref="task.md:1")],
-                    related_obligation="filters",
-                )
-            ],
+            obligation_map=[_reviewer_obligation("Alpha", test_evidence=[])],
+            findings=[_finding("Beta")],
         ),
     )
 
@@ -113,47 +119,24 @@ def _case_b() -> BenchmarkCase:
         source=BenchmarkCaseSource(kind="archetype", identifier="synthetic-b"),
         inputs=_inputs(),
         ground_truth=GroundTruthLabels(
-            gaps=[GroundTruthGap(description="csv escaping missing", obligation_ref="csv-escaping")],
-            decomposition=[
-                GroundTruthDecompositionItem(description="Escape special characters", explicit=True)
+            obligations=[
+                GroundTruthObligation(
+                    id="gamma", description="Gamma", explicit=True,
+                    evidence_class="strongly_supported", evidence_rationale="asserted",
+                    candidate_tests=["T2"],
+                ),
             ],
-            mappings=[GroundTruthMapping(test_id="test_escape", obligation_ref="escaping")],
+            gaps=[],
         ),
         reviewer_output=Review(
             mode="local",
             reviewed_revision="def456",
             provenance=_provenance(),
             obligation_map=[
-                Obligation(
-                    description="Escape special characters",
-                    type="behavior",
-                    source_text="...",
-                    importance="critical",
-                    explicit=True,
-                    observable_behavior="...",
-                    # No test_evidence: the mapping ground truth goes unmatched.
-                )
+                _reviewer_obligation("Gamma", test_evidence=["T2"]),
+                _reviewer_obligation("Delta", test_evidence=[]),
             ],
-            findings=[
-                Finding(
-                    type="missed_obligation",
-                    severity="high",
-                    description="CSV escaping not handled",
-                    evidence_tier=EvidenceTier.STATIC,
-                    produced_by=Component.STATIC_ANALYZER,
-                    links=[Link(kind="requirement", ref="task.md:2")],
-                    related_obligation="csv-escaping",
-                ),
-                Finding(
-                    type="missed_obligation",
-                    severity="low",
-                    description="Spurious, unrelated finding",
-                    evidence_tier=EvidenceTier.STATIC,
-                    produced_by=Component.STATIC_ANALYZER,
-                    links=[Link(kind="requirement", ref="task.md:3")],
-                    related_obligation="unrelated",
-                ),
-            ],
+            findings=[_finding("Epsilon")],
         ),
     )
 
@@ -163,10 +146,10 @@ def test_pooled_report_matches_hand_calculated_values():
 
     assert report.case_count == 2
     assert report.determinism_mode == "replay"
-    assert report.gap_recall == 2 / 3
-    assert report.gap_precision == 2 / 3
+    assert report.gap_recall == 1.0
+    assert report.gap_precision == 0.5
     assert report.decomposition_accuracy == 2 / 3
-    assert report.mapping_accuracy == 1 / 2
+    assert report.mapping_accuracy == 0.5
     assert report.evidence_agreement == 0.0
 
 
@@ -174,12 +157,16 @@ def test_report_includes_per_case_scores():
     report = score_case_set([_case_a(), _case_b()])
 
     assert len(report.per_case) == 2
-    # Case A alone: gap matched=1, gt=2, reported=1.
-    assert report.per_case[0].gap_recall == 0.5
+    # Case A: gap 1/1, decomposition 1/2, mapping 0/1.
+    assert report.per_case[0].gap_recall == 1.0
     assert report.per_case[0].gap_precision == 1.0
-    # Case B alone: gap matched=1, gt=1, reported=2.
-    assert report.per_case[1].gap_recall == 1.0
-    assert report.per_case[1].gap_precision == 0.5
+    assert report.per_case[0].decomposition_accuracy == 0.5
+    assert report.per_case[0].mapping_accuracy == 0.0
+    # Case B: no gaps -> recall None, precision 0/1; decomposition 1/2; mapping 1/1.
+    assert report.per_case[1].gap_recall is None
+    assert report.per_case[1].gap_precision == 0.0
+    assert report.per_case[1].decomposition_accuracy == 1.0
+    assert report.per_case[1].mapping_accuracy == 1.0
 
 
 def test_empty_case_set_yields_no_metrics():

--- a/tests/fixtures/archetypes/01-missed-obligation/labels.json
+++ b/tests/fixtures/archetypes/01-missed-obligation/labels.json
@@ -1,0 +1,44 @@
+{
+  "obligations": [
+    {
+      "id": "show-fields",
+      "description": "Show the item name, quantity, and unit price",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Both tests assert the full formatted line exactly, so a missing or malformed field would fail.",
+      "candidate_tests": ["test_receipt.py::test_positive_line", "test_receipt.py::test_two_decimal_formatting"]
+    },
+    {
+      "id": "line-total",
+      "description": "Include the line total (quantity times unit price)",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Both tests assert the exact total (3x2.5=7.50, 1x4=4.00); a wrong total formula would fail.",
+      "candidate_tests": ["test_receipt.py::test_positive_line", "test_receipt.py::test_two_decimal_formatting"]
+    },
+    {
+      "id": "money-format",
+      "description": "Format money as USD with two decimals and a leading $",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Both tests assert exact $ formatting ($2.50, $7.50, $4.00); wrong formatting would fail.",
+      "candidate_tests": ["test_receipt.py::test_positive_line", "test_receipt.py::test_two_decimal_formatting"]
+    },
+    {
+      "id": "returns-in-parens",
+      "description": "Show negative-quantity returns with the quantity and total in parentheses",
+      "explicit": true,
+      "evidence_class": "unsupported",
+      "evidence_rationale": "No test exercises a negative quantity, and the behavior is unimplemented, so nothing establishes it.",
+      "candidate_tests": []
+    }
+  ],
+  "gaps": [
+    {
+      "id": "gap-returns-in-parens",
+      "description": "Returns (negative quantity) are not shown in parentheses; the fourth stated rule is unimplemented and untested",
+      "obligation_id": "returns-in-parens",
+      "severity": "high"
+    }
+  ]
+}

--- a/tests/fixtures/archetypes/02-qualifier-missed/labels.json
+++ b/tests/fixtures/archetypes/02-qualifier-missed/labels.json
@@ -1,0 +1,36 @@
+{
+  "obligations": [
+    {
+      "id": "parse-symbol",
+      "description": "Parse a leading currency symbol into its ISO code ($ USD, GBP, EUR)",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Both tests assert the ISO code for a symbol prefix (USD, EUR); a wrong mapping would fail.",
+      "candidate_tests": ["test_pricing.py::test_dollar_symbol", "test_pricing.py::test_euro_symbol"]
+    },
+    {
+      "id": "parse-amount",
+      "description": "Parse the remaining numeric amount as a float",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Both tests assert the exact parsed amount (12.50, 3.00); a wrong parse would fail.",
+      "candidate_tests": ["test_pricing.py::test_dollar_symbol", "test_pricing.py::test_euro_symbol"]
+    },
+    {
+      "id": "backward-compat",
+      "description": "Plain numeric strings with no symbol keep working and default to USD",
+      "explicit": true,
+      "evidence_class": "unsupported",
+      "evidence_rationale": "No test passes a plain numeric string, and the code strips the first digit and raises on one, so nothing establishes the default-USD path.",
+      "candidate_tests": []
+    }
+  ],
+  "gaps": [
+    {
+      "id": "gap-backward-compat",
+      "description": "Plain numeric strings without a symbol now raise (the first digit is stripped and used as a symbol lookup) instead of parsing and defaulting to USD; the backward-compatibility qualifier is unimplemented and untested",
+      "obligation_id": "backward-compat",
+      "severity": "high"
+    }
+  ]
+}

--- a/tests/fixtures/archetypes/03-superficial-test/labels.json
+++ b/tests/fixtures/archetypes/03-superficial-test/labels.json
@@ -1,0 +1,42 @@
+{
+  "obligations": [
+    {
+      "id": "equal-payments",
+      "description": "Return a list of equal monthly payments",
+      "explicit": true,
+      "evidence_class": "nominally_supported",
+      "evidence_rationale": "The candidate test exercises amortize (in the changed code, lifts coverage) but asserts only the list length and that values are positive; it references nothing about equality, so a mutant that makes the payments unequal survives it. A present, relevant test that kills zero mapped mutants.",
+      "candidate_tests": ["test_loan.py::test_returns_a_payment_for_each_month"]
+    },
+    {
+      "id": "one-per-month",
+      "description": "One payment entry per month",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "The test asserts len(schedule)==12 for a 12-month loan, which kills any wrong-count mutant.",
+      "candidate_tests": ["test_loan.py::test_returns_a_payment_for_each_month"]
+    },
+    {
+      "id": "fully-amortizing",
+      "description": "Payments fully pay off the loan using standard amortization",
+      "explicit": true,
+      "evidence_class": "nominally_supported",
+      "evidence_rationale": "The candidate test exercises amortize but never asserts the payment amounts or that they pay off the loan, so a wrong-payment-formula mutant survives it. A present, relevant test that kills zero mapped mutants.",
+      "candidate_tests": ["test_loan.py::test_returns_a_payment_for_each_month"]
+    }
+  ],
+  "gaps": [
+    {
+      "id": "gap-equal-payments",
+      "description": "The test asserts only the list length and that values are positive, never that the payments are equal, so an unequal-payment schedule would pass",
+      "obligation_id": "equal-payments",
+      "severity": "medium"
+    },
+    {
+      "id": "gap-fully-amortizing",
+      "description": "The test never asserts the payment amounts or that they pay off the loan, so a wrong payment formula would pass",
+      "obligation_id": "fully-amortizing",
+      "severity": "medium"
+    }
+  ]
+}

--- a/tests/fixtures/archetypes/04-non-discriminating-input/labels.json
+++ b/tests/fixtures/archetypes/04-non-discriminating-input/labels.json
@@ -1,0 +1,48 @@
+{
+  "obligations": [
+    {
+      "id": "daily-rate",
+      "description": "Daily rate is monthly_price divided by days_in_month",
+      "explicit": true,
+      "evidence_class": "nominally_supported",
+      "evidence_rationale": "The candidate test asserts prorate(30,15,30)==15.0, but the plausible defect (a hard-coded price/30) gives the same answer for a 30-day month, so that mapped mutant survives - a present, relevant test that kills zero mapped mutants for this rule.",
+      "candidate_tests": ["test_billing.py::test_half_of_a_month"]
+    },
+    {
+      "id": "charge-days-used",
+      "description": "Charge for the days used at the daily rate",
+      "explicit": true,
+      "evidence_class": "partially_supported",
+      "evidence_rationale": "A mutant that ignores days_used gives 30 not 15, so the test kills it; but boundaries (0 days, a full month) are untested, so those mutants survive - kills some, misses some.",
+      "candidate_tests": ["test_billing.py::test_half_of_a_month"]
+    },
+    {
+      "id": "round-2",
+      "description": "Round the result to two decimals",
+      "explicit": true,
+      "evidence_class": "nominally_supported",
+      "evidence_rationale": "The candidate test exercises prorate (covering the round() call) but its asserted result (15.0) is a whole number, so a mutant that changes the rounding survives it. A present, relevant test that kills zero mapped mutants.",
+      "candidate_tests": ["test_billing.py::test_half_of_a_month"]
+    }
+  ],
+  "gaps": [
+    {
+      "id": "gap-daily-rate",
+      "description": "The only test uses a 30-day month, where price/days_in_month and a hard-coded price/30 give the same answer, so it cannot establish that the rate uses days_in_month",
+      "obligation_id": "daily-rate",
+      "severity": "medium"
+    },
+    {
+      "id": "gap-round-2",
+      "description": "The asserted result (15.0) is a whole number, so rounding to two decimals is never exercised; a wrong rounding rule would pass",
+      "obligation_id": "round-2",
+      "severity": "low"
+    },
+    {
+      "id": "gap-charge-days-used",
+      "description": "Only one input (15 of 30 days) is exercised, with no boundaries (0 days, a full month), so a violation at those boundaries would pass - partial coverage, acceptance only with that caveat",
+      "obligation_id": "charge-days-used",
+      "severity": "low"
+    }
+  ]
+}

--- a/tests/fixtures/archetypes/05-circular-expected-result/labels.json
+++ b/tests/fixtures/archetypes/05-circular-expected-result/labels.json
@@ -1,0 +1,34 @@
+{
+  "obligations": [
+    {
+      "id": "add-tax",
+      "description": "Return subtotal plus tax (subtotal times tax_rate)",
+      "explicit": true,
+      "evidence_class": "nominally_supported",
+      "evidence_rationale": "The candidate test is present and targets order_total, but its expected value is derived from the same production helper (_apply_tax), so it can never fail - every mapped mutant survives (structurally unfailable / circular).",
+      "candidate_tests": ["test_orders.py::test_total_applies_tax"]
+    },
+    {
+      "id": "round-2",
+      "description": "Round the total to two decimals",
+      "explicit": true,
+      "evidence_class": "nominally_supported",
+      "evidence_rationale": "The same circular test can never fail, so a rounding mutant survives it too. A present, relevant test that kills zero mapped mutants.",
+      "candidate_tests": ["test_orders.py::test_total_applies_tax"]
+    }
+  ],
+  "gaps": [
+    {
+      "id": "gap-add-tax",
+      "description": "The expected value is built from the same production helper (_apply_tax) the function uses, so a wrong tax computation would corrupt both sides equally and the test can never fail",
+      "obligation_id": "add-tax",
+      "severity": "high"
+    },
+    {
+      "id": "gap-round-2",
+      "description": "The same circular test can never fail, so it does not establish the two-decimal rounding either",
+      "obligation_id": "round-2",
+      "severity": "medium"
+    }
+  ]
+}

--- a/tests/fixtures/archetypes/06-mocked-out-behavior/labels.json
+++ b/tests/fixtures/archetypes/06-mocked-out-behavior/labels.json
@@ -1,0 +1,34 @@
+{
+  "obligations": [
+    {
+      "id": "select-rate",
+      "description": "Select the index rate for the given date via rate_source.rate_for(date)",
+      "explicit": true,
+      "evidence_class": "nominally_supported",
+      "evidence_rationale": "The candidate test targets coupon but mocks rate_for to a constant, so a mutant that selects the wrong rate for the date survives it. A present, relevant test that kills zero mapped mutants (behavior mocked out).",
+      "candidate_tests": ["test_coupon.py::test_coupon_uses_selected_rate"]
+    },
+    {
+      "id": "compute-coupon",
+      "description": "Return nominal times the selected rate, rounded to four decimals",
+      "explicit": true,
+      "evidence_class": "partially_supported",
+      "evidence_rationale": "The test asserts nominal times rate (1000*0.05=50), so a wrong-multiply mutant is killed; but rounding to four decimals is not exercised, so those mutants survive - kills some, misses some.",
+      "candidate_tests": ["test_coupon.py::test_coupon_uses_selected_rate"]
+    }
+  ],
+  "gaps": [
+    {
+      "id": "gap-mocked-rate",
+      "description": "rate_for is mocked to a constant regardless of date, so the test never establishes that the rate selected corresponds to the date - the exact behavior under review is mocked away",
+      "obligation_id": "select-rate",
+      "severity": "high"
+    },
+    {
+      "id": "gap-compute-coupon-rounding",
+      "description": "The multiplication is checked (1000*0.05=50) but rounding to four decimals is never exercised, so a wrong rounding would pass - partial coverage, acceptance only with that caveat",
+      "obligation_id": "compute-coupon",
+      "severity": "low"
+    }
+  ]
+}

--- a/tests/fixtures/archetypes/07-declaration-mismatch/labels.json
+++ b/tests/fixtures/archetypes/07-declaration-mismatch/labels.json
@@ -1,0 +1,20 @@
+{
+  "obligations": [
+    {
+      "id": "lookup",
+      "description": "Return the user record matching user_id from the users mapping",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "The test asserts the exact record for an existing id; a wrong lookup would fail.",
+      "candidate_tests": ["test_users.py::test_existing_id_returns_the_record"]
+    }
+  ],
+  "gaps": [
+    {
+      "id": "gap-declaration-overclaim",
+      "description": "The declaration claims get_user raises KeyError with a clear message on a missing id, but the implementation returns None and no test exercises the missing-id path. This is a declaration-vs-code discrepancy, not a task obligation (the task never asked for missing-id handling), so it has no obligation_id",
+      "obligation_id": null,
+      "severity": "medium"
+    }
+  ]
+}

--- a/tests/fixtures/archetypes/08-unrequested-change/labels.json
+++ b/tests/fixtures/archetypes/08-unrequested-change/labels.json
@@ -1,0 +1,28 @@
+{
+  "obligations": [
+    {
+      "id": "apply-discount",
+      "description": "Add apply_discount(total, percent) reducing the total by the given percentage, rounded to two decimals",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "The test asserts apply_discount(100,10)==90.0; a wrong discount would fail.",
+      "candidate_tests": ["test_cart.py::test_apply_discount"]
+    },
+    {
+      "id": "leave-existing",
+      "description": "Leave existing behavior as-is; only apply_discount was requested",
+      "explicit": true,
+      "evidence_class": "partially_supported",
+      "evidence_rationale": "The test asserts checkout's default still returns 5.0, so a mutant that changes the default output is killed; but the actual unrequested change (added tax_rate parameter and rounding) leaves the default path unchanged, so that mutant survives - kills some, misses some.",
+      "candidate_tests": ["test_cart.py::test_checkout_default_unchanged"]
+    }
+  ],
+  "gaps": [
+    {
+      "id": "gap-unrequested-change",
+      "description": "checkout's public signature and behavior were changed (added a tax_rate parameter and rounding) though only apply_discount was requested; the default-path test still passes, so the change goes uncaught",
+      "obligation_id": "leave-existing",
+      "severity": "medium"
+    }
+  ]
+}

--- a/tests/fixtures/archetypes/09-revision-cycle/labels.json
+++ b/tests/fixtures/archetypes/09-revision-cycle/labels.json
@@ -1,0 +1,21 @@
+{
+  "obligations": [
+    {
+      "id": "round-nearest",
+      "description": "Round to the nearest integer",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Covered by both tests; 2.3->2 together with the tie cases pins nearest-integer rounding.",
+      "candidate_tests": ["test_rounding.py::test_rounds_to_nearest", "test_rounding.py::test_ties_round_to_even"]
+    },
+    {
+      "id": "ties-to-even",
+      "description": "Ties go to the even neighbour (banker's rounding)",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "test_ties_round_to_even asserts 2.5->2 and 3.5->4, which distinguishes banker's rounding from round-half-up.",
+      "candidate_tests": ["test_rounding.py::test_ties_round_to_even"]
+    }
+  ],
+  "gaps": []
+}


### PR DESCRIPTION
Closes #12

## Summary
A labeled `BenchmarkCase` per archetype fixture (the §11.2 archetype layer), plus a rework of the ground-truth schema into the **obligation tree** the tool must show a user.

**Schema** (`case.py`, `scoring.py`): `GroundTruthLabels` is now `obligations` + `gaps`. Each `GroundTruthObligation` carries a stable `id`, the tests relevant to it (`candidate_tests`, §9.1), its evidence strength (`evidence_class`, §9.3), and a **required** `evidence_rationale` — so a weak result can never appear without a stated reason. `GroundTruthGap`s carry an id and link to the obligation they concern (or none, for a declaration/scope finding). Validators enforce referential integrity (every `obligation_id`/`candidate_test` resolves) and completeness. The scorer derives the §11.1 metrics from the tree.

**Labels** (`fixtures.py`, `labels.json` ×9): `build_benchmark_case` materializes a fixture and assembles its case — inputs from materialization, ground truth from `labels.json`. Evidence classes follow the sharpened §9.3 rubric (decision #64, merged):
- **nominally** — a present, relevant test that survives all mapped mutants (circular / mocked / superficial-but-present)
- **unsupported** — no relevant test at all (only where the behavior is unimplemented)
- **partially** — kills some mapped mutants, not all

**Every obligation short of `strongly_supported` is raised as a gap** — partial coverage is a caveat against acceptance, not a pass — enforced by a structural test (`test_non_strong_obligations_are_each_flagged_by_a_gap`).

## Human-review gate
The label *correctness* is a `[human]` gate. A per-fixture review doc (task + head code + test + the obligation tree with rationales) was reviewed and iterated with the maintainer across several rounds; the evidence classes and gaps were reconfirmed against the sharpened §9.3 definitions.

## Test plan
- [x] `pytest -q` — 178 pass. Per-fixture: builds a validating case with a decomposition; `candidate_test` ids name real pytest nodes; every non-strong obligation is flagged by a gap; hand-calculated pooled scoring example; full fixture → case → run → score loop scores the no-op checker all-miss.
- [x] `ruff check .` — clean

## Notes
- Reworks the M-B0.1 ground-truth schema and M-B0.3 scorer (both merged) — dogfooding the labels is what exposed their gaps (dangling obligation refs, no enforced completeness).
- Depends on decision #64 (§9.3 rubric), already merged to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)