### PR TITLE
M1.2: obligation decomposition (§7.3/§9.1)

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,10 +1,10 @@
 # Task
-Parse the local task file (`current-task.md`, §7.1 format) into structured task content the checker can reason over.
+Convert the parsed task file into discrete, typed obligations the checker can review the implementation against.
 
 ## Constraints
-- Extract the task behavior, constraints, scope exclusions, and completion expectations as separate fields.
-- Preserve a source-text reference (the exact span) for every extracted item.
-- Accept the §7.1 structure: `# Task`, `## Constraints`, `## Completion expectations`, and an optional scope-exclusions section.
+- Type each obligation using the §7.3 set: functional, boundary, error-handling, invariant, regression, compatibility, explanation/observability, docs/config, human-review.
+- Give each obligation a stable id and link it to the source span in the task text it derives from.
+- Produce obligations through a schema-constrained model call recorded for replay; capability tests run off the recorded transcript with no live calls.
 
 ## Completion expectations
 - Implementation

--- a/src/acceptance/requirement/obligations.py
+++ b/src/acceptance/requirement/obligations.py
@@ -1,0 +1,89 @@
+"""Obligation decomposition (M1.2, §7.3/§9.1).
+
+Converts a parsed task file into discrete, typed obligations. Decomposition is
+a semantic judgment, so it is a schema-constrained model call through the M0.4
+harness — recorded for replay, never a live call in tests. The model returns
+each obligation with a `source_quote` (exact text from the task); we locate
+that quote in the source to attach a `TextSpan`, so every obligation traces
+back to the requirement text it came from (CLAUDE.md invariant).
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from acceptance.llm import ModelClient
+from acceptance.requirement.task_file import ParsedTaskFile
+from acceptance.review_state import Obligation, ObligationType
+from acceptance.source_ref import find_span
+
+_SYSTEM_PROMPT = """\
+You decompose a software task into discrete, typed acceptance obligations.
+
+Return one obligation per distinct, independently checkable requirement. For
+each: a short stable `id` slug (kebab-case, unique); a `description`; a `type`
+from the fixed set (functional, boundary, error_handling, invariant,
+regression, compatibility, explanation_observability, docs_config,
+human_review); `importance` (critical or normal); `explicit` (true if directly
+stated in the task, false if reasonably inferred); an `observable_behavior`
+describing how the obligation is observed; and `source_quote`, an EXACT
+substring of the task text this obligation derives from.
+
+Do not invent obligations the task does not support. Do not merge distinct
+requirements. Prefer the smallest faithful set."""
+
+
+class _DecomposedObligation(BaseModel):
+    id: str
+    description: str
+    type: ObligationType
+    importance: str
+    explicit: bool
+    observable_behavior: str
+    source_quote: str
+
+
+class _Decomposition(BaseModel):
+    obligations: list[_DecomposedObligation] = Field(default_factory=list)
+
+
+def _user_prompt(parsed: ParsedTaskFile) -> str:
+    return f"Task file:\n\n{parsed.source}"
+
+
+def decompose(parsed: ParsedTaskFile, client: ModelClient) -> list[Obligation]:
+    """Decompose a parsed task into typed obligations, linked to source spans."""
+    messages = [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {"role": "user", "content": _user_prompt(parsed)},
+    ]
+    decomposition = client.complete(messages, _Decomposition)
+
+    obligations: list[Obligation] = []
+    seen_ids: set[str] = set()
+    for item in decomposition.obligations:
+        obligation_id = _unique(item.id, seen_ids)
+        span = find_span(parsed.source, item.source_quote)
+        obligations.append(
+            Obligation(
+                id=obligation_id,
+                description=item.description,
+                type=item.type,
+                importance="critical" if item.importance == "critical" else "normal",
+                explicit=item.explicit,
+                observable_behavior=item.observable_behavior,
+                source_spans=[span] if span is not None else [],
+            )
+        )
+    return obligations
+
+
+def _unique(candidate: str, seen: set[str]) -> str:
+    """Keep obligation ids unique and deterministic (suffix on collision)."""
+    obligation_id = candidate
+    suffix = 2
+    while obligation_id in seen:
+        obligation_id = f"{candidate}-{suffix}"
+        suffix += 1
+    seen.add(obligation_id)
+    return obligation_id

--- a/src/acceptance/requirement/task_file.py
+++ b/src/acceptance/requirement/task_file.py
@@ -17,6 +17,9 @@ from markdown_it import MarkdownIt
 from markdown_it.tree import SyntaxTreeNode
 
 from acceptance.model_base import PersistableModel
+from acceptance.source_ref import TextSpan
+
+__all__ = ["TextSpan", "ParsedTaskFile", "parse_task_file"]
 
 # §7.1 section headings, normalized (lowercased). A file may add other
 # sections; unknown ones are ignored rather than rejected.
@@ -24,14 +27,6 @@ _CONSTRAINTS = {"constraints"}
 _COMPLETION = {"completion expectations"}
 _EXCLUSIONS = {"scope exclusions", "exclusions"}
 _TASK = {"task"}
-
-
-class TextSpan(PersistableModel):
-    """A slice of the source: `text` is exactly `source[start:end]`."""
-
-    text: str
-    start: int
-    end: int
 
 
 class ParsedTaskFile(PersistableModel):

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -13,6 +13,7 @@ from the library rather than hand-rolled per class.
 
 from __future__ import annotations
 
+from enum import Enum
 from typing import Literal
 
 from pydantic import Field, field_validator, model_validator
@@ -20,10 +21,13 @@ from pydantic import Field, field_validator, model_validator
 from acceptance.evidence_tier import Component, EvidenceTier, authorize_tier
 from acceptance.model_base import PersistableModel as _Model
 from acceptance.serialization import canonical_json
+from acceptance.source_ref import TextSpan
 
 __all__ = [
     "Component",
     "EvidenceTier",
+    "TextSpan",
+    "ObligationType",
     "Project",
     "TaskSource",
     "MandateInterpretation",
@@ -37,6 +41,20 @@ __all__ = [
     "ReviewProvenance",
     "Review",
 ]
+
+
+class ObligationType(str, Enum):
+    """§7.3 obligation types."""
+
+    FUNCTIONAL = "functional"
+    BOUNDARY = "boundary"
+    ERROR_HANDLING = "error_handling"
+    INVARIANT = "invariant"
+    REGRESSION = "regression"
+    COMPATIBILITY = "compatibility"
+    EXPLANATION_OBSERVABILITY = "explanation_observability"
+    DOCS_CONFIG = "docs_config"
+    HUMAN_REVIEW = "human_review"
 
 
 class Project(_Model):
@@ -91,12 +109,20 @@ class ChangeSet(_Model):
 
 
 class Obligation(_Model):
+    """A discrete, typed obligation derived from the task (§7.3, §9.1; M1.2).
+
+    `id` is a stable slug so a reviewer obligation joins to the benchmark's
+    ground-truth obligation by id. `source_spans` link it to the exact task
+    text it derives from (M1.1). `explicit` is refined into explicit /
+    reasonable-inferred / open-question by M1.3."""
+
+    id: str
     description: str
-    type: str
-    source_text: str
-    importance: str
+    type: ObligationType
+    importance: Literal["critical", "normal"]
     explicit: bool
     observable_behavior: str
+    source_spans: list[TextSpan] = Field(default_factory=list)
     achieved_evidence_tier: EvidenceTier | None = None
     test_evidence: list[str] = Field(default_factory=list)
 

--- a/src/acceptance/source_ref.py
+++ b/src/acceptance/source_ref.py
@@ -1,0 +1,26 @@
+"""Source references: a `TextSpan` links a value to the exact text it came from.
+
+Lives in its own leaf module so both the review-state model (obligations link
+to task text) and the requirement parser can use it without an import cycle.
+`text == source[start:end]` always holds for a span produced from a source.
+"""
+
+from __future__ import annotations
+
+from acceptance.model_base import PersistableModel
+
+
+class TextSpan(PersistableModel):
+    text: str
+    start: int
+    end: int
+
+
+def find_span(source: str, quote: str) -> TextSpan | None:
+    """Locate `quote` in `source` and return its span, or None if absent."""
+    if not quote:
+        return None
+    idx = source.find(quote)
+    if idx < 0:
+        return None
+    return TextSpan(text=quote, start=idx, end=idx + len(quote))

--- a/tests/benchmark/test_scoring_report.py
+++ b/tests/benchmark/test_scoring_report.py
@@ -41,7 +41,14 @@ from acceptance.benchmark.case import (
 )
 from acceptance.benchmark.scoring import score_case_set
 from acceptance.evidence_tier import Component, EvidenceTier
-from acceptance.review_state import Finding, Link, Obligation, Review, ReviewProvenance
+from acceptance.review_state import (
+    Finding,
+    Link,
+    Obligation,
+    ObligationType,
+    Review,
+    ReviewProvenance,
+)
 
 
 def _inputs() -> BenchmarkCaseInputs:
@@ -61,9 +68,9 @@ def _provenance() -> ReviewProvenance:
 
 def _reviewer_obligation(description: str, test_evidence: list[str]) -> Obligation:
     return Obligation(
+        id=description.lower(),
         description=description,
-        type="behavior",
-        source_text="...",
+        type=ObligationType.FUNCTIONAL,
         importance="critical",
         explicit=True,
         observable_behavior="...",

--- a/tests/requirement/test_obligations.py
+++ b/tests/requirement/test_obligations.py
@@ -1,0 +1,204 @@
+"""M1.2 acceptance: decompose a task into typed obligations.
+
+Decomposition is a schema-constrained model call; per the M0.4/M0.5 replay-first
+invariant these tests inject the recorded model response (a hand-authored
+fixture) via the harness's completion_fn — no live calls. The response is what a
+good model returns for the §9.1 example and archetype #1; the test verifies the
+pipeline turns it into typed Obligations with ids and source spans. The model's
+actual decomposition accuracy is measured separately by the benchmark (M-B*).
+"""
+
+import json
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+from acceptance.llm import Mode, ModelClient, TranscriptStore
+from acceptance.requirement.obligations import decompose
+from acceptance.requirement.task_file import parse_task_file
+from acceptance.review_state import ObligationType
+
+ARCHETYPES = Path(__file__).resolve().parents[1] / "fixtures" / "archetypes"
+
+# The §9.1 floating-rate mandate as a §7.1 task file.
+FLOATING_RATE_TASK = """# Task
+Add floating-rate bonds using an index curve plus contractual spread. Accrual periods run the 26th through the 25th. Missing rate observations must produce an explicit error. Existing fixed-rate behavior must not change.
+"""
+
+# Recorded model response for the §9.1 example: the five derived criteria (§9.1).
+FLOATING_RATE_RESPONSE = {
+    "obligations": [
+        {
+            "id": "coupons-use-index-plus-spread",
+            "description": "Coupons use the index curve plus the contractual spread.",
+            "type": "functional",
+            "importance": "critical",
+            "explicit": True,
+            "observable_behavior": "coupon = index(date) + contractual spread",
+            "source_quote": "using an index curve plus contractual spread",
+        },
+        {
+            "id": "accrual-26th-to-25th",
+            "description": "Rate selection follows the 26th-through-25th accrual period.",
+            "type": "boundary",
+            "importance": "critical",
+            "explicit": True,
+            "observable_behavior": "the fixing chosen falls in the 26th-to-25th window",
+            "source_quote": "Accrual periods run the 26th through the 25th.",
+        },
+        {
+            "id": "missing-observation-errors",
+            "description": "A missing rate observation produces an explicit error.",
+            "type": "error_handling",
+            "importance": "critical",
+            "explicit": True,
+            "observable_behavior": "a structured error is raised when an observation is missing",
+            "source_quote": "Missing rate observations must produce an explicit error.",
+        },
+        {
+            "id": "fixed-rate-unchanged",
+            "description": "Existing fixed-rate behavior is unchanged.",
+            "type": "regression",
+            "importance": "critical",
+            "explicit": True,
+            "observable_behavior": "fixed-rate coupons match pre-change output",
+            "source_quote": "Existing fixed-rate behavior must not change.",
+        },
+        {
+            "id": "expose-selected-observation-and-spread",
+            "description": "Outputs expose the selected observation and the spread.",
+            "type": "explanation_observability",
+            "importance": "normal",
+            "explicit": False,
+            "observable_behavior": "the result reports the fixing date and spread used",
+            "source_quote": "using an index curve plus contractual spread",
+        },
+    ]
+}
+
+
+def _client_returning(response: dict) -> ModelClient:
+    def completion_fn(**kwargs):
+        content = json.dumps(response)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+
+    # Isolated ephemeral store so the injected response is always used and no
+    # transcript leaks into the repo's .acceptance/ cache.
+    return ModelClient(
+        model="anthropic/claude-sonnet-5",
+        mode=Mode.RECORD,
+        store=TranscriptStore(tempfile.mkdtemp()),
+        completion_fn=completion_fn,
+    )
+
+
+def test_floating_rate_example_yields_five_typed_criteria():
+    parsed = parse_task_file(FLOATING_RATE_TASK)
+    obligations = decompose(parsed, _client_returning(FLOATING_RATE_RESPONSE))
+
+    assert len(obligations) == 5
+    types = [o.type for o in obligations]
+    assert types == [
+        ObligationType.FUNCTIONAL,
+        ObligationType.BOUNDARY,
+        ObligationType.ERROR_HANDLING,
+        ObligationType.REGRESSION,
+        ObligationType.EXPLANATION_OBSERVABILITY,
+    ]
+    # Every obligation has a unique id.
+    assert len({o.id for o in obligations}) == 5
+
+
+def test_each_obligation_links_to_its_source_span():
+    parsed = parse_task_file(FLOATING_RATE_TASK)
+    obligations = decompose(parsed, _client_returning(FLOATING_RATE_RESPONSE))
+
+    for obligation in obligations:
+        assert obligation.source_spans, f"{obligation.id} has no source span"
+        for span in obligation.source_spans:
+            assert parsed.source[span.start : span.end] == span.text
+
+
+def test_archetype_1_includes_the_omitted_obligation():
+    """On archetype #1 the omitted (negative-quantity) obligation is present."""
+    task = (ARCHETYPES / "01-missed-obligation" / "task.md").read_text()
+    parsed = parse_task_file(task)
+
+    response = {
+        "obligations": [
+            {
+                "id": "show-fields",
+                "description": "Show the item name, quantity, and unit price.",
+                "type": "functional",
+                "importance": "critical",
+                "explicit": True,
+                "observable_behavior": "the line shows name, quantity, unit price",
+                "source_quote": "Show the item name, the quantity, and the unit price.",
+            },
+            {
+                "id": "line-total",
+                "description": "Include the line total (quantity times unit price).",
+                "type": "functional",
+                "importance": "critical",
+                "explicit": True,
+                "observable_behavior": "the line shows quantity times unit price",
+                "source_quote": "Include the line total (quantity × unit price).",
+            },
+            {
+                "id": "money-format",
+                "description": "Format money as USD with two decimals and a leading $.",
+                "type": "functional",
+                "importance": "critical",
+                "explicit": True,
+                "observable_behavior": "money renders as $ with two decimals",
+                "source_quote": "Format every money value as USD with exactly two decimals and a leading `$`.",
+            },
+            {
+                "id": "returns-in-parentheses",
+                "description": "Show negative-quantity returns in parentheses.",
+                "type": "boundary",
+                "importance": "critical",
+                "explicit": True,
+                "observable_behavior": "a return shows quantity and total in parentheses",
+                "source_quote": "For returns (a negative quantity), show the quantity and the line total in",
+            },
+        ]
+    }
+
+    obligations = decompose(parsed, _client_returning(response))
+    ids = {o.id for o in obligations}
+    assert "returns-in-parentheses" in ids
+    returns = next(o for o in obligations if o.id == "returns-in-parentheses")
+    assert returns.source_spans
+    assert parsed.source[returns.source_spans[0].start : returns.source_spans[0].end] == returns.source_spans[0].text
+
+
+def test_duplicate_ids_are_made_unique():
+    parsed = parse_task_file(FLOATING_RATE_TASK)
+    response = {
+        "obligations": [
+            {
+                "id": "dup",
+                "description": "First.",
+                "type": "functional",
+                "importance": "normal",
+                "explicit": True,
+                "observable_behavior": "...",
+                "source_quote": "floating-rate bonds",
+            },
+            {
+                "id": "dup",
+                "description": "Second.",
+                "type": "functional",
+                "importance": "normal",
+                "explicit": True,
+                "observable_behavior": "...",
+                "source_quote": "contractual spread",
+            },
+        ]
+    }
+    obligations = decompose(parsed, _client_returning(response))
+    assert [o.id for o in obligations] == ["dup", "dup-2"]

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,5 +1,13 @@
 from acceptance.report import render_report
-from acceptance.review_state import Component, EvidenceTier, Finding, Link, Obligation, Review
+from acceptance.review_state import (
+    Component,
+    EvidenceTier,
+    Finding,
+    Link,
+    Obligation,
+    ObligationType,
+    Review,
+)
 
 
 def test_empty_review_renders_the_full_shell():
@@ -27,9 +35,9 @@ def test_populated_review_lists_obligations_and_findings():
         reviewed_revision="abc",
         obligation_map=[
             Obligation(
+                id="coupons-use-spread",
                 description="Coupons use index + spread.",
-                type="behavior",
-                source_text="...",
+                type=ObligationType.FUNCTIONAL,
                 importance="critical",
                 explicit=True,
                 observable_behavior="...",

--- a/tests/test_review_state.py
+++ b/tests/test_review_state.py
@@ -12,10 +12,12 @@ from acceptance.review_state import (
     Link,
     MandateInterpretation,
     Obligation,
+    ObligationType,
     Project,
     Review,
     TaskSource,
     TestEvidence,
+    TextSpan,
 )
 
 
@@ -91,12 +93,13 @@ def test_change_set_round_trips():
 
 def test_obligation_round_trips_with_tier():
     obligation = Obligation(
+        id="coupons-use-spread",
         description="Coupons use index + contractual spread.",
-        type="behavior",
-        source_text="Add floating-rate bonds using an index curve plus contractual spread.",
+        type=ObligationType.FUNCTIONAL,
         importance="critical",
         explicit=True,
         observable_behavior="calculate_coupon returns index + spread",
+        source_spans=[TextSpan(text="index curve plus contractual spread", start=20, end=55)],
         achieved_evidence_tier=EvidenceTier.STATIC,
         test_evidence=["test_coupon_uses_spread"],
     )
@@ -105,9 +108,9 @@ def test_obligation_round_trips_with_tier():
 
 def test_obligation_round_trips_without_tier():
     obligation = Obligation(
+        id="fixed-rate-unchanged",
         description="Fixed-rate results unchanged.",
-        type="regression",
-        source_text="Existing fixed-rate behavior must not change.",
+        type=ObligationType.REGRESSION,
         importance="critical",
         explicit=True,
         observable_behavior="fixed-rate coupons identical to pre-change output",
@@ -226,9 +229,9 @@ def test_review_round_trips_empty():
 
 def test_review_round_trips_populated():
     obligation = Obligation(
+        id="coupons-use-spread",
         description="Coupons use index + contractual spread.",
-        type="behavior",
-        source_text="...",
+        type=ObligationType.FUNCTIONAL,
         importance="critical",
         explicit=True,
         observable_behavior="...",
@@ -258,9 +261,9 @@ def test_review_round_trips_populated():
 
 def test_review_evidence_tier_summary_is_derived_not_stored():
     obligation = Obligation(
+        id="obligation-1",
         description="...",
-        type="behavior",
-        source_text="...",
+        type=ObligationType.FUNCTIONAL,
         importance="critical",
         explicit=True,
         observable_behavior="...",


### PR DESCRIPTION
Closes #14
Closes #69

## Summary
Converts a parsed task file into discrete, **typed** obligations. Decomposition is a semantic judgment, so it's a schema-constrained model call through the M0.4 harness; the model returns each obligation with a `source_quote`, located in the task text to attach a `TextSpan` — so every obligation traces to the exact requirement text (CLAUDE.md invariant).

## Obligation-schema decision (#69, §3.2)
`review_state.Obligation` is finalized:
- **`id: str`** — stable slug; joins a reviewer obligation to the benchmark's `GroundTruthObligation` by id.
- **`type: ObligationType`** — the §7.3 enum (functional, boundary, error_handling, invariant, regression, compatibility, explanation_observability, docs_config, human_review), replacing the M0.2 free-text `type`.
- **`importance: Literal["critical","normal"]`**.
- **`source_spans: list[TextSpan]`** — links to the task text (M1.1), replacing the free-text `source_text`.
- `TextSpan` moves to a neutral `source_ref` module so `review_state` and `requirement` share it without an import cycle.

Dependent constructions in `review_state`/`report`/`scoring_report` tests updated for the finalized schema.

## Test plan
- [x] `pytest -q` — 189 pass. Acceptance (`test_obligations.py`): §9.1 example → five criteria with correct types; archetype #1 → the omitted negative-quantity obligation present; every obligation links to a verified source span (`source[start:end] == text`); duplicate ids de-duplicated.
- [x] Replay-first: tests inject the recorded model response via `completion_fn` — no live calls; isolated ephemeral transcript stores so nothing leaks into `.acceptance/`.
- [x] `ruff check .` — clean

## Notes
- Model *decomposition accuracy* is measured by the benchmark (M-B*), not here; these tests validate the pipeline (prompt → schema-validated response → typed Obligations with ids + spans).
- Transcript sourcing chosen as hand-authored fixtures (deterministic, no credentials); a real transcript can be recorded later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)