### PR TITLE
M1.3: explicit / inferred labeling and open questions

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,10 +1,10 @@
 # Task
-Convert the parsed task file into discrete, typed obligations the checker can review the implementation against.
+Label each obligation as explicit or reasonable-inferred, and surface material ambiguities as open questions instead of inventing obligations.
 
 ## Constraints
-- Type each obligation using the §7.3 set: functional, boundary, error-handling, invariant, regression, compatibility, explanation/observability, docs/config, human-review.
-- Give each obligation a stable id and link it to the source span in the task text it derives from.
-- Produce obligations through a schema-constrained model call recorded for replay; capability tests run off the recorded transcript with no live calls.
+- Flag each obligation as explicit (directly stated in the task) or reasonable-inferred.
+- When a requirement is materially underspecified, emit an open question needing user judgment rather than a fabricated obligation.
+- Link each open question to the ambiguous source text.
 
 ## Completion expectations
 - Implementation

--- a/src/acceptance/requirement/obligations.py
+++ b/src/acceptance/requirement/obligations.py
@@ -1,11 +1,15 @@
-"""Obligation decomposition (M1.2, §7.3/§9.1).
+"""Obligation decomposition (M1.2/M1.3, §7.3/§9.1).
 
-Converts a parsed task file into discrete, typed obligations. Decomposition is
-a semantic judgment, so it is a schema-constrained model call through the M0.4
-harness — recorded for replay, never a live call in tests. The model returns
-each obligation with a `source_quote` (exact text from the task); we locate
-that quote in the source to attach a `TextSpan`, so every obligation traces
-back to the requirement text it came from (CLAUDE.md invariant).
+Converts a parsed task file into discrete, typed obligations plus the material
+ambiguities that need user judgment. Decomposition is a semantic judgment, so
+it is a schema-constrained model call through the M0.4 harness — recorded for
+replay, never a live call in tests.
+
+Each obligation and open question is linked to a `TextSpan` in the task (the
+model returns an exact `source_quote` which we locate in the source), so every
+output traces back to the requirement text it came from (CLAUDE.md invariant).
+Material ambiguities are surfaced as `OpenQuestion`s rather than invented
+obligations — uncertainty is a first-class, expected result (M1.3).
 """
 
 from __future__ import annotations
@@ -13,24 +17,31 @@ from __future__ import annotations
 from pydantic import BaseModel, Field
 
 from acceptance.llm import ModelClient
+from acceptance.model_base import PersistableModel
 from acceptance.requirement.task_file import ParsedTaskFile
-from acceptance.review_state import Obligation, ObligationType
+from acceptance.review_state import Obligation, ObligationType, OpenQuestion
 from acceptance.source_ref import find_span
 
 _SYSTEM_PROMPT = """\
-You decompose a software task into discrete, typed acceptance obligations.
+You decompose a software task into discrete, typed acceptance obligations and
+the ambiguities that need human judgment.
 
-Return one obligation per distinct, independently checkable requirement. For
-each: a short stable `id` slug (kebab-case, unique); a `description`; a `type`
-from the fixed set (functional, boundary, error_handling, invariant,
-regression, compatibility, explanation_observability, docs_config,
-human_review); `importance` (critical or normal); `explicit` (true if directly
-stated in the task, false if reasonably inferred); an `observable_behavior`
-describing how the obligation is observed; and `source_quote`, an EXACT
+For each obligation: a short stable `id` slug (kebab-case, unique); a
+`description`; a `type` from the fixed set (functional, boundary,
+error_handling, invariant, regression, compatibility,
+explanation_observability, docs_config, human_review); `importance` (critical
+or normal); `explicit` (true if directly stated in the task, false if
+reasonably inferred); an `observable_behavior`; and `source_quote`, an EXACT
 substring of the task text this obligation derives from.
 
-Do not invent obligations the task does not support. Do not merge distinct
-requirements. Prefer the smallest faithful set."""
+Emit an inferred obligation (explicit=false) only when the inference is
+reasonable and low-risk. When a requirement is materially underspecified — you
+would have to guess a qualifier, value, or behavior to proceed — do NOT invent
+an obligation for it. Instead return an `open_question` with a stable `id`, the
+`question` to put to the user, an `importance`, and a `source_quote` for the
+ambiguous text.
+
+Do not merge distinct requirements. Prefer the smallest faithful set."""
 
 
 class _DecomposedObligation(BaseModel):
@@ -43,47 +54,78 @@ class _DecomposedObligation(BaseModel):
     source_quote: str
 
 
+class _OpenQuestion(BaseModel):
+    id: str
+    question: str
+    importance: str
+    source_quote: str
+
+
 class _Decomposition(BaseModel):
     obligations: list[_DecomposedObligation] = Field(default_factory=list)
+    open_questions: list[_OpenQuestion] = Field(default_factory=list)
+
+
+class Decomposition(PersistableModel):
+    """The result of decomposing a task: typed obligations plus the open
+    questions a good reviewer would raise rather than resolve."""
+
+    obligations: list[Obligation] = Field(default_factory=list)
+    open_questions: list[OpenQuestion] = Field(default_factory=list)
 
 
 def _user_prompt(parsed: ParsedTaskFile) -> str:
     return f"Task file:\n\n{parsed.source}"
 
 
-def decompose(parsed: ParsedTaskFile, client: ModelClient) -> list[Obligation]:
-    """Decompose a parsed task into typed obligations, linked to source spans."""
+def _importance(value: str) -> str:
+    return "critical" if value == "critical" else "normal"
+
+
+def decompose(parsed: ParsedTaskFile, client: ModelClient) -> Decomposition:
+    """Decompose a parsed task into typed obligations and open questions."""
     messages = [
         {"role": "system", "content": _SYSTEM_PROMPT},
         {"role": "user", "content": _user_prompt(parsed)},
     ]
-    decomposition = client.complete(messages, _Decomposition)
+    result = client.complete(messages, _Decomposition)
 
-    obligations: list[Obligation] = []
     seen_ids: set[str] = set()
-    for item in decomposition.obligations:
-        obligation_id = _unique(item.id, seen_ids)
-        span = find_span(parsed.source, item.source_quote)
-        obligations.append(
-            Obligation(
-                id=obligation_id,
-                description=item.description,
-                type=item.type,
-                importance="critical" if item.importance == "critical" else "normal",
-                explicit=item.explicit,
-                observable_behavior=item.observable_behavior,
-                source_spans=[span] if span is not None else [],
-            )
+    obligations = [
+        Obligation(
+            id=_unique(item.id, seen_ids),
+            description=item.description,
+            type=item.type,
+            importance=_importance(item.importance),
+            explicit=item.explicit,
+            observable_behavior=item.observable_behavior,
+            source_spans=_spans(parsed.source, item.source_quote),
         )
-    return obligations
+        for item in result.obligations
+    ]
+    open_questions = [
+        OpenQuestion(
+            id=_unique(item.id, seen_ids),
+            question=item.question,
+            importance=_importance(item.importance),
+            source_spans=_spans(parsed.source, item.source_quote),
+        )
+        for item in result.open_questions
+    ]
+    return Decomposition(obligations=obligations, open_questions=open_questions)
+
+
+def _spans(source: str, quote: str) -> list:
+    span = find_span(source, quote)
+    return [span] if span is not None else []
 
 
 def _unique(candidate: str, seen: set[str]) -> str:
-    """Keep obligation ids unique and deterministic (suffix on collision)."""
-    obligation_id = candidate
+    """Keep ids unique and deterministic across obligations and open questions."""
+    unique_id = candidate
     suffix = 2
-    while obligation_id in seen:
-        obligation_id = f"{candidate}-{suffix}"
+    while unique_id in seen:
+        unique_id = f"{candidate}-{suffix}"
         suffix += 1
-    seen.add(obligation_id)
-    return obligation_id
+    seen.add(unique_id)
+    return unique_id

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -34,6 +34,7 @@ __all__ = [
     "BuilderDeclaration",
     "ChangeSet",
     "Obligation",
+    "OpenQuestion",
     "TestEvidence",
     "ExecutionEvidence",
     "Link",
@@ -125,6 +126,19 @@ class Obligation(_Model):
     source_spans: list[TextSpan] = Field(default_factory=list)
     achieved_evidence_tier: EvidenceTier | None = None
     test_evidence: list[str] = Field(default_factory=list)
+
+
+class OpenQuestion(_Model):
+    """A material ambiguity in the task that needs user judgment (§7.3, §9.3).
+
+    Surfaced instead of silently inventing an obligation — uncertainty is a
+    first-class, expected output. `source_spans` link to the underspecified
+    task text."""
+
+    id: str
+    question: str
+    importance: Literal["critical", "normal"] = "normal"
+    source_spans: list[TextSpan] = Field(default_factory=list)
 
 
 class TestEvidence(_Model):

--- a/tests/requirement/test_obligations.py
+++ b/tests/requirement/test_obligations.py
@@ -1,11 +1,12 @@
-"""M1.2 acceptance: decompose a task into typed obligations.
+"""M1.2/M1.3 acceptance: decompose a task into typed obligations and the
+material ambiguities that need user judgment.
 
 Decomposition is a schema-constrained model call; per the M0.4/M0.5 replay-first
 invariant these tests inject the recorded model response (a hand-authored
 fixture) via the harness's completion_fn — no live calls. The response is what a
-good model returns for the §9.1 example and archetype #1; the test verifies the
-pipeline turns it into typed Obligations with ids and source spans. The model's
-actual decomposition accuracy is measured separately by the benchmark (M-B*).
+good model returns; the test verifies the pipeline turns it into typed
+Obligations and OpenQuestions with ids and source spans. The model's actual
+decomposition accuracy is measured separately by the benchmark (M-B*).
 """
 
 import json
@@ -14,7 +15,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from acceptance.llm import Mode, ModelClient, TranscriptStore
-from acceptance.requirement.obligations import decompose
+from acceptance.requirement.obligations import Decomposition, decompose
 from acceptance.requirement.task_file import parse_task_file
 from acceptance.review_state import ObligationType
 
@@ -97,7 +98,7 @@ def _client_returning(response: dict) -> ModelClient:
 
 def test_floating_rate_example_yields_five_typed_criteria():
     parsed = parse_task_file(FLOATING_RATE_TASK)
-    obligations = decompose(parsed, _client_returning(FLOATING_RATE_RESPONSE))
+    obligations = decompose(parsed, _client_returning(FLOATING_RATE_RESPONSE)).obligations
 
     assert len(obligations) == 5
     types = [o.type for o in obligations]
@@ -114,7 +115,7 @@ def test_floating_rate_example_yields_five_typed_criteria():
 
 def test_each_obligation_links_to_its_source_span():
     parsed = parse_task_file(FLOATING_RATE_TASK)
-    obligations = decompose(parsed, _client_returning(FLOATING_RATE_RESPONSE))
+    obligations = decompose(parsed, _client_returning(FLOATING_RATE_RESPONSE)).obligations
 
     for obligation in obligations:
         assert obligation.source_spans, f"{obligation.id} has no source span"
@@ -168,7 +169,7 @@ def test_archetype_1_includes_the_omitted_obligation():
         ]
     }
 
-    obligations = decompose(parsed, _client_returning(response))
+    obligations = decompose(parsed, _client_returning(response)).obligations
     ids = {o.id for o in obligations}
     assert "returns-in-parentheses" in ids
     returns = next(o for o in obligations if o.id == "returns-in-parentheses")
@@ -200,5 +201,96 @@ def test_duplicate_ids_are_made_unique():
             },
         ]
     }
-    obligations = decompose(parsed, _client_returning(response))
+    obligations = decompose(parsed, _client_returning(response)).obligations
     assert [o.id for o in obligations] == ["dup", "dup-2"]
+
+
+# --- M1.3: explicit / inferred / open questions ---
+
+UNDERSPECIFIED_TASK = """# Task
+Add a retry policy to the API client.
+
+## Constraints
+- Retry failed requests.
+"""
+
+UNDERSPECIFIED_RESPONSE = {
+    "obligations": [
+        {
+            "id": "retry-failed-requests",
+            "description": "Retry failed requests.",
+            "type": "functional",
+            "importance": "critical",
+            "explicit": True,
+            "observable_behavior": "a failed request is retried",
+            "source_quote": "Retry failed requests.",
+        }
+    ],
+    "open_questions": [
+        {
+            "id": "retry-count-unspecified",
+            "question": "How many retries, and with what backoff?",
+            "importance": "critical",
+            "source_quote": "Retry failed requests.",
+        }
+    ],
+}
+
+
+def test_underspecified_qualifier_yields_an_open_question_not_an_obligation():
+    parsed = parse_task_file(UNDERSPECIFIED_TASK)
+    result = decompose(parsed, _client_returning(UNDERSPECIFIED_RESPONSE))
+
+    assert len(result.open_questions) == 1
+    question = result.open_questions[0]
+    assert question.id == "retry-count-unspecified"
+    # The ambiguity is surfaced, not turned into a fabricated obligation.
+    assert all(o.id != question.id for o in result.obligations)
+    assert not any("retry-count" in o.id for o in result.obligations)
+    # It links to the ambiguous source text.
+    assert question.source_spans
+    for span in question.source_spans:
+        assert parsed.source[span.start : span.end] == span.text
+
+
+def test_explicit_and_inferred_flags_are_carried_through():
+    parsed = parse_task_file(FLOATING_RATE_TASK)
+    obligations = decompose(parsed, _client_returning(FLOATING_RATE_RESPONSE)).obligations
+    by_id = {o.id: o for o in obligations}
+
+    assert by_id["coupons-use-index-plus-spread"].explicit is True  # directly stated
+    assert by_id["expose-selected-observation-and-spread"].explicit is False  # inferred
+
+
+def test_ids_are_unique_across_obligations_and_open_questions():
+    parsed = parse_task_file(UNDERSPECIFIED_TASK)
+    response = {
+        "obligations": [
+            {
+                "id": "shared",
+                "description": "An obligation.",
+                "type": "functional",
+                "importance": "normal",
+                "explicit": True,
+                "observable_behavior": "...",
+                "source_quote": "Retry failed requests.",
+            }
+        ],
+        "open_questions": [
+            {
+                "id": "shared",
+                "question": "A colliding id?",
+                "importance": "normal",
+                "source_quote": "Retry failed requests.",
+            }
+        ],
+    }
+    result = decompose(parsed, _client_returning(response))
+    assert result.obligations[0].id == "shared"
+    assert result.open_questions[0].id == "shared-2"  # de-duplicated across both
+
+
+def test_decomposition_round_trips_through_persistence():
+    parsed = parse_task_file(UNDERSPECIFIED_TASK)
+    result = decompose(parsed, _client_returning(UNDERSPECIFIED_RESPONSE))
+    assert Decomposition.from_dict(result.to_dict()) == result


### PR DESCRIPTION
Closes #15

## Summary
Extends decomposition to surface material ambiguities as **first-class open questions** instead of inventing obligations — uncertainty is an expected, valid result (CLAUDE.md invariant).

- `decompose()` now returns a **`Decomposition`** (`obligations` + `open_questions`).
- The model is prompted to emit an `open_question` (not an obligation) when a requirement is materially underspecified, and to set `explicit=false` only for reasonable, low-risk inferences.
- New **`review_state.OpenQuestion`** (`id`, `question`, `importance`, `source_spans`), each linked to the ambiguous task text the same way obligations are.
- `Obligation.explicit` carries the explicit-vs-reasonable-inferred flag through; ids stay unique/deterministic across both obligations and open questions.

## Test plan
- [x] `pytest -q` — 193 pass. Acceptance (`test_obligations.py`): a task with an underspecified qualifier yields an open-question entry and **no** fabricated obligation for it; explicit/inferred flags carry through (`coupons-use-spread` explicit, `expose-selected-observation` inferred); every open question links to a verified source span; shared-id de-duplication across obligations+questions; `Decomposition` persistence round-trip.
- [x] Replay-first: injected `completion_fn`, isolated ephemeral transcript stores, no `.acceptance/` leak.
- [x] `ruff check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)