### PR TITLE
Wire the live LLM in for dogfooding (decompose CLI + OpenAI)

### DIFF
--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -17,8 +17,10 @@ import sys
 from pathlib import Path
 
 from acceptance.config import DEFAULT_MODEL, RunConfig
-from acceptance.llm import Mode
+from acceptance.llm import LLMError, Mode
 from acceptance.report import render_report
+from acceptance.requirement.obligations import Decomposition, decompose
+from acceptance.requirement.task_file import parse_task_file
 from acceptance.review_state import ChangeSet, Review
 from acceptance.review_store import ReviewStore
 
@@ -86,6 +88,51 @@ def run_check(
     return review
 
 
+def run_decompose(task: str, config: RunConfig) -> Decomposition:
+    """Parse a task file and decompose it into obligations + open questions.
+
+    Uses a live model call (in RECORD mode) — the dogfooding path for M1.2/M1.3.
+    """
+    parsed = parse_task_file(_read_task(task))
+    return decompose(parsed, config.build_client())
+
+
+def render_decomposition(result: Decomposition) -> str:
+    lines = ["Obligations:"]
+    if result.obligations:
+        for o in result.obligations:
+            flag = "explicit" if o.explicit else "inferred"
+            lines.append(f"  [{o.type.value}/{flag}] {o.id}: {o.description}")
+    else:
+        lines.append("  (none)")
+    lines.append("")
+    lines.append("Open questions:")
+    if result.open_questions:
+        for q in result.open_questions:
+            lines.append(f"  ? {q.id}: {q.question}")
+    else:
+        lines.append("  (none)")
+    return "\n".join(lines)
+
+
+def _add_model_flags(parser: argparse.ArgumentParser, default_mode: str) -> None:
+    parser.add_argument(
+        "--model",
+        default=DEFAULT_MODEL,
+        help=f"Model to route via LiteLLM (default: {DEFAULT_MODEL}).",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=[m.value for m in Mode],
+        default=default_mode,
+        help="record (live call on cache miss) or replay (transcripts only).",
+    )
+    parser.add_argument("--seed", type=int, default=None, help="Model seed (determinism).")
+    parser.add_argument(
+        "--temperature", type=float, default=0.0, help="Model temperature (default: 0.0)."
+    )
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="acceptance")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -94,26 +141,22 @@ def build_parser() -> argparse.ArgumentParser:
     check.add_argument("--task", required=True, help="Path to the task file.")
     check.add_argument("--base", required=True, help="Base Git revision.")
     check.add_argument("--head", required=True, help="Head Git revision.")
-    check.add_argument(
-        "--model",
-        default=DEFAULT_MODEL,
-        help=f"Model to route via LiteLLM (default: {DEFAULT_MODEL}).",
-    )
-    check.add_argument(
-        "--mode",
-        choices=[m.value for m in Mode],
-        default=Mode.REPLAY.value,
-        help="record (live call on cache miss) or replay (transcripts only). "
-        "Default: replay — never issues a live call.",
-    )
-    check.add_argument("--seed", type=int, default=None, help="Model seed (determinism).")
-    check.add_argument(
-        "--temperature", type=float, default=0.0, help="Model temperature (default: 0.0)."
-    )
+    _add_model_flags(check, default_mode=Mode.REPLAY.value)  # never call live unbidden
     check.add_argument(
         "--json",
         action="store_true",
         help="Emit the structured Review as JSON instead of the §16 report.",
+    )
+
+    dec = subparsers.add_parser(
+        "decompose", help="Decompose a task file into obligations + open questions (live)."
+    )
+    dec.add_argument("--task", required=True, help="Path to the task file.")
+    _add_model_flags(dec, default_mode=Mode.RECORD.value)  # dogfood: live call on cache miss
+    dec.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the structured Decomposition as JSON.",
     )
 
     return parser
@@ -139,6 +182,27 @@ def main(argv: list[str] | None = None) -> int:
             print(json.dumps(review.to_dict(), indent=2))
         else:
             print(render_report(review))
+        return 0
+
+    if args.command == "decompose":
+        config = RunConfig(
+            model=args.model,
+            mode=Mode(args.mode),
+            seed=args.seed,
+            temperature=args.temperature,
+        )
+        try:
+            result = run_decompose(args.task, config)
+        except CliError as exc:
+            print(f"acceptance: error: {exc}", file=sys.stderr)
+            return 1
+        except LLMError as exc:
+            print(f"acceptance: model error: {exc}", file=sys.stderr)
+            return 1
+        if args.json:
+            print(json.dumps(result.to_dict(), indent=2))
+        else:
+            print(render_decomposition(result))
         return 0
 
     parser.error(f"unknown command: {args.command}")

--- a/src/acceptance/config.py
+++ b/src/acceptance/config.py
@@ -23,7 +23,8 @@ from pydantic import BaseModel, ConfigDict, Field
 from acceptance.llm import DEFAULT_TRANSCRIPT_ROOT, Mode, ModelClient, TranscriptStore
 from acceptance.review_state import ReviewProvenance
 
-DEFAULT_MODEL = "anthropic/claude-sonnet-5"
+# LiteLLM model string. Provider-agnostic: swap freely via --model / RunConfig.
+DEFAULT_MODEL = "openai/gpt-5.4-mini"
 
 
 class RunConfig(BaseModel):

--- a/src/acceptance/requirement/obligations.py
+++ b/src/acceptance/requirement/obligations.py
@@ -14,7 +14,7 @@ obligations — uncertainty is a first-class, expected result (M1.3).
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from acceptance.llm import ModelClient
 from acceptance.model_base import PersistableModel
@@ -44,7 +44,13 @@ ambiguous text.
 Do not merge distinct requirements. Prefer the smallest faithful set."""
 
 
+# The model-response schemas must be OpenAI strict-mode compatible: every object
+# forbids extra properties (additionalProperties:false) and every field is
+# required (no defaults). extra="forbid" yields the former; listing all fields
+# without defaults yields the latter. Empty arrays are returned explicitly.
 class _DecomposedObligation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     id: str
     description: str
     type: ObligationType
@@ -55,6 +61,8 @@ class _DecomposedObligation(BaseModel):
 
 
 class _OpenQuestion(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     id: str
     question: str
     importance: str
@@ -62,8 +70,10 @@ class _OpenQuestion(BaseModel):
 
 
 class _Decomposition(BaseModel):
-    obligations: list[_DecomposedObligation] = Field(default_factory=list)
-    open_questions: list[_OpenQuestion] = Field(default_factory=list)
+    model_config = ConfigDict(extra="forbid")
+
+    obligations: list[_DecomposedObligation]
+    open_questions: list[_OpenQuestion]
 
 
 class Decomposition(PersistableModel):

--- a/tests/requirement/test_obligations.py
+++ b/tests/requirement/test_obligations.py
@@ -74,7 +74,8 @@ FLOATING_RATE_RESPONSE = {
             "observable_behavior": "the result reports the fixing date and spread used",
             "source_quote": "using an index curve plus contractual spread",
         },
-    ]
+    ],
+    "open_questions": [],
 }
 
 
@@ -166,7 +167,8 @@ def test_archetype_1_includes_the_omitted_obligation():
                 "observable_behavior": "a return shows quantity and total in parentheses",
                 "source_quote": "For returns (a negative quantity), show the quantity and the line total in",
             },
-        ]
+        ],
+        "open_questions": [],
     }
 
     obligations = decompose(parsed, _client_returning(response)).obligations
@@ -199,7 +201,8 @@ def test_duplicate_ids_are_made_unique():
                 "observable_behavior": "...",
                 "source_quote": "contractual spread",
             },
-        ]
+        ],
+        "open_questions": [],
     }
     obligations = decompose(parsed, _client_returning(response)).obligations
     assert [o.id for o in obligations] == ["dup", "dup-2"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -176,3 +176,47 @@ def test_run_check_rejects_a_revision_missing_from_the_given_repo(
             store=ReviewStore(tmp_path / "reviews"),
             repo=git_repo_elsewhere["path"],
         )
+
+
+# --- decompose subcommand (M1.2/M1.3 dogfood path) ---
+
+def test_decompose_replay_without_transcript_fails_cleanly(
+    fixture_task_path, tmp_path, monkeypatch, capsys
+):
+    # REPLAY mode with no recorded transcript must not call live; it errors out.
+    # chdir to an empty dir so the relative transcript store is guaranteed empty.
+    monkeypatch.chdir(tmp_path)
+    exit_code = main(["decompose", "--task", fixture_task_path, "--mode", "replay"])
+
+    assert exit_code == 1
+    assert "model error" in capsys.readouterr().err
+
+
+def test_decompose_missing_task_fails_cleanly(capsys):
+    exit_code = main(["decompose", "--task", "does-not-exist.md", "--mode", "replay"])
+    assert exit_code == 1
+    assert "task file not found" in capsys.readouterr().err
+
+
+def test_render_decomposition_lists_obligations_and_open_questions():
+    from acceptance.cli import render_decomposition
+    from acceptance.requirement.obligations import Decomposition
+    from acceptance.review_state import Obligation, ObligationType, OpenQuestion
+
+    result = Decomposition(
+        obligations=[
+            Obligation(
+                id="ob-1",
+                description="Do the thing.",
+                type=ObligationType.FUNCTIONAL,
+                importance="critical",
+                explicit=True,
+                observable_behavior="...",
+            )
+        ],
+        open_questions=[OpenQuestion(id="q-1", question="How many?", importance="normal")],
+    )
+
+    rendered = render_decomposition(result)
+    assert "[functional/explicit] ob-1: Do the thing." in rendered
+    assert "? q-1: How many?" in rendered


### PR DESCRIPTION
Revisits M1.2 to make the decomposition pipeline actually runnable against a live model — the tests stay deterministic (static responses), but we can now dogfood the real LLM path.

## Summary
- **`acceptance decompose --task <file>`** — a new CLI subcommand that runs the real M1.2/M1.3 pipeline (parse → decompose) against a task file with a live model, in **RECORD** mode so the transcript is captured and subsequent runs replay for free. Emits typed obligations + open questions (or `--json`).
- **Default model → `openai/gpt-5.4-mini`** (OpenAI is the configured provider in this environment; still fully swappable via `--model` / `RunConfig`, per the LLM-agnostic goal).
- **Fixes a real OpenAI strict-structured-output incompatibility** the first live call surfaced: strict mode requires `additionalProperties: false` on every schema object and all fields required. The decomposition response models now set `extra="forbid"` and drop field defaults (`open_questions` is returned explicitly), so the pydantic-generated schema is strict-compatible. Static fixtures updated for the now-required key.

## Verified end to end (live)
`gpt-5.4-mini` decomposed the project's own `current-task.md` into 6 typed obligations (with explicit/inferred flags) + 2 open questions; **REPLAY** reproduced the same output in ~0.2s with no live call; token usage and cost (`$0.0027`) recorded in the transcript. The `.acceptance/cache/` transcript is gitignored.

## Test plan
- [x] `pytest -q` — 196 pass. Static capability tests unchanged. New: `decompose` replay-without-transcript fails cleanly, missing-task fails cleanly, `render_decomposition` output. Schema verified to have `additionalProperties:false` + all-required on every object.
- [x] `ruff check .` — clean
- [x] Manual live dogfood run (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)