### PR TITLE
M1.4: decomposition scoring hook

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,10 +1,9 @@
 # Task
-Label each obligation as explicit or reasonable-inferred, and surface material ambiguities as open questions instead of inventing obligations.
+Wire the decomposition output (M1.2/M1.3) into the benchmark's decomposition-accuracy metric (M-B0.3), so archetype cases report a real decomposition-accuracy number.
 
 ## Constraints
-- Flag each obligation as explicit (directly stated in the task) or reasonable-inferred.
-- When a requirement is materially underspecified, emit an open question needing user judgment rather than a fabricated obligation.
-- Link each open question to the ambiguous source text.
+- Decomposing a case only needs its task text, not a materialized repo — the hook should not require the full check pipeline's git/diff machinery.
+- Stay replay-first: the scoring hook's own tests inject a recorded model response, no live calls.
 
 ## Completion expectations
 - Implementation

--- a/src/acceptance/benchmark/decomposition.py
+++ b/src/acceptance/benchmark/decomposition.py
@@ -1,0 +1,38 @@
+"""Decomposition scoring hook (M1.4).
+
+Wires M1.2/M1.3's obligation decomposition into the M-B0.3
+decomposition-accuracy metric. Decomposing a case only needs its task text —
+not a materialized repo, diff, or test run — so this hook is deliberately
+lighter than the full checker pipeline (M-B0.2's run_case): no git
+materialization, just parse -> decompose -> a minimal Review carrying the
+resulting obligation_map, ready for score_case/score_case_set.
+"""
+
+from __future__ import annotations
+
+from acceptance.benchmark.case import BenchmarkCase
+from acceptance.benchmark.scoring import score_case
+from acceptance.llm import ModelClient
+from acceptance.requirement.obligations import decompose
+from acceptance.requirement.task_file import parse_task_file
+from acceptance.review_state import Review, ReviewProvenance
+
+
+def decompose_case(case: BenchmarkCase, client: ModelClient) -> BenchmarkCase:
+    """Decompose a case's task text and return a scored copy of `case`."""
+    parsed = parse_task_file(case.inputs.task_text)
+    result = decompose(parsed, client)
+
+    review = Review(
+        mode="local",
+        reviewed_revision=case.inputs.head_revision,
+        provenance=ReviewProvenance(
+            determinism_mode=client.mode.value,
+            model=client.model,
+            temperature=client.temperature,
+            seed=client.seed,
+        ),
+        obligation_map=result.obligations,
+    )
+    scored_case = case.model_copy(update={"reviewer_output": review})
+    return scored_case.model_copy(update={"score": score_case(scored_case)})

--- a/tests/benchmark/test_decomposition.py
+++ b/tests/benchmark/test_decomposition.py
@@ -1,0 +1,115 @@
+"""M1.4 acceptance: archetype cases report a decomposition-accuracy number.
+
+decompose_case only needs a case's task text (no repo materialization), so
+these tests inject a recorded model response directly — replay-first, no live
+calls, same pattern as M1.2/M1.3's tests.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+from acceptance.benchmark.decomposition import decompose_case
+from acceptance.benchmark.fixtures import build_benchmark_case
+from acceptance.benchmark.scoring import score_case_set
+from acceptance.llm import Mode, ModelClient, TranscriptStore
+
+ARCHETYPES_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "archetypes"
+FIXTURE_DIRS = sorted(p for p in ARCHETYPES_DIR.iterdir() if p.is_dir())
+
+
+def _client_returning(response: dict) -> ModelClient:
+    def completion_fn(**kwargs):
+        content = json.dumps(response)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+
+    return ModelClient(
+        model="anthropic/claude-sonnet-5",
+        mode=Mode.RECORD,
+        store=TranscriptStore(tempfile.mkdtemp()),
+        completion_fn=completion_fn,
+    )
+
+
+def _obligation_response(descriptions: list[str]) -> dict:
+    return {
+        "obligations": [
+            {
+                "id": f"o{i}",
+                "description": desc,
+                "type": "functional",
+                "importance": "normal",
+                "explicit": True,
+                "observable_behavior": "...",
+                "source_quote": desc,
+            }
+            for i, desc in enumerate(descriptions)
+        ],
+        "open_questions": [],
+    }
+
+
+def test_archetype_1_reports_the_expected_decomposition_accuracy(tmp_path):
+    """The real archetype #1 ground truth has 4 obligations; a decomposition
+    that reproduces 3 of the 4 exact descriptions (omitting the returns-in-
+    parens obligation, matching the archetype's own missed-obligation story)
+    yields decomposition_accuracy == 3/4."""
+    case = build_benchmark_case(
+        ARCHETYPES_DIR / "01-missed-obligation", tmp_path / "repo"
+    )
+    response = _obligation_response(
+        [
+            "Show the item name, quantity, and unit price",
+            "Include the line total (quantity times unit price)",
+            "Format money as USD with two decimals and a leading $",
+        ]
+    )
+
+    scored = decompose_case(case, _client_returning(response))
+
+    assert scored.score is not None
+    assert scored.score.decomposition_accuracy == 3 / 4
+
+
+def test_decompose_case_does_not_mutate_the_input_case(tmp_path):
+    case = build_benchmark_case(ARCHETYPES_DIR / "01-missed-obligation", tmp_path / "repo")
+    decompose_case(case, _client_returning(_obligation_response([])))
+
+    assert case.reviewer_output is None
+    assert case.score is None
+
+
+def test_all_archetype_cases_report_a_decomposition_accuracy_number(tmp_path):
+    """Pooled across all nine archetypes: score_case_set reports a real,
+    non-None decomposition_accuracy — the M1.4 acceptance."""
+    scored_cases = []
+    for i, fixture_dir in enumerate(FIXTURE_DIRS):
+        case = build_benchmark_case(fixture_dir, tmp_path / f"repo-{i}")
+        # Synthetic response: every ground-truth obligation but the last one,
+        # reusing the case's own labels (no hand-typed descriptions needed).
+        descriptions = [o.description for o in case.ground_truth.obligations]
+        response = _obligation_response(descriptions[:-1] if len(descriptions) > 1 else [])
+        scored_cases.append(decompose_case(case, _client_returning(response)))
+
+    report = score_case_set(scored_cases)
+
+    assert report.case_count == len(FIXTURE_DIRS)
+    assert report.decomposition_accuracy is not None
+    assert 0.0 < report.decomposition_accuracy < 1.0
+    # Every individual archetype case also reports its own number.
+    for case_score in report.per_case:
+        assert case_score.decomposition_accuracy is not None
+
+
+def test_decompose_case_leaves_other_metrics_as_no_op_defaults(tmp_path):
+    """Only decomposition_accuracy is meaningful here; gaps/mappings/evidence
+    are untouched since decompose_case doesn't populate findings."""
+    case = build_benchmark_case(ARCHETYPES_DIR / "09-revision-cycle", tmp_path / "repo")
+    scored = decompose_case(case, _client_returning(_obligation_response([])))
+
+    assert scored.score.gap_recall is None  # archetype 09 has no ground-truth gaps
+    assert scored.score.mapping_accuracy == 0.0  # ground truth has mappings; none reported


### PR DESCRIPTION
Closes #16

## Summary
Wires M1.2/M1.3's obligation decomposition into the M-B0.3 decomposition-accuracy metric.

- **`decompose_case(case, client)`** — parses a `BenchmarkCase`'s task text, decomposes it, and returns a scored copy with a minimal `Review` carrying just the resulting `obligation_map`.
- **Deliberately lighter than the full checker pipeline** (M-B0.2's `run_case`): decomposition only needs task text, not a materialized repo/diff/test run, so no git work happens here.
- **Provenance** is derived directly from the `ModelClient`'s own attributes (mode/model/temperature/seed) — the hook takes a client, not a `RunConfig`, matching `decompose()`'s own signature.

## Test plan
- [x] `pytest -q` — 200 pass. Acceptance (`test_decomposition.py`): archetype #1 with a response reproducing 3 of its 4 ground-truth obligations → `decomposition_accuracy == 3/4`, hand-verified against the real labels. Pooled `score_case_set` over **all nine** archetype cases reports a real, non-`None` number — the literal M1.4 acceptance.
- [x] Manual standalone demo: pooled decomposition-accuracy **0.591** across the archetype set, per-case range 0.0–0.75 (printed in the PR discussion, not committed).
- [x] Replay-first: injected `completion_fn`, isolated transcript stores, no live calls.
- [x] `ruff check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)