### PR TITLE
M2.1: revision & diff extraction (§13.3 Git change analysis)

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,9 +1,10 @@
 # Task
-Wire the decomposition output (M1.2/M1.3) into the benchmark's decomposition-accuracy metric (M-B0.3), so archetype cases report a real decomposition-accuracy number.
+Extract the Git change set between a base and head revision: changed files, a source-vs-test partition, hunk-level diffs, and config/dependency-file changes.
 
 ## Constraints
-- Decomposing a case only needs its task text, not a materialized repo — the hook should not require the full check pipeline's git/diff machinery.
-- Stay replay-first: the scoring hook's own tests inject a recorded model response, no live calls.
+- Categorize every changed file as source, test, config, or other.
+- Represent diffs at hunk granularity, not as one flattened string per side.
+- Correctly detect added, modified, deleted, and renamed files.
 
 ## Completion expectations
 - Implementation

--- a/src/acceptance/change/__init__.py
+++ b/src/acceptance/change/__init__.py
@@ -1,0 +1,1 @@
+"""Git change analysis: revisions -> a structured ChangeSet (M2)."""

--- a/src/acceptance/change/diff.py
+++ b/src/acceptance/change/diff.py
@@ -1,0 +1,141 @@
+"""Revision & diff extraction (M2.1).
+
+Extracts the structural Git change set between two revisions: which files
+changed, how (added/modified/deleted/renamed), what they are (source/test/
+config/other), and their hunk-level diffs. Pure `git` plumbing — no LLM call,
+since this is structural, not semantic (§13.3 Git change analysis).
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+from acceptance.review_state import ChangeSet, DiffHunk, FileChange
+
+_TEST_PATH_RE = re.compile(r"(^|/)tests?/|(^|/)test_[^/]+\.py$|_test\.py$")
+_CONFIG_NAMES = {
+    "pyproject.toml",
+    "setup.py",
+    "setup.cfg",
+    "Pipfile",
+    "Pipfile.lock",
+    "poetry.lock",
+    "package.json",
+    "package-lock.json",
+    "yarn.lock",
+    "tox.ini",
+}
+_CONFIG_SUFFIXES = (".lock",)
+
+_STATUS_MAP = {"A": "added", "M": "modified", "D": "deleted"}
+
+_DIFF_HEADER_RE = re.compile(r"^diff --git a/(.+) b/(.+)$")
+_HUNK_HEADER_RE = re.compile(
+    r"^@@ -(?P<old_start>\d+)(?:,(?P<old_lines>\d+))? "
+    r"\+(?P<new_start>\d+)(?:,(?P<new_lines>\d+))? @@.*$"
+)
+
+
+def extract_change_set(repo: Path, base: str, head: str) -> ChangeSet:
+    """Extract the structural change set between `base` and `head` in `repo`."""
+    entries = _parse_name_status(_git(repo, "diff", "--name-status", "-M", base, head))
+    blocks = _split_file_blocks(_git(repo, "diff", "-U3", base, head))
+
+    files = [
+        FileChange(
+            path=entry["path"],
+            status=entry["status"],
+            category=_categorize(entry["path"]),
+            old_path=entry["old_path"],
+            hunks=_parse_hunks(blocks.get(entry["path"]) or blocks.get(entry["old_path"]) or ""),
+        )
+        for entry in entries
+    ]
+    return ChangeSet(base_revision=base, head_revision=head, files=files)
+
+
+def _categorize(path: str) -> str:
+    name = path.rsplit("/", 1)[-1]
+    if _TEST_PATH_RE.search(path):
+        return "test"
+    if name in _CONFIG_NAMES or name.endswith(_CONFIG_SUFFIXES):
+        return "config"
+    if name.startswith("requirements") and name.endswith((".txt", ".in")):
+        return "config"
+    if name.endswith(".py"):
+        return "source"
+    return "other"
+
+
+def _parse_name_status(output: str) -> list[dict]:
+    entries = []
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        code = parts[0]
+        if code.startswith("R"):
+            entries.append({"status": "renamed", "path": parts[2], "old_path": parts[1]})
+        else:
+            entries.append(
+                {"status": _STATUS_MAP.get(code[0], "modified"), "path": parts[1], "old_path": None}
+            )
+    return entries
+
+
+def _split_file_blocks(full_diff: str) -> dict[str, str]:
+    """Map each file's `diff --git` b-side path to its raw diff block text."""
+    blocks: dict[str, str] = {}
+    current_key: str | None = None
+    current_lines: list[str] = []
+
+    def flush() -> None:
+        if current_key is not None:
+            blocks[current_key] = "\n".join(current_lines)
+
+    for line in full_diff.splitlines():
+        header = _DIFF_HEADER_RE.match(line)
+        if header:
+            flush()
+            current_key = header.group(2)
+            current_lines = [line]
+        else:
+            current_lines.append(line)
+    flush()
+    return blocks
+
+
+def _parse_hunks(diff_block: str) -> list[DiffHunk]:
+    hunks = []
+    lines = diff_block.splitlines()
+    i, n = 0, len(lines)
+    while i < n:
+        match = _HUNK_HEADER_RE.match(lines[i])
+        if not match:
+            i += 1
+            continue
+        header = lines[i]
+        i += 1
+        body: list[str] = []
+        while i < n and not lines[i].startswith("@@ ") and not lines[i].startswith("diff --git "):
+            body.append(lines[i])
+            i += 1
+        hunks.append(
+            DiffHunk(
+                header=header,
+                old_start=int(match.group("old_start")),
+                old_lines=int(match.group("old_lines") or 1),
+                new_start=int(match.group("new_start")),
+                new_lines=int(match.group("new_lines") or 1),
+                content="\n".join(body),
+            )
+        )
+    return hunks
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout

--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -1,11 +1,15 @@
 """`acceptance` CLI entrypoint.
 
-Parses `check --task --base --head` plus the M0.5 determinism controls
-(`--model`, `--mode`, `--seed`, `--temperature`), validates its inputs, and
-runs the M0.6 walking-skeleton pipeline: ingest task + revisions → write an
-empty but well-formed Review to the state store → render the §16 report.
-Requirement interpretation, real diffing, and test analysis land in later
-milestones; the sections render present-and-empty until then.
+`check --task --base --head` runs the M0.6 walking-skeleton pipeline: ingest
+task + revisions → write an empty but well-formed Review → render the §16
+report. Its sections render present-and-empty until the capabilities that
+fill them (M1-M7) are assembled into the pipeline.
+
+`decompose` and `diff` are standalone dogfooding entry points for those
+capabilities as they land — `decompose` runs the real M1.2/M1.3 obligation
+decomposition against a task file (live model call); `diff` runs the real
+M2.1 change-set extraction against two revisions. Neither is wired into
+`check` yet; that assembly happens later (M7).
 """
 
 from __future__ import annotations
@@ -16,6 +20,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from acceptance.change.diff import extract_change_set
 from acceptance.config import DEFAULT_MODEL, RunConfig
 from acceptance.llm import LLMError, Mode
 from acceptance.report import render_report
@@ -81,7 +86,8 @@ def run_check(
         mode="local",
         reviewed_revision=head_sha,
         provenance=config.provenance(),
-        # Diff endpoints only; real change extraction (files, diffs) is M2.
+        # Diff endpoints only; real extraction exists (change/diff.py, dogfooded
+        # via `acceptance diff`) but isn't wired into this pipeline yet (M7).
         change_set=ChangeSet(base_revision=base_sha, head_revision=head_sha),
     )
     store.write(review)
@@ -112,6 +118,28 @@ def render_decomposition(result: Decomposition) -> str:
             lines.append(f"  ? {q.id}: {q.question}")
     else:
         lines.append("  (none)")
+    return "\n".join(lines)
+
+
+def run_diff(repo: str, base: str, head: str) -> ChangeSet:
+    """Extract the structural change set between two revisions (M2.1)."""
+    repo_path = Path(repo)
+    base_sha = _resolve_revision(base, repo=repo_path)
+    head_sha = _resolve_revision(head, repo=repo_path)
+    return extract_change_set(repo_path, base_sha, head_sha)
+
+
+def render_change_set(change_set: ChangeSet) -> str:
+    lines = [f"Files changed ({len(change_set.files)}):"]
+    if not change_set.files:
+        lines.append("  (none)")
+    for f in change_set.files:
+        origin = f" (from {f.old_path})" if f.old_path else ""
+        hunk_count = len(f.hunks)
+        lines.append(
+            f"  [{f.category}/{f.status}] {f.path}{origin}  "
+            f"({hunk_count} hunk{'' if hunk_count == 1 else 's'})"
+        )
     return "\n".join(lines)
 
 
@@ -159,6 +187,18 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit the structured Decomposition as JSON.",
     )
 
+    diff = subparsers.add_parser(
+        "diff", help="Extract the structural change set between two revisions."
+    )
+    diff.add_argument("--repo", default=".", help="Path to the Git repo (default: here).")
+    diff.add_argument("--base", required=True, help="Base Git revision.")
+    diff.add_argument("--head", required=True, help="Head Git revision.")
+    diff.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the structured ChangeSet as JSON.",
+    )
+
     return parser
 
 
@@ -203,6 +243,18 @@ def main(argv: list[str] | None = None) -> int:
             print(json.dumps(result.to_dict(), indent=2))
         else:
             print(render_decomposition(result))
+        return 0
+
+    if args.command == "diff":
+        try:
+            change_set = run_diff(args.repo, args.base, args.head)
+        except CliError as exc:
+            print(f"acceptance: error: {exc}", file=sys.stderr)
+            return 1
+        if args.json:
+            print(json.dumps(change_set.to_dict(), indent=2))
+        else:
+            print(render_change_set(change_set))
         return 0
 
     parser.error(f"unknown command: {args.command}")

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -32,6 +32,8 @@ __all__ = [
     "TaskSource",
     "MandateInterpretation",
     "BuilderDeclaration",
+    "DiffHunk",
+    "FileChange",
     "ChangeSet",
     "Obligation",
     "OpenQuestion",
@@ -100,13 +102,31 @@ class BuilderDeclaration(_Model):
     additional_behavioral_changes: str
 
 
+class DiffHunk(_Model):
+    """One `@@ -a,b +c,d @@` unified-diff hunk."""
+
+    header: str
+    old_start: int
+    old_lines: int
+    new_start: int
+    new_lines: int
+    content: str
+
+
+class FileChange(_Model):
+    """One changed file between base and head (M2.1, §13.3 Git change analysis)."""
+
+    path: str
+    status: Literal["added", "modified", "deleted", "renamed"]
+    category: Literal["source", "test", "config", "other"]
+    old_path: str | None = None  # set when status == "renamed"
+    hunks: list[DiffHunk] = Field(default_factory=list)
+
+
 class ChangeSet(_Model):
     base_revision: str
     head_revision: str
-    changed_files: list[str] = Field(default_factory=list)
-    source_diff: str = ""
-    test_diff: str = ""
-    config_dependency_changes: list[str] = Field(default_factory=list)
+    files: list[FileChange] = Field(default_factory=list)
 
 
 class Obligation(_Model):

--- a/tests/change/test_diff.py
+++ b/tests/change/test_diff.py
@@ -1,0 +1,172 @@
+"""M2.1 acceptance: on a fixture with a source edit, a test edit, and a
+dependency bump, all three are correctly categorized."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from acceptance.change.diff import extract_change_set
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+
+def _commit(repo: Path, message: str) -> str:
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", message)
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path) -> Path:
+    path = tmp_path / "repo"
+    path.mkdir()
+    _git(path, "init", "-q")
+    _git(path, "config", "user.email", "test@example.com")
+    _git(path, "config", "user.name", "Test")
+    return path
+
+
+def test_source_test_and_dependency_edits_are_correctly_categorized(repo):
+    (repo / "tests").mkdir()
+    (repo / "pkg.py").write_text("def f():\n    return 1\n")
+    (repo / "tests" / "test_pkg.py").write_text("def test_f():\n    assert True\n")
+    (repo / "requirements.txt").write_text("requests==2.0\n")
+    base = _commit(repo, "base")
+
+    (repo / "pkg.py").write_text("def f():\n    return 2\n")
+    (repo / "tests" / "test_pkg.py").write_text("def test_f():\n    assert True\n\n\ndef test_g():\n    assert True\n")
+    (repo / "requirements.txt").write_text("requests==3.0\n")
+    head = _commit(repo, "head")
+
+    change_set = extract_change_set(repo, base, head)
+
+    by_path = {f.path: f for f in change_set.files}
+    assert set(by_path) == {"pkg.py", "tests/test_pkg.py", "requirements.txt"}
+
+    assert by_path["pkg.py"].category == "source"
+    assert by_path["pkg.py"].status == "modified"
+    assert by_path["pkg.py"].hunks
+
+    assert by_path["tests/test_pkg.py"].category == "test"
+    assert by_path["tests/test_pkg.py"].status == "modified"
+    assert by_path["tests/test_pkg.py"].hunks
+
+    assert by_path["requirements.txt"].category == "config"
+    assert by_path["requirements.txt"].status == "modified"
+    assert by_path["requirements.txt"].hunks
+
+
+def test_hunk_content_is_captured_correctly(repo):
+    (repo / "pkg.py").write_text("line1\nline2\nline3\n")
+    base = _commit(repo, "base")
+    (repo / "pkg.py").write_text("line1\nCHANGED\nline3\n")
+    head = _commit(repo, "head")
+
+    change_set = extract_change_set(repo, base, head)
+    hunk = change_set.files[0].hunks[0]
+
+    assert hunk.old_start == 1
+    assert hunk.new_start == 1
+    assert "-line2" in hunk.content
+    assert "+CHANGED" in hunk.content
+
+
+def test_added_file_is_detected(repo):
+    (repo / "existing.py").write_text("x = 1\n")
+    base = _commit(repo, "base")
+    (repo / "new_module.py").write_text("y = 2\n")
+    head = _commit(repo, "head")
+
+    change_set = extract_change_set(repo, base, head)
+    assert len(change_set.files) == 1
+    added = change_set.files[0]
+    assert added.path == "new_module.py"
+    assert added.status == "added"
+    assert added.category == "source"
+    assert added.hunks
+
+
+def test_deleted_file_is_detected(repo):
+    (repo / "gone.py").write_text("x = 1\n")
+    base = _commit(repo, "base")
+    (repo / "gone.py").unlink()
+    head = _commit(repo, "head")
+
+    change_set = extract_change_set(repo, base, head)
+    assert len(change_set.files) == 1
+    deleted = change_set.files[0]
+    assert deleted.path == "gone.py"
+    assert deleted.status == "deleted"
+    assert deleted.old_path is None
+    assert deleted.hunks
+
+
+def test_renamed_file_is_detected(repo):
+    (repo / "old_name.py").write_text("def f():\n    return 1\ndef g():\n    return 2\n")
+    base = _commit(repo, "base")
+    _git(repo, "mv", "old_name.py", "new_name.py")
+    (repo / "new_name.py").write_text("def f():\n    return 1\ndef g():\n    return 3\n")
+    head = _commit(repo, "head")
+
+    change_set = extract_change_set(repo, base, head)
+    assert len(change_set.files) == 1
+    renamed = change_set.files[0]
+    assert renamed.path == "new_name.py"
+    assert renamed.old_path == "old_name.py"
+    assert renamed.status == "renamed"
+    assert renamed.hunks  # content changed too
+
+
+def test_no_changes_between_identical_revisions(repo):
+    (repo / "pkg.py").write_text("x = 1\n")
+    base = _commit(repo, "base")
+
+    change_set = extract_change_set(repo, base, base)
+    assert change_set.files == []
+
+
+def test_multi_hunk_file_produces_multiple_hunks(repo):
+    lines = [f"line{i}\n" for i in range(1, 41)]
+    (repo / "pkg.py").write_text("".join(lines))
+    base = _commit(repo, "base")
+
+    lines[2] = "CHANGED_NEAR_TOP\n"
+    lines[35] = "CHANGED_NEAR_BOTTOM\n"
+    (repo / "pkg.py").write_text("".join(lines))
+    head = _commit(repo, "head")
+
+    change_set = extract_change_set(repo, base, head)
+    assert len(change_set.files[0].hunks) == 2
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected_category"),
+    [
+        ("pyproject.toml", "config"),
+        ("setup.py", "config"),
+        ("Pipfile.lock", "config"),
+        ("poetry.lock", "config"),
+        ("package.json", "config"),
+        ("requirements-dev.txt", "config"),
+        ("README.md", "other"),
+        ("src/pkg/module.py", "source"),
+        ("tests/test_module.py", "test"),
+        ("src/pkg/module_test.py", "test"),
+    ],
+)
+def test_categorization_by_filename(repo, filename, expected_category):
+    path = repo / filename
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("content v1\n")
+    base = _commit(repo, "base")
+    path.write_text("content v2\n")
+    head = _commit(repo, "head")
+
+    change_set = extract_change_set(repo, base, head)
+    assert change_set.files[0].category == expected_category

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,7 @@ def test_check_json_emits_empty_structured_review(git_repo, fixture_task_path, c
     # Diff endpoints are ingested; file-level diffing is still M2.
     assert review["change_set"]["base_revision"] == git_repo["base"]
     assert review["change_set"]["head_revision"] == git_repo["head"]
-    assert review["change_set"]["changed_files"] == []
+    assert review["change_set"]["files"] == []
     assert review["obligation_map"] == []
     assert review["findings"] == []
     assert review["limitations"] == []

--- a/tests/test_review_state.py
+++ b/tests/test_review_state.py
@@ -6,8 +6,10 @@ from acceptance.review_state import (
     BuilderDeclaration,
     ChangeSet,
     Component,
+    DiffHunk,
     EvidenceTier,
     ExecutionEvidence,
+    FileChange,
     Finding,
     Link,
     MandateInterpretation,
@@ -83,10 +85,23 @@ def test_change_set_round_trips():
     change_set = ChangeSet(
         base_revision="abc123",
         head_revision="def456",
-        changed_files=["src/foo.py"],
-        source_diff="--- a/src/foo.py\n+++ b/src/foo.py\n",
-        test_diff="",
-        config_dependency_changes=[],
+        files=[
+            FileChange(
+                path="src/foo.py",
+                status="modified",
+                category="source",
+                hunks=[
+                    DiffHunk(
+                        header="@@ -1,2 +1,2 @@",
+                        old_start=1,
+                        old_lines=2,
+                        new_start=1,
+                        new_lines=2,
+                        content=" a\n-b\n+c",
+                    )
+                ],
+            )
+        ],
     )
     assert _round_trip(change_set) == change_set
 


### PR DESCRIPTION
Closes #17

## Summary
New `src/acceptance/change/diff.py`: `extract_change_set(repo, base, head)` extracts the structural Git change set between two revisions via pure `git` plumbing — no LLM call, since this is structural, not semantic.

**Revises `review_state.ChangeSet`** (an M0.2 placeholder — flat `changed_files` list, single `source_diff`/`test_diff` strings) into the real shape M2.1 requires — same pattern as M1.2's `Obligation` revision:
```
DiffHunk:    header, old_start, old_lines, new_start, new_lines, content
FileChange:  path, status (added/modified/deleted/renamed), category (source/test/config/other),
             old_path (renames), hunks: list[DiffHunk]
ChangeSet:   base_revision, head_revision, files: list[FileChange]
```

**Categorization** is a path/filename heuristic: `test_*.py`/`*_test.py`/`tests?/` → test; known dependency/config filenames (`pyproject.toml`, `requirements*.txt`, `*.lock`, `package.json`, ...) → config; remaining `.py` → source; else other.

**`acceptance diff --repo --base --head`** — dogfooding entry point, alongside `check`/`decompose`. Not wired into `check`'s pipeline yet (that assembly is M7).

## Test plan
- [x] `pytest -q` — 217 pass. Acceptance (`test_diff.py`): a fixture with a source edit, a test edit, and a dependency bump are all three correctly categorized with real hunks. Plus added/deleted/renamed detection, multi-hunk files, identical-revision no-op, and a parametrized filename-categorization sweep.
- [x] **Manually dogfooded against this repo's own merged history** (M0.1→M0.2, `e82366e..f582a24`): `pyproject.toml` → config, `review_state.py` → source, both test files → test — all correctly categorized on real commits, not just fixtures.
- [x] `ruff check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)