### PR TITLE
M2.2: surrounding-code retrieval

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,10 +1,10 @@
 # Task
-Extract the Git change set between a base and head revision: changed files, a source-vs-test partition, hunk-level diffs, and config/dependency-file changes.
+For each changed code region, retrieve the enclosing definition and its direct in-repo call sites, within a bounded retrieval budget.
 
 ## Constraints
-- Categorize every changed file as source, test, config, or other.
-- Represent diffs at hunk granularity, not as one flattened string per side.
-- Correctly detect added, modified, deleted, and renamed files.
+- Find the innermost function/class/method definition that encloses each changed line, via Python AST parsing.
+- Retrieve direct call sites of each changed definition elsewhere in the repo.
+- Respect a configurable budget cap (files scanned, call sites per definition); mark results truncated when the cap is hit rather than scanning unbounded.
 
 ## Completion expectations
 - Implementation

--- a/src/acceptance/change/context.py
+++ b/src/acceptance/change/context.py
@@ -1,0 +1,272 @@
+"""Surrounding-code retrieval (M2.2, §12 autonomous gathering / §17 cost).
+
+For each changed code region, retrieve the enclosing definition (the innermost
+function/class/method containing a changed line) and its direct in-repo call
+sites, via Python AST — no LLM, this is structural. A `RetrievalBudget` bounds
+breadth (files scanned, call sites per definition); when a cap is hit the
+result is flagged truncated rather than silently dropping context (§3.2
+decision, #75).
+
+Caller matching is name-based (a call `foo(...)` / `obj.foo(...)` matches a
+changed definition named `foo`) — a retrieval heuristic that surfaces
+candidates; precision is a later concern (M3/M5), not retrieval's.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Literal
+
+from pydantic import Field
+
+from acceptance.model_base import PersistableModel
+from acceptance.review_state import ChangeSet
+
+
+class RetrievalBudget(PersistableModel):
+    max_files_scanned: int = 200
+    max_call_sites_per_definition: int = 20
+
+
+class CodeDefinition(PersistableModel):
+    qualname: str
+    kind: Literal["function", "async_function", "class", "method"]
+    file: str
+    start_line: int
+    end_line: int
+    source: str
+
+
+class CallSite(PersistableModel):
+    file: str
+    line: int
+    source_line: str
+    in_definition: str | None = None  # qualname of the enclosing definition, if any
+
+
+class CodeContext(PersistableModel):
+    definition: CodeDefinition
+    call_sites: list[CallSite] = Field(default_factory=list)
+    call_sites_truncated: bool = False
+
+
+class RetrievalResult(PersistableModel):
+    contexts: list[CodeContext] = Field(default_factory=list)
+    files_scanned: int = 0
+    files_scanned_truncated: bool = False
+
+
+_DEF_NODES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+
+# Vendored / generated directories are never in-repo callers, and scanning them
+# would waste the budget (they typically dwarf the source tree). Skipped.
+_EXCLUDED_DIRS = {
+    ".venv",
+    "venv",
+    ".git",
+    "__pycache__",
+    "node_modules",
+    "build",
+    "dist",
+    ".tox",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    "site-packages",
+    ".eggs",
+}
+
+
+def retrieve_context(
+    repo: Path, change_set: ChangeSet, budget: RetrievalBudget | None = None
+) -> RetrievalResult:
+    """Retrieve enclosing definitions of changed regions and their callers."""
+    budget = budget or RetrievalBudget()
+
+    definitions: dict[str, CodeDefinition] = {}
+    for file_change in change_set.files:
+        if file_change.category != "source" or file_change.status == "deleted":
+            continue
+        source = _read(repo / file_change.path)
+        if source is None:
+            continue
+        module = _parse(source)
+        if module is None:
+            continue
+        index = _index_definitions(module, file_change.path, source)
+        for hunk in file_change.hunks:
+            changed_lines = range(hunk.new_start, hunk.new_start + max(hunk.new_lines, 1))
+            enclosing = _innermost_enclosing(index, changed_lines)
+            if enclosing is not None:
+                definitions[enclosing.qualname] = enclosing
+
+    target_names = {defn.qualname.rsplit(".", 1)[-1]: defn for defn in definitions.values()}
+    call_sites: dict[str, list[CallSite]] = {q: [] for q in definitions}
+    truncated: dict[str, bool] = {q: False for q in definitions}
+
+    files_scanned, files_truncated = _scan_callers(
+        repo, target_names, call_sites, truncated, budget
+    )
+
+    contexts = [
+        CodeContext(
+            definition=defn,
+            call_sites=call_sites[qualname],
+            call_sites_truncated=truncated[qualname],
+        )
+        for qualname, defn in definitions.items()
+    ]
+    return RetrievalResult(
+        contexts=contexts,
+        files_scanned=files_scanned,
+        files_scanned_truncated=files_truncated,
+    )
+
+
+def _scan_callers(
+    repo: Path,
+    target_names: dict[str, CodeDefinition],
+    call_sites: dict[str, list[CallSite]],
+    truncated: dict[str, bool],
+    budget: RetrievalBudget,
+) -> tuple[int, bool]:
+    files = sorted(
+        path
+        for path in repo.rglob("*.py")
+        if not (_EXCLUDED_DIRS & set(path.relative_to(repo).parts[:-1]))
+    )
+    files_truncated = len(files) > budget.max_files_scanned
+    files_scanned = 0
+    for path in files[: budget.max_files_scanned]:
+        source = _read(path)
+        if source is None:
+            continue
+        module = _parse(source)
+        if module is None:
+            continue
+        files_scanned += 1
+        rel = str(path.relative_to(repo))
+        source_lines = source.splitlines()
+        for call in _iter_calls(module):
+            name = _call_name(call.node)
+            defn = target_names.get(name)
+            if defn is None:
+                continue
+            qualname = defn.qualname
+            if len(call_sites[qualname]) >= budget.max_call_sites_per_definition:
+                truncated[qualname] = True
+                continue
+            line = call.node.lineno
+            call_sites[qualname].append(
+                CallSite(
+                    file=rel,
+                    line=line,
+                    source_line=source_lines[line - 1].strip() if line <= len(source_lines) else "",
+                    in_definition=call.enclosing,
+                )
+            )
+    return files_scanned, files_truncated
+
+
+class _IndexedDef:
+    def __init__(self, node: ast.AST, qualname: str, kind: str):
+        self.node = node
+        self.qualname = qualname
+        self.kind = kind
+
+
+def _index_definitions(module: ast.Module, file: str, source: str) -> list[CodeDefinition]:
+    """All definitions in a module, with qualnames tracking nesting."""
+    lines = source.splitlines()
+    results: list[CodeDefinition] = []
+
+    def visit(node: ast.AST, prefix: str, inside_class: bool) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, _DEF_NODES):
+                qualname = f"{prefix}.{child.name}" if prefix else child.name
+                kind = _kind(child, inside_class)
+                end = getattr(child, "end_lineno", child.lineno)
+                results.append(
+                    CodeDefinition(
+                        qualname=qualname,
+                        kind=kind,
+                        file=file,
+                        start_line=child.lineno,
+                        end_line=end,
+                        source="\n".join(lines[child.lineno - 1 : end]),
+                    )
+                )
+                visit(child, qualname, isinstance(child, ast.ClassDef))
+
+    visit(module, "", False)
+    return results
+
+
+def _innermost_enclosing(
+    definitions: list[CodeDefinition], changed_lines: range
+) -> CodeDefinition | None:
+    """The smallest-range definition that contains any of the changed lines."""
+    candidates = [
+        d
+        for d in definitions
+        if any(d.start_line <= line <= d.end_line for line in changed_lines)
+    ]
+    if not candidates:
+        return None
+    return min(candidates, key=lambda d: d.end_line - d.start_line)
+
+
+class _Call:
+    def __init__(self, node: ast.Call, enclosing: str | None):
+        self.node = node
+        self.enclosing = enclosing
+
+
+def _iter_calls(module: ast.Module) -> list[_Call]:
+    """Every call in the module, tagged with its enclosing definition qualname."""
+    calls: list[_Call] = []
+
+    def visit(node: ast.AST, enclosing: str | None, prefix: str) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, ast.Call):
+                calls.append(_Call(child, enclosing))
+            if isinstance(child, _DEF_NODES):
+                qualname = f"{prefix}.{child.name}" if prefix else child.name
+                visit(child, qualname, qualname)
+            else:
+                visit(child, enclosing, prefix)
+
+    visit(module, None, "")
+    return calls
+
+
+def _call_name(call: ast.Call) -> str | None:
+    func = call.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _kind(node: ast.AST, inside_class: bool) -> str:
+    if isinstance(node, ast.ClassDef):
+        return "class"
+    if isinstance(node, ast.AsyncFunctionDef):
+        return "async_function"
+    return "method" if inside_class else "function"
+
+
+def _read(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _parse(source: str) -> ast.Module | None:
+    try:
+        return ast.parse(source)
+    except SyntaxError:
+        return None

--- a/tests/change/test_context.py
+++ b/tests/change/test_context.py
@@ -1,0 +1,181 @@
+"""M2.2 acceptance: for a changed function, its definition and at least its
+in-repo callers are retrieved; retrieval respects the configured budget cap."""
+
+from pathlib import Path
+
+from acceptance.change.context import RetrievalBudget, retrieve_context
+from acceptance.review_state import ChangeSet, DiffHunk, FileChange
+
+
+def _hunk(new_start: int, new_lines: int) -> DiffHunk:
+    return DiffHunk(
+        header=f"@@ -{new_start},{new_lines} +{new_start},{new_lines} @@",
+        old_start=new_start,
+        old_lines=new_lines,
+        new_start=new_start,
+        new_lines=new_lines,
+        content="",
+    )
+
+
+def _change_set(*files: FileChange) -> ChangeSet:
+    return ChangeSet(base_revision="base", head_revision="head", files=list(files))
+
+
+def _source_change(path: str, new_start: int, new_lines: int, status: str = "modified") -> FileChange:
+    return FileChange(
+        path=path,
+        status=status,
+        category="source",
+        hunks=[_hunk(new_start, new_lines)],
+    )
+
+
+def _write(repo: Path, name: str, content: str) -> None:
+    (repo / name).write_text(content)
+
+
+MOD = """\
+def helper():
+    return 1
+
+
+def target():
+    return helper() + 1
+"""
+
+CALLER = """\
+from mod import target
+
+
+def use_it():
+    return target() + target()
+"""
+
+
+def test_changed_function_definition_and_callers_are_retrieved(tmp_path):
+    repo = tmp_path
+    _write(repo, "mod.py", MOD)
+    _write(repo, "caller.py", CALLER)
+    # The hunk lands on `target` (lines 5-6).
+    change_set = _change_set(_source_change("mod.py", new_start=5, new_lines=2))
+
+    result = retrieve_context(repo, change_set)
+
+    assert len(result.contexts) == 1
+    context = result.contexts[0]
+    assert context.definition.qualname == "target"
+    assert context.definition.kind == "function"
+    assert context.definition.file == "mod.py"
+    assert "def target():" in context.definition.source
+
+    # At least the in-repo callers are retrieved (two calls in caller.py).
+    caller_files = {c.file for c in context.call_sites}
+    assert "caller.py" in caller_files
+    assert len(context.call_sites) == 2
+    assert all(c.in_definition == "use_it" for c in context.call_sites)
+
+
+def test_innermost_enclosing_definition_is_a_method(tmp_path):
+    repo = tmp_path
+    _write(
+        repo,
+        "svc.py",
+        "class Service:\n"
+        "    def start(self):\n"
+        "        return self.run()\n"
+        "\n"
+        "    def run(self):\n"
+        "        return 42\n",
+    )
+    _write(repo, "client.py", "from svc import Service\n\n\ndef go():\n    return Service().run()\n")
+    # Change lands on Service.run (lines 5-6).
+    change_set = _change_set(_source_change("svc.py", new_start=5, new_lines=2))
+
+    result = retrieve_context(repo, change_set)
+
+    context = result.contexts[0]
+    assert context.definition.qualname == "Service.run"
+    assert context.definition.kind == "method"
+    # `Service().run()` is a name-based caller match.
+    assert any(c.file == "client.py" and c.in_definition == "go" for c in context.call_sites)
+
+
+def test_call_site_budget_cap_is_respected_and_flagged(tmp_path):
+    repo = tmp_path
+    _write(repo, "mod.py", MOD)
+    _write(repo, "caller.py", CALLER)  # two target() calls
+    change_set = _change_set(_source_change("mod.py", new_start=5, new_lines=2))
+
+    result = retrieve_context(
+        repo, change_set, RetrievalBudget(max_call_sites_per_definition=1)
+    )
+
+    context = result.contexts[0]
+    assert len(context.call_sites) == 1  # capped
+    assert context.call_sites_truncated is True
+
+
+def test_files_scanned_budget_cap_is_respected_and_flagged(tmp_path):
+    repo = tmp_path
+    _write(repo, "mod.py", MOD)
+    _write(repo, "caller.py", CALLER)
+    _write(repo, "zzz_other.py", "x = 1\n")  # 3 py files total
+    change_set = _change_set(_source_change("mod.py", new_start=5, new_lines=2))
+
+    result = retrieve_context(repo, change_set, RetrievalBudget(max_files_scanned=1))
+
+    assert result.files_scanned == 1
+    assert result.files_scanned_truncated is True
+
+
+def test_vendored_directories_are_not_scanned_for_callers(tmp_path):
+    repo = tmp_path
+    _write(repo, "mod.py", MOD)
+    # A caller that lives under .venv must not be scanned (not an in-repo caller).
+    (repo / ".venv").mkdir()
+    (repo / ".venv" / "vendored.py").write_text("from mod import target\ntarget()\n")
+    change_set = _change_set(_source_change("mod.py", new_start=5, new_lines=2))
+
+    result = retrieve_context(repo, change_set)
+
+    context = result.contexts[0]
+    assert all(".venv" not in c.file for c in context.call_sites)
+
+
+def test_deleted_files_are_skipped(tmp_path):
+    repo = tmp_path
+    _write(repo, "caller.py", CALLER)
+    change_set = _change_set(_source_change("mod.py", new_start=5, new_lines=2, status="deleted"))
+
+    result = retrieve_context(repo, change_set)
+
+    assert result.contexts == []
+
+
+def test_non_source_files_are_skipped(tmp_path):
+    repo = tmp_path
+    _write(repo, "requirements.txt", "requests==2.0\n")
+    change_set = _change_set(
+        FileChange(
+            path="requirements.txt",
+            status="modified",
+            category="config",
+            hunks=[_hunk(1, 1)],
+        )
+    )
+
+    result = retrieve_context(repo, change_set)
+    assert result.contexts == []
+
+
+def test_result_round_trips_through_persistence(tmp_path):
+    from acceptance.change.context import RetrievalResult
+
+    repo = tmp_path
+    _write(repo, "mod.py", MOD)
+    _write(repo, "caller.py", CALLER)
+    change_set = _change_set(_source_change("mod.py", new_start=5, new_lines=2))
+
+    result = retrieve_context(repo, change_set)
+    assert RetrievalResult.from_dict(result.to_dict()) == result


### PR DESCRIPTION
Closes #18
Closes #75

## Summary
New `src/acceptance/change/context.py`: `retrieve_context(repo, change_set, budget)` retrieves, for each changed region, the innermost enclosing definition (function/class/method) via Python `ast` and its direct in-repo call sites — no LLM, this is structural.

## Budget decision (#75, §3.2)
- **`RetrievalBudget`** bounds *breadth*: `max_files_scanned` (default 200), `max_call_sites_per_definition` (default 20).
- When a cap is hit, the result is flagged **`truncated`** (`call_sites_truncated` / `files_scanned_truncated`) rather than silently dropping context.
- **Name-based caller matching** (`foo(...)`/`obj.foo(...)` matches a def named `foo`) — a retrieval heuristic surfacing candidates; precision is M3/M5's job.
- **Direct callers only** (depth 1).

## Vendored-dir exclusion (caught while dogfooding)
`.venv`/`__pycache__`/`node_modules`/`build`/... are excluded from the caller scan — otherwise they dwarf *and sort ahead of* the source tree and would consume the entire budget on a real repo.

## Test plan
- [x] `pytest -q` — 225 pass. Acceptance (`test_context.py`): a changed function's definition + its two in-repo callers retrieved; call-site budget truncates and flags; innermost-nesting picks the method not the class; deleted/non-source files skipped; vendored dirs not scanned; persistence round-trip.
- [x] **Dogfooded end to end on this repo**: retrieving `parse_task_file` found its definition (lines 42–60) and **all 17 real call sites** across `src/` and `tests/`, each tagged with its enclosing function (71 files scanned, `.venv` excluded, no truncation).
- [x] `ruff check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)