### PR TITLE
M2.3: working-tree mode (§5.1)

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,10 +1,10 @@
 # Task
-For each changed code region, retrieve the enclosing definition and its direct in-repo call sites, within a bounded retrieval budget.
+Analyze uncommitted working-tree changes against a base revision, so the checker works before a PR or commit exists (§5.1).
 
 ## Constraints
-- Find the innermost function/class/method definition that encloses each changed line, via Python AST parsing.
-- Retrieve direct call sites of each changed definition elsewhere in the repo.
-- Respect a configurable budget cap (files scanned, call sites per definition); mark results truncated when the cap is hit rather than scanning unbounded.
+- A dirty working tree (staged and/or unstaged changes, no head commit required) must produce the same ChangeSet shape M2.1 produces for a committed diff.
+- Untracked new files must be detected as added files, not silently ignored.
+- Do not require a head commit to exist.
 
 ## Completion expectations
 - Implementation

--- a/src/acceptance/change/diff.py
+++ b/src/acceptance/change/diff.py
@@ -1,9 +1,19 @@
-"""Revision & diff extraction (M2.1).
+"""Revision & diff extraction (M2.1) and working-tree mode (M2.3, §5.1).
 
-Extracts the structural Git change set between two revisions: which files
-changed, how (added/modified/deleted/renamed), what they are (source/test/
-config/other), and their hunk-level diffs. Pure `git` plumbing — no LLM call,
-since this is structural, not semantic (§13.3 Git change analysis).
+Extracts the structural Git change set between two revisions — or between a
+base revision and the current working tree, so the checker works before a PR
+or commit exists — into the same shape: which files changed, how (added/
+modified/deleted/renamed), what they are (source/test/config/other), and
+their hunk-level diffs. Pure `git` plumbing — no LLM call, since this is
+structural, not semantic (§13.3 Git change analysis).
+
+Working-tree mode limitation: `git diff` never shows untracked files, so they
+are detected separately (`git ls-files --others`) and read directly rather
+than diffed. This means a rename done via plain `mv` (not staged with
+`git mv`) is seen as a deletion plus a separate untracked addition, not a
+rename — untracked files can't participate in git's similarity-based rename
+detection. A staged rename (`git mv`, or `mv` + `git add`) is detected
+correctly, same as a committed one.
 """
 
 from __future__ import annotations
@@ -13,6 +23,8 @@ import subprocess
 from pathlib import Path
 
 from acceptance.review_state import ChangeSet, DiffHunk, FileChange
+
+WORKING_TREE_SENTINEL = "<working-tree>"
 
 _TEST_PATH_RE = re.compile(r"(^|/)tests?/|(^|/)test_[^/]+\.py$|_test\.py$")
 _CONFIG_NAMES = {
@@ -42,8 +54,22 @@ def extract_change_set(repo: Path, base: str, head: str) -> ChangeSet:
     """Extract the structural change set between `base` and `head` in `repo`."""
     entries = _parse_name_status(_git(repo, "diff", "--name-status", "-M", base, head))
     blocks = _split_file_blocks(_git(repo, "diff", "-U3", base, head))
+    return ChangeSet(
+        base_revision=base, head_revision=head, files=_build_files(entries, blocks)
+    )
 
-    files = [
+
+def extract_working_tree_change_set(repo: Path, base: str) -> ChangeSet:
+    """Extract the change set between `base` and the current working tree
+    (staged + unstaged + untracked) — no head commit required (§5.1)."""
+    entries = _parse_name_status(_git(repo, "diff", "--name-status", "-M", base))
+    blocks = _split_file_blocks(_git(repo, "diff", "-U3", base))
+    files = _build_files(entries, blocks) + _untracked_file_changes(repo)
+    return ChangeSet(base_revision=base, head_revision=WORKING_TREE_SENTINEL, files=files)
+
+
+def _build_files(entries: list[dict], blocks: dict[str, str]) -> list[FileChange]:
+    return [
         FileChange(
             path=entry["path"],
             status=entry["status"],
@@ -53,7 +79,44 @@ def extract_change_set(repo: Path, base: str, head: str) -> ChangeSet:
         )
         for entry in entries
     ]
-    return ChangeSet(base_revision=base, head_revision=head, files=files)
+
+
+def _untracked_file_changes(repo: Path) -> list[FileChange]:
+    """Untracked files as synthetic all-added FileChanges — git diff can't
+    diff a file it doesn't know about, so these are read directly."""
+    changes = []
+    for path in _git(repo, "ls-files", "--others", "--exclude-standard").splitlines():
+        if not path.strip():
+            continue
+        try:
+            content = (repo / path).read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        changes.append(
+            FileChange(
+                path=path,
+                status="added",
+                category=_categorize(path),
+                hunks=_whole_file_hunk(content),
+            )
+        )
+    return changes
+
+
+def _whole_file_hunk(content: str) -> list[DiffHunk]:
+    lines = content.splitlines()
+    if not lines:
+        return []
+    return [
+        DiffHunk(
+            header=f"@@ -0,0 +1,{len(lines)} @@",
+            old_start=0,
+            old_lines=0,
+            new_start=1,
+            new_lines=len(lines),
+            content="\n".join(f"+{line}" for line in lines),
+        )
+    ]
 
 
 def _categorize(path: str) -> str:

--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -20,7 +20,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from acceptance.change.diff import extract_change_set
+from acceptance.change.diff import extract_change_set, extract_working_tree_change_set
 from acceptance.config import DEFAULT_MODEL, RunConfig
 from acceptance.llm import LLMError, Mode
 from acceptance.report import render_report
@@ -121,16 +121,22 @@ def render_decomposition(result: Decomposition) -> str:
     return "\n".join(lines)
 
 
-def run_diff(repo: str, base: str, head: str) -> ChangeSet:
-    """Extract the structural change set between two revisions (M2.1)."""
+def run_diff(repo: str, base: str, head: str | None) -> ChangeSet:
+    """Extract the structural change set (M2.1), or against the working tree
+    when `head` is omitted (M2.3, §5.1 — works before a PR/commit exists)."""
     repo_path = Path(repo)
     base_sha = _resolve_revision(base, repo=repo_path)
+    if head is None:
+        return extract_working_tree_change_set(repo_path, base_sha)
     head_sha = _resolve_revision(head, repo=repo_path)
     return extract_change_set(repo_path, base_sha, head_sha)
 
 
 def render_change_set(change_set: ChangeSet) -> str:
-    lines = [f"Files changed ({len(change_set.files)}):"]
+    lines = [
+        f"Base: {change_set.base_revision}  Head: {change_set.head_revision}",
+        f"Files changed ({len(change_set.files)}):",
+    ]
     if not change_set.files:
         lines.append("  (none)")
     for f in change_set.files:
@@ -192,7 +198,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     diff.add_argument("--repo", default=".", help="Path to the Git repo (default: here).")
     diff.add_argument("--base", required=True, help="Base Git revision.")
-    diff.add_argument("--head", required=True, help="Head Git revision.")
+    diff.add_argument(
+        "--head",
+        default=None,
+        help="Head Git revision. Omit to diff against the working tree (§5.1).",
+    )
     diff.add_argument(
         "--json",
         action="store_true",

--- a/tests/change/test_working_tree.py
+++ b/tests/change/test_working_tree.py
@@ -1,0 +1,175 @@
+"""M2.3 acceptance: a dirty working tree produces the same change-set shape
+as a committed diff (§5.1 — works before a PR exists)."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from acceptance.change.diff import (
+    WORKING_TREE_SENTINEL,
+    extract_change_set,
+    extract_working_tree_change_set,
+)
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+
+def _commit(repo: Path, message: str) -> str:
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", message)
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path) -> Path:
+    path = tmp_path / "repo"
+    path.mkdir()
+    _git(path, "init", "-q")
+    _git(path, "config", "user.email", "test@example.com")
+    _git(path, "config", "user.name", "Test")
+    return path
+
+
+def _shape(change_set):
+    """(path, status, category) per file, ignoring revision identity — the
+    comparable "shape" the acceptance check is about."""
+    return sorted((f.path, f.status, f.category) for f in change_set.files)
+
+
+def test_dirty_working_tree_matches_committed_diff_shape(tmp_path, repo):
+    (repo / "tests").mkdir()
+    (repo / "pkg.py").write_text("def f():\n    return 1\n")
+    (repo / "tests" / "test_pkg.py").write_text("def test_f():\n    assert True\n")
+    (repo / "requirements.txt").write_text("requests==2.0\n")
+    base = _commit(repo, "base")
+
+    # Make the same edits in two separate checkouts of the same base: one left
+    # uncommitted (working-tree mode), one committed (M2.1 mode).
+    working_repo = repo
+    (working_repo / "pkg.py").write_text("def f():\n    return 2\n")
+    (working_repo / "tests" / "test_pkg.py").write_text(
+        "def test_f():\n    assert True\n\n\ndef test_g():\n    assert True\n"
+    )
+    (working_repo / "requirements.txt").write_text("requests==3.0\n")
+    # Stage one file and leave the others unstaged, to prove both are included.
+    _git(working_repo, "add", "pkg.py")
+
+    working_tree_result = extract_working_tree_change_set(working_repo, base)
+
+    committed_repo = tmp_path / "committed"
+    subprocess.run(["git", "clone", "-q", str(repo), str(committed_repo)], check=True, capture_output=True)
+    _git(committed_repo, "checkout", "-q", base)
+    (committed_repo / "pkg.py").write_text("def f():\n    return 2\n")
+    (committed_repo / "tests" / "test_pkg.py").write_text(
+        "def test_f():\n    assert True\n\n\ndef test_g():\n    assert True\n"
+    )
+    (committed_repo / "requirements.txt").write_text("requests==3.0\n")
+    head = _commit(committed_repo, "head")
+    committed_result = extract_change_set(committed_repo, base, head)
+
+    assert _shape(working_tree_result) == _shape(committed_result)
+    # Every file has real hunks in both modes.
+    for result in (working_tree_result, committed_result):
+        for file_change in result.files:
+            assert file_change.hunks
+
+    assert working_tree_result.head_revision == WORKING_TREE_SENTINEL
+    assert working_tree_result.base_revision == base
+
+
+def test_untracked_new_file_is_detected_as_added(repo):
+    (repo / "pkg.py").write_text("x = 1\n")
+    base = _commit(repo, "base")
+
+    (repo / "new_module.py").write_text("y = 2\nz = 3\n")
+
+    change_set = extract_working_tree_change_set(repo, base)
+
+    assert len(change_set.files) == 1
+    added = change_set.files[0]
+    assert added.path == "new_module.py"
+    assert added.status == "added"
+    assert added.category == "source"
+    assert added.hunks
+    assert "+y = 2" in added.hunks[0].content
+    assert "+z = 3" in added.hunks[0].content
+
+
+def test_staged_and_unstaged_changes_are_both_included(repo):
+    (repo / "a.py").write_text("a = 1\n")
+    (repo / "b.py").write_text("b = 1\n")
+    base = _commit(repo, "base")
+
+    (repo / "a.py").write_text("a = 2\n")
+    _git(repo, "add", "a.py")  # staged
+    (repo / "b.py").write_text("b = 2\n")  # unstaged
+
+    change_set = extract_working_tree_change_set(repo, base)
+
+    paths = {f.path for f in change_set.files}
+    assert paths == {"a.py", "b.py"}
+
+
+def test_no_commits_after_base_are_required(repo):
+    """Working-tree mode never needs a head commit — only uncommitted state."""
+    (repo / "pkg.py").write_text("x = 1\n")
+    base = _commit(repo, "base")
+    (repo / "pkg.py").write_text("x = 2\n")
+
+    change_set = extract_working_tree_change_set(repo, base)
+
+    assert change_set.head_revision == WORKING_TREE_SENTINEL
+    assert len(change_set.files) == 1
+
+
+def test_deleted_file_in_working_tree_is_detected(repo):
+    (repo / "gone.py").write_text("x = 1\n")
+    base = _commit(repo, "base")
+    (repo / "gone.py").unlink()
+
+    change_set = extract_working_tree_change_set(repo, base)
+
+    assert len(change_set.files) == 1
+    assert change_set.files[0].status == "deleted"
+    assert change_set.files[0].path == "gone.py"
+
+
+def test_unstaged_plain_mv_is_not_detected_as_a_rename(repo):
+    """Documented limitation: an untracked rename (mv without git add/git mv)
+    is seen as a deletion + a separate untracked addition."""
+    (repo / "old_name.py").write_text("x = 1\n")
+    base = _commit(repo, "base")
+    (repo / "old_name.py").rename(repo / "new_name.py")
+
+    change_set = extract_working_tree_change_set(repo, base)
+
+    statuses = {f.path: f.status for f in change_set.files}
+    assert statuses == {"old_name.py": "deleted", "new_name.py": "added"}
+
+
+def test_staged_rename_is_detected_correctly(repo):
+    (repo / "old_name.py").write_text("x = 1\ny = 2\nz = 3\n")
+    base = _commit(repo, "base")
+    _git(repo, "mv", "old_name.py", "new_name.py")
+
+    change_set = extract_working_tree_change_set(repo, base)
+
+    assert len(change_set.files) == 1
+    renamed = change_set.files[0]
+    assert renamed.status == "renamed"
+    assert renamed.path == "new_name.py"
+    assert renamed.old_path == "old_name.py"
+
+
+def test_no_changes_yields_empty_change_set(repo):
+    (repo / "pkg.py").write_text("x = 1\n")
+    base = _commit(repo, "base")
+
+    change_set = extract_working_tree_change_set(repo, base)
+    assert change_set.files == []


### PR DESCRIPTION
Closes #19

## Summary
`extract_working_tree_change_set(repo, base)` diffs base against the current working tree (staged + unstaged) via `git diff <base>` (no head arg), producing the **same** `ChangeSet`/`FileChange`/`DiffHunk` shape as a committed diff (M2.1) — so the checker works before a PR or commit exists (§5.1). `head_revision` is set to a `WORKING_TREE_SENTINEL` since there's no commit to point at.

- **Untracked files**: `git diff` never shows them, so they're found via `git ls-files --others --exclude-standard` and read directly into a synthetic all-added `FileChange`/`DiffHunk` rather than diffed.
- **Documented limitation**: an untracked rename (`mv` without `git add`/`git mv`) shows as a deletion + a separate untracked addition, not a rename — untracked files can't participate in git's similarity-based rename detection. A staged rename (`git mv`) is detected correctly, same as committed.
- **`acceptance diff --head` is now optional** — omit it for working-tree mode, reusing the same subcommand.

## Test plan
- [x] `pytest -q` — 233 pass. Acceptance (`test_working_tree.py`): the same edits made two ways (left uncommitted vs. committed to a real head) produce the **identical change-set shape** (path/status/category), real hunks on both sides. Plus untracked-file detection, staged+unstaged both included, no head commit required, deleted-file detection, the rename limitation, and a staged rename detected correctly.
- [x] **Dogfooded on this repo's own uncommitted M2.3 changes**: `acceptance diff --base main` (no `--head`) correctly found all 4 uncommitted files, including the new untracked test file detected as `added`.
- [x] `ruff check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)