### PR TITLE
M3.1: obligation-to-diff classification (§9.2)

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,10 +1,10 @@
 # Task
-Analyze uncommitted working-tree changes against a base revision, so the checker works before a PR or commit exists (§5.1).
+Classify each obligation against the diff — Addressed / Partially addressed / Not addressed / Unclear / Requires-non-code-evidence — linking each to the specific diff regions that address it, or explicitly recording that none do.
 
 ## Constraints
-- A dirty working tree (staged and/or unstaged changes, no head commit required) must produce the same ChangeSet shape M2.1 produces for a committed diff.
-- Untracked new files must be detected as added files, not silently ignored.
-- Do not require a head commit to exist.
+- This is implementation-coverage only: whether the code changed to address the obligation. It does not prove the obligation works; passing-test evidence is a separate axis (M4/M5) and must not be conflated here.
+- Every classification links to exact diff regions (file + hunk) or explicitly records "no corresponding change."
+- Produce classifications through a schema-constrained model call recorded for replay; capability tests run off the recorded transcript with no live calls.
 
 ## Completion expectations
 - Implementation

--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -22,9 +22,10 @@ from pathlib import Path
 
 from acceptance.change.diff import extract_change_set, extract_working_tree_change_set
 from acceptance.config import DEFAULT_MODEL, RunConfig
+from acceptance.coverage.classify import ImplementationCoverage, classify_coverage
 from acceptance.llm import LLMError, Mode
 from acceptance.report import render_report
-from acceptance.requirement.obligations import Decomposition, decompose
+from acceptance.requirement.obligations import Decomposition, Obligation, decompose
 from acceptance.requirement.task_file import parse_task_file
 from acceptance.review_state import ChangeSet, Review
 from acceptance.review_store import ReviewStore
@@ -149,6 +150,40 @@ def render_change_set(change_set: ChangeSet) -> str:
     return "\n".join(lines)
 
 
+def run_classify(
+    task: str, base: str, head: str | None, config: RunConfig, repo: str = "."
+) -> tuple[list[Obligation], list[ImplementationCoverage]]:
+    """Decompose a task, extract its change set, and classify each obligation
+    against the diff — a live end-to-end dogfood of M1 + M2 + M3.1."""
+    repo_path = Path(repo)
+    parsed = parse_task_file(_read_task(task))
+    obligations = decompose(parsed, config.build_client()).obligations
+
+    base_sha = _resolve_revision(base, repo=repo_path)
+    if head is None:
+        change_set = extract_working_tree_change_set(repo_path, base_sha)
+    else:
+        head_sha = _resolve_revision(head, repo=repo_path)
+        change_set = extract_change_set(repo_path, base_sha, head_sha)
+
+    coverages = classify_coverage(obligations, change_set, config.build_client())
+    return obligations, coverages
+
+
+def render_coverage(
+    obligations: list[Obligation], coverages: list[ImplementationCoverage]
+) -> str:
+    descriptions = {o.id: o.description for o in obligations}
+    lines = ["Implementation coverage (code only — not test evidence):"]
+    if not coverages:
+        lines.append("  (none)")
+    for cov in coverages:
+        refs = ", ".join(f"{r.file}" for r in cov.diff_refs) or "no corresponding change"
+        lines.append(f"  [{cov.status.value}] {cov.obligation_id}: {descriptions.get(cov.obligation_id, '')}")
+        lines.append(f"      -> {refs}")
+    return "\n".join(lines)
+
+
 def _add_model_flags(parser: argparse.ArgumentParser, default_mode: str) -> None:
     parser.add_argument(
         "--model",
@@ -209,6 +244,26 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit the structured ChangeSet as JSON.",
     )
 
+    classify = subparsers.add_parser(
+        "classify",
+        help="Decompose a task, diff a change, and classify each obligation "
+        "against the diff (implementation coverage, live).",
+    )
+    classify.add_argument("--task", required=True, help="Path to the task file.")
+    classify.add_argument("--repo", default=".", help="Path to the Git repo (default: here).")
+    classify.add_argument("--base", required=True, help="Base Git revision.")
+    classify.add_argument(
+        "--head",
+        default=None,
+        help="Head Git revision. Omit to use the working tree (§5.1).",
+    )
+    _add_model_flags(classify, default_mode=Mode.RECORD.value)
+    classify.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the structured coverage classifications as JSON.",
+    )
+
     return parser
 
 
@@ -265,6 +320,29 @@ def main(argv: list[str] | None = None) -> int:
             print(json.dumps(change_set.to_dict(), indent=2))
         else:
             print(render_change_set(change_set))
+        return 0
+
+    if args.command == "classify":
+        config = RunConfig(
+            model=args.model,
+            mode=Mode(args.mode),
+            seed=args.seed,
+            temperature=args.temperature,
+        )
+        try:
+            obligations, coverages = run_classify(
+                args.task, args.base, args.head, config, args.repo
+            )
+        except CliError as exc:
+            print(f"acceptance: error: {exc}", file=sys.stderr)
+            return 1
+        except LLMError as exc:
+            print(f"acceptance: model error: {exc}", file=sys.stderr)
+            return 1
+        if args.json:
+            print(json.dumps([c.to_dict() for c in coverages], indent=2))
+        else:
+            print(render_coverage(obligations, coverages))
         return 0
 
     parser.error(f"unknown command: {args.command}")

--- a/src/acceptance/coverage/__init__.py
+++ b/src/acceptance/coverage/__init__.py
@@ -1,0 +1,1 @@
+"""Implementation-coverage analysis: obligations x diff -> classification (M3)."""

--- a/src/acceptance/coverage/classify.py
+++ b/src/acceptance/coverage/classify.py
@@ -1,0 +1,153 @@
+"""Obligation-to-diff classification (M3.1, §9.2 implementation-coverage review).
+
+Classifies each obligation against the diff: does the changed code contain a
+credible response to it? This is IMPLEMENTATION coverage only — it finds likely
+incompleteness before acceptance; it does NOT prove the obligation works. That
+is a separate axis: discriminating passing-test evidence (M4/M5, graded by the
+§9.3 evidence classes and §8.1 evidence tiers). "Addressed" here means "the
+code addresses it", never "the obligation is satisfied". It is also distinct
+from M8's execution coverage (whether a test reaches the code).
+
+Classification is a semantic judgment, so it is a schema-constrained model call
+through the M0.4 harness — recorded for replay, never a live call in tests.
+Each result links to the exact diff hunks that address the obligation, or
+records that none do (empty diff_refs = "no corresponding change").
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from acceptance.llm import ModelClient
+from acceptance.model_base import PersistableModel
+from acceptance.review_state import ChangeSet, Obligation
+
+
+class CoverageStatus(str, Enum):
+    """§9.2 implementation-coverage classifications."""
+
+    ADDRESSED = "addressed"
+    PARTIALLY_ADDRESSED = "partially_addressed"
+    NOT_ADDRESSED = "not_addressed"
+    UNCLEAR = "unclear"
+    REQUIRES_NON_CODE_EVIDENCE = "requires_non_code_evidence"
+
+
+class DiffRef(PersistableModel):
+    """A link to a specific changed region (file + hunk header)."""
+
+    file: str
+    hunk_header: str
+
+
+class ImplementationCoverage(PersistableModel):
+    """How the diff covers one obligation (implementation only, not test evidence)."""
+
+    obligation_id: str
+    status: CoverageStatus
+    rationale: str
+    diff_refs: list[DiffRef] = Field(default_factory=list)
+
+
+_SYSTEM_PROMPT = """\
+You classify how a code diff addresses each acceptance obligation. This is
+IMPLEMENTATION coverage only — whether the changed code responds to the
+obligation. Do NOT judge whether it is tested or correct; that is assessed
+separately.
+
+For each obligation return a `status`:
+- addressed: the diff contains a credible, complete code response.
+- partially_addressed: relevant behavior is present in the diff but a
+  qualifier, branch, condition, or case is missing.
+- not_addressed: no diff region responds to the obligation at all.
+- unclear: the change may be indirect and static evidence is insufficient.
+- requires_non_code_evidence: satisfying it needs docs, visual behavior, or
+  deploy config rather than code.
+
+Also return a short `rationale` and `diff_refs`: the labels (like `path#0`) of
+the hunks that address the obligation. For not_addressed, `diff_refs` MUST be
+empty. Link only hunks that genuinely respond to the obligation."""
+
+
+class _Classification(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    obligation_id: str
+    status: CoverageStatus
+    rationale: str
+    diff_refs: list[str]
+
+
+class _Coverage(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    classifications: list[_Classification]
+
+
+def classify_coverage(
+    obligations: list[Obligation], change_set: ChangeSet, client: ModelClient
+) -> list[ImplementationCoverage]:
+    """Classify each obligation against the change set (implementation coverage)."""
+    label_to_ref = _hunk_labels(change_set)
+    messages = [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {"role": "user", "content": _render_prompt(obligations, change_set, label_to_ref)},
+    ]
+    result = client.complete(messages, _Coverage)
+
+    by_id = {c.obligation_id: c for c in result.classifications}
+    coverages = []
+    for obligation in obligations:
+        classification = by_id.get(obligation.id)
+        if classification is None:
+            coverages.append(
+                ImplementationCoverage(
+                    obligation_id=obligation.id,
+                    status=CoverageStatus.UNCLEAR,
+                    rationale="No classification was returned for this obligation.",
+                )
+            )
+            continue
+        refs = [label_to_ref[label] for label in classification.diff_refs if label in label_to_ref]
+        coverages.append(
+            ImplementationCoverage(
+                obligation_id=obligation.id,
+                status=classification.status,
+                rationale=classification.rationale,
+                diff_refs=refs,
+            )
+        )
+    return coverages
+
+
+def _hunk_labels(change_set: ChangeSet) -> dict[str, DiffRef]:
+    labels: dict[str, DiffRef] = {}
+    for file_change in change_set.files:
+        for index, hunk in enumerate(file_change.hunks):
+            labels[f"{file_change.path}#{index}"] = DiffRef(
+                file=file_change.path, hunk_header=hunk.header
+            )
+    return labels
+
+
+def _render_prompt(
+    obligations: list[Obligation], change_set: ChangeSet, label_to_ref: dict[str, DiffRef]
+) -> str:
+    lines = ["## Obligations", ""]
+    for obligation in obligations:
+        lines.append(f"- id={obligation.id} [{obligation.type.value}]: {obligation.description}")
+    lines.append("")
+    lines.append("## Diff")
+    if not change_set.files:
+        lines.append("(no changes)")
+    for file_change in change_set.files:
+        lines.append("")
+        lines.append(f"### {file_change.path} ({file_change.status}, {file_change.category})")
+        if not file_change.hunks:
+            lines.append("(no hunks)")
+        for index, hunk in enumerate(file_change.hunks):
+            lines.append(f"[{file_change.path}#{index}] {hunk.header}")
+            lines.append(hunk.content)
+    return "\n".join(lines)

--- a/tests/coverage/test_classify.py
+++ b/tests/coverage/test_classify.py
@@ -1,0 +1,191 @@
+"""M3.1 acceptance: archetype #1 -> missing instruction classified Not
+addressed; #2 -> missing qualifier classified Partially addressed; both link to
+exact code or record "no corresponding change".
+
+Classification is a schema-constrained model call; per the replay-first
+invariant these tests inject the recorded response (a hand-authored fixture)
+via completion_fn — no live calls. The response is what a good model returns;
+the test verifies the pipeline turns it into ImplementationCoverage with real
+diff-region links. Classification *accuracy* is measured by the benchmark (M3.3).
+"""
+
+import json
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+from acceptance.change.diff import extract_change_set
+from acceptance.benchmark.fixtures import materialize_archetype
+from acceptance.coverage.classify import (
+    CoverageStatus,
+    ImplementationCoverage,
+    classify_coverage,
+)
+from acceptance.llm import Mode, ModelClient, TranscriptStore
+from acceptance.review_state import ChangeSet, Obligation, ObligationType
+
+ARCHETYPES = Path(__file__).resolve().parents[1] / "fixtures" / "archetypes"
+
+
+def _client_returning(response: dict) -> ModelClient:
+    def completion_fn(**kwargs):
+        content = json.dumps(response)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+
+    return ModelClient(
+        model="anthropic/claude-sonnet-5",
+        mode=Mode.RECORD,
+        store=TranscriptStore(tempfile.mkdtemp()),
+        completion_fn=completion_fn,
+    )
+
+
+def _obligation(obligation_id: str, description: str, typ: ObligationType) -> Obligation:
+    return Obligation(
+        id=obligation_id,
+        description=description,
+        type=typ,
+        importance="critical",
+        explicit=True,
+        observable_behavior="...",
+    )
+
+
+def _archetype_change_set(name: str, tmp_path: Path) -> ChangeSet:
+    fixture = materialize_archetype(ARCHETYPES / name, tmp_path / "repo")
+    return extract_change_set(fixture.repo_path, fixture.base_sha, fixture.head_sha)
+
+
+def _source_file(change_set: ChangeSet, suffix: str) -> str:
+    return next(f.path for f in change_set.files if f.path.endswith(suffix))
+
+
+def test_archetype_1_missing_instruction_is_not_addressed(tmp_path):
+    change_set = _archetype_change_set("01-missed-obligation", tmp_path)
+    receipt = _source_file(change_set, "receipt.py")
+
+    obligations = [
+        _obligation("show-fields", "Show item name, quantity, unit price", ObligationType.FUNCTIONAL),
+        _obligation(
+            "returns-in-parens",
+            "Show negative-quantity returns in parentheses",
+            ObligationType.BOUNDARY,
+        ),
+    ]
+    response = {
+        "classifications": [
+            {
+                "obligation_id": "show-fields",
+                "status": "addressed",
+                "rationale": "format_line renders name/qty/price.",
+                "diff_refs": [f"{receipt}#0"],
+            },
+            {
+                "obligation_id": "returns-in-parens",
+                "status": "not_addressed",
+                "rationale": "No code handles negative quantities.",
+                "diff_refs": [],
+            },
+        ]
+    }
+
+    coverages = classify_coverage(obligations, change_set, _client_returning(response))
+    by_id = {c.obligation_id: c for c in coverages}
+
+    # The missing instruction is Not addressed, with no corresponding change.
+    assert by_id["returns-in-parens"].status == CoverageStatus.NOT_ADDRESSED
+    assert by_id["returns-in-parens"].diff_refs == []
+    # The addressed one links to an exact hunk in a real file.
+    assert by_id["show-fields"].status == CoverageStatus.ADDRESSED
+    assert by_id["show-fields"].diff_refs
+    assert by_id["show-fields"].diff_refs[0].file == receipt
+    assert by_id["show-fields"].diff_refs[0].hunk_header.startswith("@@")
+
+
+def test_archetype_2_missing_qualifier_is_partially_addressed(tmp_path):
+    change_set = _archetype_change_set("02-qualifier-missed", tmp_path)
+    pricing = _source_file(change_set, "pricing.py")
+
+    obligations = [
+        _obligation(
+            "parse-symbol", "Parse a leading currency symbol to ISO", ObligationType.FUNCTIONAL
+        ),
+        _obligation(
+            "backward-compat",
+            "Plain numeric strings keep working and default to USD",
+            ObligationType.COMPATIBILITY,
+        ),
+    ]
+    response = {
+        "classifications": [
+            {
+                "obligation_id": "parse-symbol",
+                "status": "addressed",
+                "rationale": "SYMBOLS maps the prefix to an ISO code.",
+                "diff_refs": [f"{pricing}#0"],
+            },
+            {
+                "obligation_id": "backward-compat",
+                "status": "partially_addressed",
+                "rationale": "parse_price was changed but the no-symbol branch is missing.",
+                "diff_refs": [f"{pricing}#0"],
+            },
+        ]
+    }
+
+    coverages = classify_coverage(obligations, change_set, _client_returning(response))
+    by_id = {c.obligation_id: c for c in coverages}
+
+    # The missing qualifier is Partially addressed (relevant behavior present,
+    # a branch missing) — and links to the exact code that is incomplete.
+    assert by_id["backward-compat"].status == CoverageStatus.PARTIALLY_ADDRESSED
+    assert by_id["backward-compat"].diff_refs
+    assert by_id["backward-compat"].diff_refs[0].file == pricing
+
+
+def test_missing_classification_defaults_to_unclear(tmp_path):
+    change_set = _archetype_change_set("01-missed-obligation", tmp_path)
+    obligations = [_obligation("only", "Some obligation", ObligationType.FUNCTIONAL)]
+    # Model returned no classification for this obligation.
+    coverages = classify_coverage(obligations, change_set, _client_returning({"classifications": []}))
+
+    assert len(coverages) == 1
+    assert coverages[0].status == CoverageStatus.UNCLEAR
+
+
+def test_unknown_hunk_labels_are_dropped(tmp_path):
+    change_set = _archetype_change_set("01-missed-obligation", tmp_path)
+    obligations = [_obligation("x", "obligation", ObligationType.FUNCTIONAL)]
+    response = {
+        "classifications": [
+            {
+                "obligation_id": "x",
+                "status": "addressed",
+                "rationale": "...",
+                "diff_refs": ["nonexistent.py#7"],  # not a real hunk
+            }
+        ]
+    }
+    coverages = classify_coverage(obligations, change_set, _client_returning(response))
+    assert coverages[0].diff_refs == []  # unknown label dropped, not crashed
+
+
+def test_coverage_round_trips_through_persistence(tmp_path):
+    change_set = _archetype_change_set("01-missed-obligation", tmp_path)
+    receipt = _source_file(change_set, "receipt.py")
+    obligations = [_obligation("show-fields", "Show fields", ObligationType.FUNCTIONAL)]
+    response = {
+        "classifications": [
+            {
+                "obligation_id": "show-fields",
+                "status": "addressed",
+                "rationale": "ok",
+                "diff_refs": [f"{receipt}#0"],
+            }
+        ]
+    }
+    coverage = classify_coverage(obligations, change_set, _client_returning(response))[0]
+    assert ImplementationCoverage.from_dict(coverage.to_dict()) == coverage

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -220,3 +220,46 @@ def test_render_decomposition_lists_obligations_and_open_questions():
     rendered = render_decomposition(result)
     assert "[functional/explicit] ob-1: Do the thing." in rendered
     assert "? q-1: How many?" in rendered
+
+
+# --- classify subcommand (M3.1 dogfood path) ---
+
+def test_classify_replay_without_transcript_fails_cleanly(
+    fixture_task_path, git_repo, monkeypatch, capsys
+):
+    # REPLAY with no transcript: the first live call (decompose) can't replay.
+    monkeypatch.chdir(git_repo["path"])
+    exit_code = main(
+        ["classify", "--task", fixture_task_path, "--base", git_repo["base"],
+         "--head", git_repo["head"], "--mode", "replay"]
+    )
+    assert exit_code == 1
+    assert "model error" in capsys.readouterr().err
+
+
+def test_render_coverage_output():
+    from acceptance.cli import render_coverage
+    from acceptance.coverage.classify import CoverageStatus, DiffRef, ImplementationCoverage
+    from acceptance.review_state import Obligation, ObligationType
+
+    obligations = [
+        Obligation(id="ob-1", description="Do the thing.", type=ObligationType.FUNCTIONAL,
+                   importance="critical", explicit=True, observable_behavior="..."),
+        Obligation(id="ob-2", description="Handle the edge.", type=ObligationType.BOUNDARY,
+                   importance="normal", explicit=True, observable_behavior="..."),
+    ]
+    coverages = [
+        ImplementationCoverage(
+            obligation_id="ob-1", status=CoverageStatus.ADDRESSED, rationale="done",
+            diff_refs=[DiffRef(file="pkg.py", hunk_header="@@ -1 +1 @@")],
+        ),
+        ImplementationCoverage(
+            obligation_id="ob-2", status=CoverageStatus.NOT_ADDRESSED, rationale="missing",
+        ),
+    ]
+
+    rendered = render_coverage(obligations, coverages)
+    assert "[addressed] ob-1: Do the thing." in rendered
+    assert "pkg.py" in rendered
+    assert "[not_addressed] ob-2: Handle the edge." in rendered
+    assert "no corresponding change" in rendered


### PR DESCRIPTION
Closes #20

## Summary
New `src/acceptance/coverage/classify.py`: `classify_coverage(obligations, change_set, client)` classifies each obligation against the diff — **Addressed / Partially addressed / Not addressed / Unclear / Requires-non-code-evidence** — each linked to the exact diff hunks that address it, or empty `diff_refs` for "no corresponding change". Schema-constrained model call; recorded for replay, no live calls in tests.

## Implementation coverage is only one axis
This is **implementation** coverage (§9.2) — whether the code responds to the obligation. It is a **separate axis from test evidence**: "Addressed" means the code addresses it, never that the obligation is *satisfied*. Full support additionally requires discriminating passing tests (M4/M5, §9.3 evidence classes and §8.1 tiers). The docstring/prompt make this explicit; it's also distinct from M8's execution coverage.

The §9.2 nuance the acceptance hinges on: **Not addressed** = no relevant code change at all; **Partially addressed** = relevant behavior present but a qualifier/branch missing.

`acceptance classify` added — decompose → diff → classify, live end-to-end (M1+M2+M3.1).

## Dogfood output (live)
Ran on this PR's own task + diff — the tool reviewing its own implementation:

```
Implementation coverage (code only — not test evidence):
  [addressed] classify-each-obligation-against-diff: ...
      -> src/acceptance/coverage/classify.py, src/acceptance/cli.py, ...
  ...
  [unclear] record-call-for-replay: ...
      -> current-task.md, tests/coverage/test_classify.py, tests/test_cli.py
  [addressed] use-recorded-transcript-offline: ...
```

8/9 of its own obligations classified Addressed (linked to the implementing hunks); `record-call-for-replay` correctly flagged **Unclear** — replay lives in the unchanged M0.4 harness, not this diff. A real, non-trivial judgment, not a rubber stamp.

## Test plan
- [x] `pytest -q` — 240 pass. Acceptance (`test_classify.py`): materializing archetypes #1/#2 and extracting real change sets, #1's returns-in-parens → Not addressed (empty diff_refs), #2's backward-compat → Partially addressed (links the real `parse_price` hunk). Plus missing→unclear, unknown-label drop, persistence round-trip. New `classify` CLI tests.
- [x] `ruff check .` — clean
- [x] Live dogfood: `decompose` + `diff` + new `classify` on this branch (output above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)