### PR TITLE
fix(test): set git identity on cloned repo (CI green)

### DIFF
--- a/tests/change/test_working_tree.py
+++ b/tests/change/test_working_tree.py
@@ -64,6 +64,10 @@ def test_dirty_working_tree_matches_committed_diff_shape(tmp_path, repo):
 
     committed_repo = tmp_path / "committed"
     subprocess.run(["git", "clone", "-q", str(repo), str(committed_repo)], check=True, capture_output=True)
+    # `git clone` does not copy local config, so the clone has no commit
+    # identity — set one explicitly (CI has no global/auto-detectable identity).
+    _git(committed_repo, "config", "user.email", "test@example.com")
+    _git(committed_repo, "config", "user.name", "Test")
     _git(committed_repo, "checkout", "-q", base)
     (committed_repo / "pkg.py").write_text("def f():\n    return 2\n")
     (committed_repo / "tests" / "test_pkg.py").write_text(


### PR DESCRIPTION
Fixes the CI failure introduced by M2.3 (#77).

## Root cause
`test_dirty_working_tree_matches_committed_diff_shape` clones the fixture repo and commits in the clone. `git clone` does not copy local config, so the clone had no commit identity. It passed locally because git filled in a global (or auto-detected `user@host`) identity; CI has neither, so `git commit` exited 128 ("unable to auto-detect email").

## Fix
Set `user.email`/`user.name` on the clone explicitly.

## Verification
Reproduced the CI condition locally with `GIT_CONFIG_GLOBAL` = a config containing `[user] useConfigOnly = true` (forbids auto-detect) + `GIT_CONFIG_SYSTEM=/dev/null`: the test failed before the fix, passes after. Ran the **whole suite** under that condition — 233 pass, confirming no other test has the same latent identity dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)