### PR TITLE
M3.2: unrequested-change detection (§9.2)

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,10 +1,10 @@
 # Task
-Classify each obligation against the diff — Addressed / Partially addressed / Not addressed / Unclear / Requires-non-code-evidence — linking each to the specific diff regions that address it, or explicitly recording that none do.
+Flag diff regions that no obligation calls for as candidate unrequested changes, giving extra weight to public-interface, dependency, and adjacent-behavior changes.
 
 ## Constraints
-- This is implementation-coverage only: whether the code changed to address the obligation. It does not prove the obligation works; passing-test evidence is a separate axis (M4/M5) and must not be conflated here.
-- Every classification links to exact diff regions (file + hunk) or explicitly records "no corresponding change."
-- Produce classifications through a schema-constrained model call recorded for replay; capability tests run off the recorded transcript with no live calls.
+- Report changes not required by any obligation as candidate unrequested changes, each linked to the specific diff regions.
+- Categorize each by nature (public-interface / dependency / adjacent-behavior / internal / other) so the notable ones stand out.
+- Produce the detection through a schema-constrained model call recorded for replay; capability tests run off the recorded transcript with no live calls.
 
 ## Completion expectations
 - Implementation

--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from acceptance.change.diff import extract_change_set, extract_working_tree_change_set
 from acceptance.config import DEFAULT_MODEL, RunConfig
 from acceptance.coverage.classify import ImplementationCoverage, classify_coverage
+from acceptance.coverage.unrequested import UnrequestedChange, detect_unrequested_changes
 from acceptance.llm import LLMError, Mode
 from acceptance.report import render_report
 from acceptance.requirement.obligations import Decomposition, Obligation, decompose
@@ -152,9 +153,10 @@ def render_change_set(change_set: ChangeSet) -> str:
 
 def run_classify(
     task: str, base: str, head: str | None, config: RunConfig, repo: str = "."
-) -> tuple[list[Obligation], list[ImplementationCoverage]]:
-    """Decompose a task, extract its change set, and classify each obligation
-    against the diff — a live end-to-end dogfood of M1 + M2 + M3.1."""
+) -> tuple[list[Obligation], list[ImplementationCoverage], list[UnrequestedChange]]:
+    """Decompose a task, extract its change set, classify each obligation against
+    the diff, and flag unrequested changes — a live end-to-end dogfood of
+    M1 + M2 + M3.1 + M3.2."""
     repo_path = Path(repo)
     parsed = parse_task_file(_read_task(task))
     obligations = decompose(parsed, config.build_client()).obligations
@@ -167,11 +169,14 @@ def run_classify(
         change_set = extract_change_set(repo_path, base_sha, head_sha)
 
     coverages = classify_coverage(obligations, change_set, config.build_client())
-    return obligations, coverages
+    unrequested = detect_unrequested_changes(obligations, change_set, config.build_client())
+    return obligations, coverages, unrequested
 
 
-def render_coverage(
-    obligations: list[Obligation], coverages: list[ImplementationCoverage]
+def render_classify(
+    obligations: list[Obligation],
+    coverages: list[ImplementationCoverage],
+    unrequested: list[UnrequestedChange],
 ) -> str:
     descriptions = {o.id: o.description for o in obligations}
     lines = ["Implementation coverage (code only — not test evidence):"]
@@ -180,6 +185,14 @@ def render_coverage(
     for cov in coverages:
         refs = ", ".join(f"{r.file}" for r in cov.diff_refs) or "no corresponding change"
         lines.append(f"  [{cov.status.value}] {cov.obligation_id}: {descriptions.get(cov.obligation_id, '')}")
+        lines.append(f"      -> {refs}")
+    lines.append("")
+    lines.append("Unrequested changes (no obligation calls for these):")
+    if not unrequested:
+        lines.append("  (none)")
+    for change in unrequested:
+        refs = ", ".join(f"{r.file}" for r in change.diff_refs) or "?"
+        lines.append(f"  [{change.kind.value}] {change.rationale}")
         lines.append(f"      -> {refs}")
     return "\n".join(lines)
 
@@ -330,7 +343,7 @@ def main(argv: list[str] | None = None) -> int:
             temperature=args.temperature,
         )
         try:
-            obligations, coverages = run_classify(
+            obligations, coverages, unrequested = run_classify(
                 args.task, args.base, args.head, config, args.repo
             )
         except CliError as exc:
@@ -340,9 +353,17 @@ def main(argv: list[str] | None = None) -> int:
             print(f"acceptance: model error: {exc}", file=sys.stderr)
             return 1
         if args.json:
-            print(json.dumps([c.to_dict() for c in coverages], indent=2))
+            print(
+                json.dumps(
+                    {
+                        "coverage": [c.to_dict() for c in coverages],
+                        "unrequested_changes": [u.to_dict() for u in unrequested],
+                    },
+                    indent=2,
+                )
+            )
         else:
-            print(render_coverage(obligations, coverages))
+            print(render_classify(obligations, coverages, unrequested))
         return 0
 
     parser.error(f"unknown command: {args.command}")

--- a/src/acceptance/coverage/classify.py
+++ b/src/acceptance/coverage/classify.py
@@ -20,9 +20,12 @@ from enum import Enum
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from acceptance.coverage.prompt import DiffRef, hunk_labels, render_diff_prompt, resolve_refs
 from acceptance.llm import ModelClient
 from acceptance.model_base import PersistableModel
 from acceptance.review_state import ChangeSet, Obligation
+
+__all__ = ["CoverageStatus", "DiffRef", "ImplementationCoverage", "classify_coverage"]
 
 
 class CoverageStatus(str, Enum):
@@ -33,13 +36,6 @@ class CoverageStatus(str, Enum):
     NOT_ADDRESSED = "not_addressed"
     UNCLEAR = "unclear"
     REQUIRES_NON_CODE_EVIDENCE = "requires_non_code_evidence"
-
-
-class DiffRef(PersistableModel):
-    """A link to a specific changed region (file + hunk header)."""
-
-    file: str
-    hunk_header: str
 
 
 class ImplementationCoverage(PersistableModel):
@@ -90,10 +86,10 @@ def classify_coverage(
     obligations: list[Obligation], change_set: ChangeSet, client: ModelClient
 ) -> list[ImplementationCoverage]:
     """Classify each obligation against the change set (implementation coverage)."""
-    label_to_ref = _hunk_labels(change_set)
+    label_to_ref = hunk_labels(change_set)
     messages = [
         {"role": "system", "content": _SYSTEM_PROMPT},
-        {"role": "user", "content": _render_prompt(obligations, change_set, label_to_ref)},
+        {"role": "user", "content": render_diff_prompt(obligations, change_set)},
     ]
     result = client.complete(messages, _Coverage)
 
@@ -110,7 +106,7 @@ def classify_coverage(
                 )
             )
             continue
-        refs = [label_to_ref[label] for label in classification.diff_refs if label in label_to_ref]
+        refs = resolve_refs(classification.diff_refs, label_to_ref)
         coverages.append(
             ImplementationCoverage(
                 obligation_id=obligation.id,
@@ -120,34 +116,3 @@ def classify_coverage(
             )
         )
     return coverages
-
-
-def _hunk_labels(change_set: ChangeSet) -> dict[str, DiffRef]:
-    labels: dict[str, DiffRef] = {}
-    for file_change in change_set.files:
-        for index, hunk in enumerate(file_change.hunks):
-            labels[f"{file_change.path}#{index}"] = DiffRef(
-                file=file_change.path, hunk_header=hunk.header
-            )
-    return labels
-
-
-def _render_prompt(
-    obligations: list[Obligation], change_set: ChangeSet, label_to_ref: dict[str, DiffRef]
-) -> str:
-    lines = ["## Obligations", ""]
-    for obligation in obligations:
-        lines.append(f"- id={obligation.id} [{obligation.type.value}]: {obligation.description}")
-    lines.append("")
-    lines.append("## Diff")
-    if not change_set.files:
-        lines.append("(no changes)")
-    for file_change in change_set.files:
-        lines.append("")
-        lines.append(f"### {file_change.path} ({file_change.status}, {file_change.category})")
-        if not file_change.hunks:
-            lines.append("(no hunks)")
-        for index, hunk in enumerate(file_change.hunks):
-            lines.append(f"[{file_change.path}#{index}] {hunk.header}")
-            lines.append(hunk.content)
-    return "\n".join(lines)

--- a/src/acceptance/coverage/prompt.py
+++ b/src/acceptance/coverage/prompt.py
@@ -1,0 +1,60 @@
+"""Shared prompt-building for the M3 coverage analyses.
+
+Both implementation-coverage classification (classify.py) and unrequested-change
+detection (unrequested.py) present the same thing to the model — the obligations
+and the diff with labeled hunks — and map the model's hunk labels back to
+`DiffRef`s. That shared machinery lives here so the two modules don't reach into
+each other's internals.
+"""
+
+from __future__ import annotations
+
+from acceptance.model_base import PersistableModel
+from acceptance.review_state import ChangeSet, Obligation
+
+
+class DiffRef(PersistableModel):
+    """A link to a specific changed region (file + hunk header)."""
+
+    file: str
+    hunk_header: str
+
+
+def hunk_label(path: str, index: int) -> str:
+    return f"{path}#{index}"
+
+
+def hunk_labels(change_set: ChangeSet) -> dict[str, DiffRef]:
+    """Map each `path#index` label to the DiffRef it identifies."""
+    labels: dict[str, DiffRef] = {}
+    for file_change in change_set.files:
+        for index, hunk in enumerate(file_change.hunks):
+            labels[hunk_label(file_change.path, index)] = DiffRef(
+                file=file_change.path, hunk_header=hunk.header
+            )
+    return labels
+
+
+def render_diff_prompt(obligations: list[Obligation], change_set: ChangeSet) -> str:
+    """Render obligations + the labeled diff for the model to reason over."""
+    lines = ["## Obligations", ""]
+    for obligation in obligations:
+        lines.append(f"- id={obligation.id} [{obligation.type.value}]: {obligation.description}")
+    lines.append("")
+    lines.append("## Diff")
+    if not change_set.files:
+        lines.append("(no changes)")
+    for file_change in change_set.files:
+        lines.append("")
+        lines.append(f"### {file_change.path} ({file_change.status}, {file_change.category})")
+        if not file_change.hunks:
+            lines.append("(no hunks)")
+        for index, hunk in enumerate(file_change.hunks):
+            lines.append(f"[{hunk_label(file_change.path, index)}] {hunk.header}")
+            lines.append(hunk.content)
+    return "\n".join(lines)
+
+
+def resolve_refs(labels: list[str], label_to_ref: dict[str, DiffRef]) -> list[DiffRef]:
+    """Map returned hunk labels back to DiffRefs, dropping unknown labels."""
+    return [label_to_ref[label] for label in labels if label in label_to_ref]

--- a/src/acceptance/coverage/unrequested.py
+++ b/src/acceptance/coverage/unrequested.py
@@ -1,0 +1,93 @@
+"""Unrequested-change detection (M3.2, §9.2).
+
+The inverse of implementation-coverage classification (classify.py): instead of
+asking "which diff region addresses this obligation", it asks "which diff
+region does no obligation call for" and flags those as candidate unrequested
+changes — giving extra weight to public-interface, dependency, and
+adjacent-behavior changes, which are the ones most worth a human's attention
+(§9.2, demonstration scenario #8).
+
+A semantic judgment, so a schema-constrained model call through the M0.4
+harness — recorded for replay, never a live call in tests. Each flagged change
+links to the exact diff hunks it concerns.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from acceptance.coverage.prompt import DiffRef, hunk_labels, render_diff_prompt, resolve_refs
+from acceptance.llm import ModelClient
+from acceptance.model_base import PersistableModel
+from acceptance.review_state import ChangeSet, Obligation
+
+
+class UnrequestedChangeKind(str, Enum):
+    PUBLIC_INTERFACE = "public_interface"
+    DEPENDENCY = "dependency"
+    ADJACENT_BEHAVIOR = "adjacent_behavior"
+    INTERNAL = "internal"
+    OTHER = "other"
+
+
+class UnrequestedChange(PersistableModel):
+    """A diff region no obligation called for (§9.2 unrequested change)."""
+
+    kind: UnrequestedChangeKind
+    rationale: str
+    diff_refs: list[DiffRef] = Field(default_factory=list)
+
+
+_SYSTEM_PROMPT = """\
+You find UNREQUESTED changes: diff regions that no listed obligation calls for.
+The obligations are the complete set of what the task asked for. Any change not
+needed to satisfy some obligation is a candidate unrequested change — report it.
+
+Give extra weight to (classify each `kind`):
+- public_interface: a change to a public function/method signature, name, return
+  type, or exported symbol.
+- dependency: an added/removed/upgraded dependency or config that affects them.
+- adjacent_behavior: a behavior change to code the task did not mention.
+- internal: a purely internal refactor with no external effect.
+- other: anything else unrequested.
+
+For each unrequested change return its `kind`, a short `rationale`, and
+`diff_refs`: the labels (like `path#0`) of the hunks it concerns. Do not report
+changes that a listed obligation requires. If every change is requested, return
+an empty list."""
+
+
+class _Detected(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: UnrequestedChangeKind
+    rationale: str
+    diff_refs: list[str]
+
+
+class _Detections(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    unrequested_changes: list[_Detected]
+
+
+def detect_unrequested_changes(
+    obligations: list[Obligation], change_set: ChangeSet, client: ModelClient
+) -> list[UnrequestedChange]:
+    """Flag diff regions no obligation calls for as candidate unrequested changes."""
+    label_to_ref = hunk_labels(change_set)
+    messages = [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {"role": "user", "content": render_diff_prompt(obligations, change_set)},
+    ]
+    result = client.complete(messages, _Detections)
+
+    changes = []
+    for detected in result.unrequested_changes:
+        refs = resolve_refs(detected.diff_refs, label_to_ref)
+        changes.append(
+            UnrequestedChange(kind=detected.kind, rationale=detected.rationale, diff_refs=refs)
+        )
+    return changes

--- a/tests/coverage/test_unrequested.py
+++ b/tests/coverage/test_unrequested.py
@@ -1,0 +1,123 @@
+"""M3.2 acceptance: archetype #8 -> the unmentioned public-interface change is
+flagged as an unrequested change.
+
+Detection is a schema-constrained model call; per the replay-first invariant
+these tests inject the recorded response via completion_fn — no live calls.
+Detection *accuracy* is measured by the benchmark (M3.3)."""
+
+import json
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+from acceptance.benchmark.fixtures import materialize_archetype
+from acceptance.change.diff import extract_change_set
+from acceptance.coverage.unrequested import (
+    UnrequestedChange,
+    UnrequestedChangeKind,
+    detect_unrequested_changes,
+)
+from acceptance.llm import Mode, ModelClient, TranscriptStore
+from acceptance.review_state import ChangeSet, Obligation, ObligationType
+
+ARCHETYPES = Path(__file__).resolve().parents[1] / "fixtures" / "archetypes"
+
+
+def _client_returning(response: dict) -> ModelClient:
+    def completion_fn(**kwargs):
+        content = json.dumps(response)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+
+    return ModelClient(
+        model="anthropic/claude-sonnet-5",
+        mode=Mode.RECORD,
+        store=TranscriptStore(tempfile.mkdtemp()),
+        completion_fn=completion_fn,
+    )
+
+
+def _obligation(obligation_id: str, description: str, typ: ObligationType) -> Obligation:
+    return Obligation(
+        id=obligation_id,
+        description=description,
+        type=typ,
+        importance="critical",
+        explicit=True,
+        observable_behavior="...",
+    )
+
+
+def _archetype_change_set(name: str, tmp_path: Path) -> ChangeSet:
+    fixture = materialize_archetype(ARCHETYPES / name, tmp_path / "repo")
+    return extract_change_set(fixture.repo_path, fixture.base_sha, fixture.head_sha)
+
+
+def _source_file(change_set: ChangeSet, suffix: str) -> str:
+    return next(f.path for f in change_set.files if f.path.endswith(suffix))
+
+
+def test_archetype_8_public_interface_change_is_flagged(tmp_path):
+    change_set = _archetype_change_set("08-unrequested-change", tmp_path)
+    cart = _source_file(change_set, "cart.py")
+
+    # The task only asked for apply_discount; leave-existing forbids changing
+    # unrelated behavior. checkout's signature change is unrequested.
+    obligations = [
+        _obligation("apply-discount", "Add apply_discount(total, percent)", ObligationType.FUNCTIONAL),
+        _obligation("leave-existing", "Leave existing behavior as-is", ObligationType.COMPATIBILITY),
+    ]
+    response = {
+        "unrequested_changes": [
+            {
+                "kind": "public_interface",
+                "rationale": "checkout gained a tax_rate parameter and rounding; not requested.",
+                "diff_refs": [f"{cart}#0"],
+            }
+        ]
+    }
+
+    changes = detect_unrequested_changes(obligations, change_set, _client_returning(response))
+
+    assert len(changes) == 1
+    assert changes[0].kind == UnrequestedChangeKind.PUBLIC_INTERFACE
+    assert changes[0].diff_refs
+    assert changes[0].diff_refs[0].file == cart
+    assert changes[0].diff_refs[0].hunk_header.startswith("@@")
+
+
+def test_nothing_flagged_when_all_changes_are_requested(tmp_path):
+    change_set = _archetype_change_set("01-missed-obligation", tmp_path)
+    obligations = [_obligation("x", "obligation", ObligationType.FUNCTIONAL)]
+
+    changes = detect_unrequested_changes(
+        obligations, change_set, _client_returning({"unrequested_changes": []})
+    )
+    assert changes == []
+
+
+def test_unknown_hunk_labels_are_dropped(tmp_path):
+    change_set = _archetype_change_set("08-unrequested-change", tmp_path)
+    obligations = [_obligation("x", "obligation", ObligationType.FUNCTIONAL)]
+    response = {
+        "unrequested_changes": [
+            {"kind": "dependency", "rationale": "...", "diff_refs": ["ghost.py#9"]}
+        ]
+    }
+    changes = detect_unrequested_changes(obligations, change_set, _client_returning(response))
+    assert changes[0].diff_refs == []  # unknown label dropped, not crashed
+
+
+def test_unrequested_change_round_trips_through_persistence(tmp_path):
+    change_set = _archetype_change_set("08-unrequested-change", tmp_path)
+    cart = _source_file(change_set, "cart.py")
+    obligations = [_obligation("apply-discount", "Add apply_discount", ObligationType.FUNCTIONAL)]
+    response = {
+        "unrequested_changes": [
+            {"kind": "public_interface", "rationale": "checkout signature changed", "diff_refs": [f"{cart}#0"]}
+        ]
+    }
+    change = detect_unrequested_changes(obligations, change_set, _client_returning(response))[0]
+    assert UnrequestedChange.from_dict(change.to_dict()) == change

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -237,9 +237,10 @@ def test_classify_replay_without_transcript_fails_cleanly(
     assert "model error" in capsys.readouterr().err
 
 
-def test_render_coverage_output():
-    from acceptance.cli import render_coverage
+def test_render_classify_output():
+    from acceptance.cli import render_classify
     from acceptance.coverage.classify import CoverageStatus, DiffRef, ImplementationCoverage
+    from acceptance.coverage.unrequested import UnrequestedChange, UnrequestedChangeKind
     from acceptance.review_state import Obligation, ObligationType
 
     obligations = [
@@ -257,9 +258,19 @@ def test_render_coverage_output():
             obligation_id="ob-2", status=CoverageStatus.NOT_ADDRESSED, rationale="missing",
         ),
     ]
+    unrequested = [
+        UnrequestedChange(
+            kind=UnrequestedChangeKind.PUBLIC_INTERFACE,
+            rationale="checkout signature changed",
+            diff_refs=[DiffRef(file="cart.py", hunk_header="@@ -1 +1 @@")],
+        )
+    ]
 
-    rendered = render_coverage(obligations, coverages)
+    rendered = render_classify(obligations, coverages, unrequested)
     assert "[addressed] ob-1: Do the thing." in rendered
     assert "pkg.py" in rendered
     assert "[not_addressed] ob-2: Handle the edge." in rendered
     assert "no corresponding change" in rendered
+    assert "Unrequested changes" in rendered
+    assert "[public_interface] checkout signature changed" in rendered
+    assert "cart.py" in rendered


### PR DESCRIPTION
Closes #21

## Summary
New `src/acceptance/coverage/unrequested.py`: `detect_unrequested_changes(obligations, change_set, client)` flags diff regions no obligation calls for as candidate unrequested changes, categorized by kind (**public_interface**, **dependency**, **adjacent_behavior**, internal, other) so the notable ones stand out (§9.2, scenario #8). The inverse of M3.1's obligation-to-diff classification. Schema-constrained model call; recorded for replay, no live calls in tests.

- Extracts shared prompt machinery (`DiffRef`, hunk labels, diff rendering, ref resolution) out of `classify.py` into **`coverage/prompt.py`**, so the two M3 modules share it instead of reaching into each other's internals (also dropped a now-unused param). `classify.py` re-exports `DiffRef`.
- **`acceptance classify` now shows coverage AND unrequested changes** — the fuller M3 view, toward M7's assembled review. (`--json` shape → `{coverage, unrequested_changes}`.)

## Dogfood output (live, on this PR's own diff)
The tool flagged **its own scope creep**:

```
Unrequested changes (no obligation calls for these):
  [internal] Refactoring shared diff-prompt helpers out of coverage/classify.py into a new prompt module ...
      -> src/acceptance/coverage/classify.py, src/acceptance/coverage/prompt.py
  [other] The CLI now returns and renders implementation coverage plus unrequested changes together, and changes JSON output shape from a list to an object with two keys ...
      -> src/acceptance/cli.py
  [other] The new acceptance test exercises a specific archetype and persistence behavior ...
```

The `prompt.py` refactor and the `classify` JSON-contract change are real, defensible engineering calls — but genuinely beyond the literal task, and the tool surfaced them for human judgment exactly as designed. (`decompose` + `diff` also shown in the PR thread.)

## Test plan
- [x] `pytest -q` — 244 pass. Acceptance (`test_unrequested.py`): materializing archetype #8, checkout's unmentioned signature change is flagged `public_interface` linking the real `cart.py` hunk. Plus nothing-flagged-when-all-requested, unknown-label drop, persistence round-trip. Refactor keeps M3.1's tests green.
- [x] `ruff check .` — clean
- [x] Live dogfood (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)