### PR TITLE
M3.3: coverage scoring hook (§11.1)

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,11 +1,11 @@
 # Task
-Flag diff regions that no obligation calls for as candidate unrequested changes, giving extra weight to public-interface, dependency, and adjacent-behavior changes.
+Feed M3.1's implementation-coverage classifications and M3.2's unrequested-change detections into the M-B0.3 gap-detection (recall) and false-alarm (precision) scoring.
 
 ## Constraints
-- Report changes not required by any obligation as candidate unrequested changes, each linked to the specific diff regions.
-- Categorize each by nature (public-interface / dependency / adjacent-behavior / internal / other) so the notable ones stand out.
-- Produce the detection through a schema-constrained model call recorded for replay; capability tests run off the recorded transcript with no live calls.
+- Reuse the existing §11.1 gap metric (`scoring.py`); do not redefine it.
+- A non-addressed coverage classification becomes a Finding linked to the obligation it concerns, so it is matchable against ground-truth gaps.
+- Keep the hook lighter than the full checker pipeline (M-B0.2's run_case) — no test execution, same shape as M1.4's decompose_case.
 
 ## Completion expectations
 - Implementation
-- Unit tests
+- Unit tests: archetypes #1, #2, and #8 each contribute a real, hand-calculable gap_recall/gap_precision figure.

--- a/src/acceptance/benchmark/coverage.py
+++ b/src/acceptance/benchmark/coverage.py
@@ -1,0 +1,119 @@
+"""Coverage scoring hook (M3.3).
+
+Wires M3.1's implementation-coverage classification and M3.2's
+unrequested-change detection into the M-B0.3 gap-detection/false-alarm
+metric. Like M1.4's decompose_case (decomposition.py), this stays lighter
+than the full checker pipeline (M-B0.2's run_case) — it only needs a case's
+task text and its materialized repo's diff, no test execution.
+
+`scoring.py`'s gap metric (`_gap_counts`) matches a ground-truth gap to a
+reported `Finding` by the description of the obligation the gap concerns
+(`Finding.related_obligation`). A non-addressed `ImplementationCoverage` is
+exactly that: it names the obligation the checker believes is incompletely
+covered, so it becomes a Finding linked to that obligation. An
+`UnrequestedChange` has no obligation to link — §9.2 unrequested changes are
+about code that shouldn't have changed, not about an obligation going
+unmet — so it becomes an unlinked Finding: reported for a human to read, but
+not yet counted by a metric that only scores obligation-linked gaps.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from acceptance.benchmark.case import BenchmarkCase
+from acceptance.benchmark.scoring import score_case
+from acceptance.change.diff import extract_change_set
+from acceptance.coverage.classify import CoverageStatus, ImplementationCoverage, classify_coverage
+from acceptance.coverage.unrequested import UnrequestedChange, detect_unrequested_changes
+from acceptance.evidence_tier import Component, EvidenceTier
+from acceptance.llm import ModelClient
+from acceptance.requirement.obligations import decompose
+from acceptance.requirement.task_file import parse_task_file
+from acceptance.review_state import Finding, Link, Obligation, Review, ReviewProvenance
+
+_SEVERITY_BY_STATUS = {
+    CoverageStatus.NOT_ADDRESSED: "high",
+    CoverageStatus.PARTIALLY_ADDRESSED: "medium",
+    CoverageStatus.UNCLEAR: "low",
+    CoverageStatus.REQUIRES_NON_CODE_EVIDENCE: "low",
+}
+
+
+def _coverage_finding(obligation: Obligation, coverage: ImplementationCoverage) -> Finding:
+    if coverage.diff_refs:
+        links = [
+            Link(kind="code", ref=f"{ref.file}#{ref.hunk_header}", text=coverage.rationale)
+            for ref in coverage.diff_refs
+        ]
+    else:
+        links = [Link(kind="requirement", ref=obligation.id, text=obligation.description)]
+    return Finding(
+        type="coverage_gap",
+        severity=_SEVERITY_BY_STATUS[coverage.status],
+        description=coverage.rationale,
+        evidence_tier=EvidenceTier.STATIC,
+        produced_by=Component.STATIC_ANALYZER,
+        links=links,
+        related_obligation=obligation.description,
+    )
+
+
+def _unrequested_finding(change: UnrequestedChange) -> Finding | None:
+    # No diff location to point to means nothing a human can act on; the
+    # required-link invariant (Finding._require_at_least_one_link) would
+    # reject it anyway, so skip rather than fabricate a link.
+    if not change.diff_refs:
+        return None
+    return Finding(
+        type="unrequested_change",
+        severity="low" if change.kind.value == "internal" else "medium",
+        description=change.rationale,
+        evidence_tier=EvidenceTier.STATIC,
+        produced_by=Component.STATIC_ANALYZER,
+        links=[
+            Link(kind="code", ref=f"{ref.file}#{ref.hunk_header}", text=change.rationale)
+            for ref in change.diff_refs
+        ],
+    )
+
+
+def classify_case(case: BenchmarkCase, client: ModelClient) -> BenchmarkCase:
+    """Decompose, classify coverage, and detect unrequested changes for a
+    case's diff; return a scored copy of `case`."""
+    parsed = parse_task_file(case.inputs.task_text)
+    obligations = decompose(parsed, client).obligations
+    change_set = extract_change_set(
+        Path(case.inputs.repo), case.inputs.base_revision, case.inputs.head_revision
+    )
+
+    coverages = classify_coverage(obligations, change_set, client)
+    unrequested = detect_unrequested_changes(obligations, change_set, client)
+
+    obligations_by_id = {obligation.id: obligation for obligation in obligations}
+    findings = [
+        _coverage_finding(obligations_by_id[coverage.obligation_id], coverage)
+        for coverage in coverages
+        if coverage.status != CoverageStatus.ADDRESSED
+    ]
+    findings.extend(
+        finding
+        for finding in (_unrequested_finding(change) for change in unrequested)
+        if finding is not None
+    )
+
+    review = Review(
+        mode="local",
+        reviewed_revision=case.inputs.head_revision,
+        provenance=ReviewProvenance(
+            determinism_mode=client.mode.value,
+            model=client.model,
+            temperature=client.temperature,
+            seed=client.seed,
+        ),
+        obligation_map=obligations,
+        change_set=change_set,
+        findings=findings,
+    )
+    scored_case = case.model_copy(update={"reviewer_output": review})
+    return scored_case.model_copy(update={"score": score_case(scored_case)})

--- a/tests/benchmark/test_coverage.py
+++ b/tests/benchmark/test_coverage.py
@@ -1,0 +1,252 @@
+"""M3.3 acceptance: M3.1's implementation-coverage classification and M3.2's
+unrequested-change detection feed the M-B0.3 gap-detection/false-alarm
+metric. Archetypes #1 (missed obligation), #2 (missed qualifier), and #8
+(unrequested change) each contribute a real, hand-calculable gap_recall/
+gap_precision figure.
+
+classify_case makes three schema-constrained calls per case (decompose,
+classify_coverage, detect_unrequested_changes); per the replay-first
+invariant the test client dispatches a fixed, hand-authored response per
+call by its response schema name — no live calls.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+from acceptance.benchmark.coverage import classify_case
+from acceptance.benchmark.fixtures import build_benchmark_case
+from acceptance.change.diff import extract_change_set
+from acceptance.llm import Mode, ModelClient, TranscriptStore
+
+ARCHETYPES_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "archetypes"
+
+
+def _client_dispatching(responses_by_schema: dict) -> ModelClient:
+    def completion_fn(**kwargs):
+        schema_name = kwargs["response_format"]["json_schema"]["name"]
+        content = json.dumps(responses_by_schema[schema_name])
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+
+    return ModelClient(
+        model="anthropic/claude-sonnet-5",
+        mode=Mode.RECORD,
+        store=TranscriptStore(tempfile.mkdtemp()),
+        completion_fn=completion_fn,
+    )
+
+
+def _decomposition_response(obligations: list[dict]) -> dict:
+    return {
+        "obligations": [
+            {
+                "id": o["id"],
+                "description": o["description"],
+                "type": o["type"],
+                "importance": "critical",
+                "explicit": True,
+                "observable_behavior": "...",
+                "source_quote": o["source_quote"],
+            }
+            for o in obligations
+        ],
+        "open_questions": [],
+    }
+
+
+def _classification_response(classifications: list[dict]) -> dict:
+    return {
+        "classifications": [
+            {
+                "obligation_id": c["obligation_id"],
+                "status": c["status"],
+                "rationale": c.get("rationale", "..."),
+                "diff_refs": c.get("diff_refs", []),
+            }
+            for c in classifications
+        ]
+    }
+
+
+def test_archetype_1_missed_obligation_yields_full_recall_and_precision(tmp_path):
+    case = build_benchmark_case(ARCHETYPES_DIR / "01-missed-obligation", tmp_path / "repo")
+
+    obligations = [
+        {
+            "id": "show-fields",
+            "description": "Show the item name, quantity, and unit price",
+            "type": "functional",
+            "source_quote": "Show the item name, the quantity, and the unit price.",
+        },
+        {
+            "id": "line-total",
+            "description": "Include the line total (quantity times unit price)",
+            "type": "functional",
+            "source_quote": "Include the line total (quantity × unit price).",
+        },
+        {
+            "id": "money-format",
+            "description": "Format money as USD with two decimals and a leading $",
+            "type": "functional",
+            "source_quote": "Format every money value as USD with exactly two decimals",
+        },
+        {
+            "id": "returns-in-parens",
+            "description": "Show negative-quantity returns with the quantity and total in parentheses",
+            "type": "boundary",
+            "source_quote": "For returns (a negative quantity)",
+        },
+    ]
+    client = _client_dispatching(
+        {
+            "_Decomposition": _decomposition_response(obligations),
+            "_Coverage": _classification_response(
+                [
+                    {"obligation_id": "show-fields", "status": "addressed"},
+                    {"obligation_id": "line-total", "status": "addressed"},
+                    {"obligation_id": "money-format", "status": "addressed"},
+                    {"obligation_id": "returns-in-parens", "status": "not_addressed"},
+                ]
+            ),
+            "_Detections": {"unrequested_changes": []},
+        }
+    )
+
+    scored = classify_case(case, client)
+
+    gap_findings = [f for f in scored.reviewer_output.findings if f.type == "coverage_gap"]
+    assert len(gap_findings) == 1
+    assert gap_findings[0].related_obligation == (
+        "Show negative-quantity returns with the quantity and total in parentheses"
+    )
+    assert scored.score.gap_recall == 1.0
+    assert scored.score.gap_precision == 1.0
+
+
+def test_archetype_2_missed_qualifier_yields_full_recall_and_precision(tmp_path):
+    case = build_benchmark_case(ARCHETYPES_DIR / "02-qualifier-missed", tmp_path / "repo")
+
+    obligations = [
+        {
+            "id": "parse-symbol",
+            "description": "Parse a leading currency symbol into its ISO code ($ USD, GBP, EUR)",
+            "type": "functional",
+            "source_quote": "Parse a leading currency symbol into its ISO code",
+        },
+        {
+            "id": "parse-amount",
+            "description": "Parse the remaining numeric amount as a float",
+            "type": "functional",
+            "source_quote": "Parse the remaining numeric amount as a float.",
+        },
+        {
+            "id": "backward-compat",
+            "description": "Plain numeric strings with no symbol keep working and default to USD",
+            "type": "compatibility",
+            "source_quote": "Existing callers pass plain numeric strings with no symbol",
+        },
+    ]
+    client = _client_dispatching(
+        {
+            "_Decomposition": _decomposition_response(obligations),
+            "_Coverage": _classification_response(
+                [
+                    {"obligation_id": "parse-symbol", "status": "addressed"},
+                    {"obligation_id": "parse-amount", "status": "addressed"},
+                    {"obligation_id": "backward-compat", "status": "not_addressed"},
+                ]
+            ),
+            "_Detections": {"unrequested_changes": []},
+        }
+    )
+
+    scored = classify_case(case, client)
+
+    gap_findings = [f for f in scored.reviewer_output.findings if f.type == "coverage_gap"]
+    assert len(gap_findings) == 1
+    assert gap_findings[0].related_obligation == (
+        "Plain numeric strings with no symbol keep working and default to USD"
+    )
+    assert scored.score.gap_recall == 1.0
+    assert scored.score.gap_precision == 1.0
+
+
+def test_archetype_8_unrequested_change_gap_matches_via_its_obligation(tmp_path):
+    fixture_dir = ARCHETYPES_DIR / "08-unrequested-change"
+    case = build_benchmark_case(fixture_dir, tmp_path / "repo")
+    # Discover the real hunk label for cart.py so the unrequested-change
+    # finding carries a genuine diff_ref, same as the checker would produce.
+    change_set = extract_change_set(
+        Path(case.inputs.repo), case.inputs.base_revision, case.inputs.head_revision
+    )
+    cart = next(f for f in change_set.files if f.path.endswith("cart.py"))
+    cart_ref = f"{cart.path}#0"
+
+    obligations = [
+        {
+            "id": "apply-discount",
+            "description": "Add apply_discount(total, percent) reducing the total by the given percentage, rounded to two decimals",
+            "type": "functional",
+            "source_quote": "Add `apply_discount(total, percent)` to `cart.py`",
+        },
+        {
+            "id": "leave-existing",
+            "description": "Leave existing behavior as-is; only apply_discount was requested",
+            "type": "compatibility",
+            "source_quote": "existing behavior should be left as-is",
+        },
+    ]
+    client = _client_dispatching(
+        {
+            "_Decomposition": _decomposition_response(obligations),
+            "_Coverage": _classification_response(
+                [
+                    {"obligation_id": "apply-discount", "status": "addressed"},
+                    {
+                        "obligation_id": "leave-existing",
+                        "status": "partially_addressed",
+                        "rationale": "checkout still defaults correctly but gained an untested tax_rate branch.",
+                    },
+                ]
+            ),
+            "_Detections": {
+                "unrequested_changes": [
+                    {
+                        "kind": "public_interface",
+                        "rationale": "checkout gained a tax_rate parameter and rounding; not requested.",
+                        "diff_refs": [cart_ref],
+                    }
+                ]
+            },
+        }
+    )
+
+    scored = classify_case(case, client)
+    findings_by_type = {f.type for f in scored.reviewer_output.findings}
+
+    # Both M3.1 and M3.2 output are fed in as findings...
+    assert findings_by_type == {"coverage_gap", "unrequested_change"}
+    # ...but only the obligation-linked coverage gap moves the gap metric,
+    # matching the ground-truth gap that is itself linked to leave-existing.
+    assert scored.score.gap_recall == 1.0
+    assert scored.score.gap_precision == 1.0
+
+
+def test_classify_case_does_not_mutate_the_input_case(tmp_path):
+    case = build_benchmark_case(ARCHETYPES_DIR / "01-missed-obligation", tmp_path / "repo")
+    client = _client_dispatching(
+        {
+            "_Decomposition": _decomposition_response([]),
+            "_Coverage": {"classifications": []},
+            "_Detections": {"unrequested_changes": []},
+        }
+    )
+
+    classify_case(case, client)
+
+    assert case.reviewer_output is None
+    assert case.score is None


### PR DESCRIPTION
## Summary
- New `benchmark/coverage.py` hook (`classify_case`), same pattern as M1.4's `decompose_case`: decompose → classify_coverage (M3.1) → detect_unrequested_changes (M3.2) → `Finding`s → `score_case`.
- A non-`addressed` coverage classification becomes a `Finding` linked to the obligation it concerns (`related_obligation`), which is exactly what `scoring.py`'s existing gap metric matches against ground-truth gaps.
- Unrequested-change detections become `Finding`s too (reported, type `unrequested_change`), but don't yet move gap_recall/gap_precision — `UnrequestedChange` has no obligation to link to, and the existing metric only matches obligation-linked findings. Filed as a follow-up decision: #81.

## Test plan
- [x] New tests (`tests/benchmark/test_coverage.py`): archetypes #1, #2, #8 each produce `gap_recall == 1.0` and `gap_precision == 1.0` against hand-verified ground truth; a no-mutation test.
- [x] Full suite: 248 passed (was 244).
- [x] ruff clean.
- [x] Dogfooded live: `acceptance decompose` / `diff` / `classify` against this change's own diff (see PR discussion / session log) — classify correctly flagged the unrequested-change scoring gap as `partially_addressed`, which is what led to filing #81.

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)