### PR TITLE
Pre-M4 cleanup: reconcile M3.5/M7.6 backlog, dedupe test/hook code

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,11 +1,12 @@
 # Task
-Feed M3.1's implementation-coverage classifications and M3.2's unrequested-change detections into the M-B0.3 gap-detection (recall) and false-alarm (precision) scoring.
+Pre-M4 cleanup pass: reconcile the M3.5/M7.6 backlog mirror with the real GitHub issues, and remove duplicated code the M3.1–M3.3 capabilities accumulated before it repeats again in M3.5/M4/M5.
 
 ## Constraints
-- Reuse the existing §11.1 gap metric (`scoring.py`); do not redefine it.
-- A non-addressed coverage classification becomes a Finding linked to the obligation it concerns, so it is matchable against ground-truth gaps.
-- Keep the hook lighter than the full checker pipeline (M-B0.2's run_case) — no test execution, same shape as M1.4's decompose_case.
+- Reconcile `planning/backlog/` (issues.tsv, milestones.tsv, per-task markdown files) and the plan doc's M3.5 section with the actual GitHub issue numbering (M3.5.5 renumbered from "Advisory presentation" to the docs task; the advisory-presentation task moved to M7.6).
+- Extract the duplicated schema-constrained-model-call test double (`_client_returning`/`_client_dispatching`) out of five test files into a shared helper.
+- Extract the duplicated `ReviewProvenance`-from-`ModelClient` and "copy case, attach review, attach score" pattern out of the two existing benchmark scoring hooks (M1.4, M3.3) before a third one repeats it.
+- Behavior must not change: all existing tests keep passing unmodified in intent, just de-duplicated.
 
 ## Completion expectations
 - Implementation
-- Unit tests: archetypes #1, #2, and #8 each contribute a real, hand-calculable gap_recall/gap_precision figure.
+- Unit tests (existing suite stays green; no new behavior to test)

--- a/docs/Stage-1-Development-Plan.md
+++ b/docs/Stage-1-Development-Plan.md
@@ -60,7 +60,7 @@ Per the chosen tech depth, this plan fixes **constraints and the decisions each 
 - **Mutation targeting** — how a named plausible defect maps to exact lines and a concrete code mutation (§8.2). *(M8)*
 - **Feasibility probe** — what signals declare a suite "hermetic and fast enough" (§8.3). *(M8)*
 - **Benchmark dataset selection & licensing** — *resolved; see §10.* Primary base layer is **SWE-bench Verified** (500 human-validated instances); **BugsInPy** (~500 reproducible bugs) backs the offline-mutant and execution layers. Remaining action is confirming per-repo licenses and BugsInPy's licensing status before any redistribution. *(M-B1)*
-- **Unrequested-change scoring & disposition** — *resolved; see DR-081.* Score unrequested-change detection as its own precision/recall axis (not folded into the gap metric), on the archetype layer in Stage 1 with real-change scoring deferred; model an explicit disposition (in-service / separable / risky) with a strict/loose policy knob; present findings as advisory. *(M3.5)*
+- **Unrequested-change scoring & disposition** — *resolved; see DR-081.* Score unrequested-change detection as its own precision/recall axis (not folded into the gap metric), on the archetype layer in Stage 1 with real-change scoring deferred; model an explicit disposition (in-service / separable / risky) with a strict/loose policy knob; present findings as advisory. *(M3.5; the advisory presentation itself lands with M7.6.)*
 
 ---
 
@@ -137,7 +137,7 @@ Rationale for the two most load-bearing ordering choices: (a) **benchmark-before
 | 5 | Circular expected result | M5 |
 | 6 | Critical behavior mocked out | M5 |
 | 7 | Declaration mismatch | M6 |
-| 8 | Unrequested change | M3 + M3.5 |
+| 8 | Unrequested change | M3 + M3.5 + M7 (M7.6 advisory presentation) |
 | 9 | Local revision cycle (rerun) | M7 (incremental re-run over M0 state) |
 | 14 | Execution-confirmed weak test | M8 |
 
@@ -197,8 +197,9 @@ Each task lists **inputs → deliverable → acceptance check**. Tasks within a 
 - **M3.5.2 Disposition on the Finding schema.** *Inputs:* §9.2, §15, DR-081. *Deliverable:* a `disposition` field on unrequested-change findings (in-service / separable / risky), obligation-less by construction; a strict/loose scope-expansion policy setting. *Acceptance:* an unrequested-change finding round-trips with a disposition and no `related_obligation`; the finding invariant permits obligation-less findings only for this type.
 - **M3.5.3 Separability classification.** *Inputs:* M3.5.2, M3.1 coverage, §9.2. *Deliverable:* classify each unrequested change via the removability litmus (would the task still be complete without it?) plus signals (new public surface, own tests, disjoint modules); emit an advisory "consider splitting into its own PR/backlog item" recommendation for `separable`. *Acceptance:* a planted separable feature → `separable` with the split recommendation; an in-service refactor an obligation depends on → `in_service`.
 - **M3.5.4 Archetype expansion.** *Inputs:* M-B5a, §13.5 #8. *Deliverable:* unrequested-change archetypes beyond #8 — a separable extra feature, an in-service refactor, and a risky adjacent-behavior change — with ground-truth dispositions. *Acceptance:* each new fixture builds and its disposition label validates `[human]`.
-- **M3.5.5 Advisory presentation.** *Inputs:* §16, DR-081, §9.2. *Deliverable:* render unrequested-change findings prominently but as advisory, separating certainty from importance; no defect-claim language. *Acceptance:* CLI shows unrequested changes with disposition, framed "no obligation explains this — your call." *(Lands with M7 CLI output; specified here.)*
-- **M3.5.6 Spec + plan documentation.** *Inputs:* DR-081. *Deliverable:* §9.2, §9.3, §11.1, §15 updated with the two-axis frame, disposition taxonomy, and confidence-vs-importance framing. *Acceptance:* `[human]` review confirms the two axes and disposition model are recorded.
+- **M3.5.5 Spec + plan documentation.** ✅ *Inputs:* DR-081. *Deliverable:* §9.2, §9.3, §11.1, §15 updated with the two-axis frame, disposition taxonomy, and confidence-vs-importance framing. *Acceptance:* `[human]` review confirms the two axes and disposition model are recorded. *Delivered in #90.*
+
+*M3.5's original "advisory presentation" sub-task moved to §M7 as **M7.6** — it lands with M7's CLI output, not before.*
 
 ### M4 — Test discovery & mapping
 
@@ -225,6 +226,7 @@ Each task lists **inputs → deliverable → acceptance check**. Tasks within a 
 - **M7.3 Next-instruction generator.** *Inputs:* gaps + recommendations, §10.1 example. *Deliverable:* a `.acceptance/next-instruction.md` that tells the agent what to implement and which discriminating tests to add. *Acceptance:* on a multi-gap archetype, the next instruction names each gap and its distinguishing test, matching the §10.1 style.
 - **M7.4 CLI report.** *Inputs:* §16 format. *Deliverable:* the §16 CLI output — obligation coverage, test evidence with per-line tier tags, unrequested changes, recommended-next-instruction pointer. *Acceptance:* rendered output matches the §16 layout; every test-evidence line shows its evidence tier.
 - **M7.5 Incremental re-run.** *Inputs:* M0 state store, §13.5 #9. *Deliverable:* re-run against a new head, updating only affected obligations/findings and reflecting closed gaps. *Acceptance:* archetype #9 → after the fix, the previously failing obligation flips to addressed and the verdict updates.
+- **M7.6 Advisory presentation of unrequested-change findings.** *Inputs:* §16, DR-081, §9.2. *Deliverable:* render unrequested-change findings prominently but as advisory, separating certainty from importance; no defect-claim language; show the disposition per finding. *Acceptance:* CLI shows unrequested changes with disposition, framed "no obligation explains this — your call." *(Specified in M3.5/DR-081; lands here with the rest of M7's CLI output.)*
 
 ### M-B1…M-B4 — Real-change benchmark datasets + accuracy report
 

--- a/planning/backlog/M3.5.1.md
+++ b/planning/backlog/M3.5.1.md
@@ -1,0 +1,14 @@
+> **Task `M3.5.1` — Milestone M3.5**  ·  Track: benchmark
+> Auto-generated from `Stage-1-Development-Plan.md` § 6. Edit freely.
+
+## Inputs
+#81, §11.1, `scoring.py`, M3.2/M3.3.
+
+## Deliverable
+an `unrequested_precision` / `unrequested_recall` pair matching obligation-less findings against obligation-less ground-truth changes, reported separately from the gap metric; archetype #8 ground truth updated.
+
+## Acceptance
+archetype #8's unrequested-change detection contributes a precision/recall number that does **not** route through its leave-existing obligation's coverage classification.
+
+---
+*Dogfooding note:* when you pick up this issue, copy the Deliverable/Acceptance into a `current-task.md` — that file becomes a real input the checker will one day ingest.

--- a/planning/backlog/M3.5.2.md
+++ b/planning/backlog/M3.5.2.md
@@ -1,0 +1,14 @@
+> **Task `M3.5.2` — Milestone M3.5**  ·  Track: checker
+> Auto-generated from `Stage-1-Development-Plan.md` § 6. Edit freely.
+
+## Inputs
+§9.2, §15, DR-081.
+
+## Deliverable
+a `disposition` field on unrequested-change findings (in-service / separable / risky), obligation-less by construction; a strict/loose scope-expansion policy setting.
+
+## Acceptance
+an unrequested-change finding round-trips with a disposition and no `related_obligation`; the finding invariant permits obligation-less findings only for this type.
+
+---
+*Dogfooding note:* when you pick up this issue, copy the Deliverable/Acceptance into a `current-task.md` — that file becomes a real input the checker will one day ingest.

--- a/planning/backlog/M3.5.3.md
+++ b/planning/backlog/M3.5.3.md
@@ -1,0 +1,14 @@
+> **Task `M3.5.3` — Milestone M3.5**  ·  Track: checker
+> Auto-generated from `Stage-1-Development-Plan.md` § 6. Edit freely.
+
+## Inputs
+M3.5.2, M3.1 coverage, §9.2.
+
+## Deliverable
+classify each unrequested change via the removability litmus (would the task still be complete without it?) plus signals (new public surface, own tests, disjoint modules); emit an advisory "consider splitting into its own PR/backlog item" recommendation for `separable`.
+
+## Acceptance
+a planted separable feature → `separable` with the split recommendation; an in-service refactor an obligation depends on → `in_service`.
+
+---
+*Dogfooding note:* when you pick up this issue, copy the Deliverable/Acceptance into a `current-task.md` — that file becomes a real input the checker will one day ingest.

--- a/planning/backlog/M3.5.4.md
+++ b/planning/backlog/M3.5.4.md
@@ -1,0 +1,14 @@
+> **Task `M3.5.4` — Milestone M3.5**  ·  Track: benchmark
+> Auto-generated from `Stage-1-Development-Plan.md` § 6. Edit freely.
+
+## Inputs
+M-B5a, §13.5 #8.
+
+## Deliverable
+unrequested-change archetypes beyond #8 — a separable extra feature, an in-service refactor, and a risky adjacent-behavior change — with ground-truth dispositions.
+
+## Acceptance
+each new fixture builds and its disposition label validates `[human]`.
+
+---
+*Dogfooding note:* when you pick up this issue, copy the Deliverable/Acceptance into a `current-task.md` — that file becomes a real input the checker will one day ingest.

--- a/planning/backlog/M3.5.5.md
+++ b/planning/backlog/M3.5.5.md
@@ -1,0 +1,14 @@
+> **Task `M3.5.5` — Milestone M3.5**  ·  Track: docs
+> Auto-generated from `Stage-1-Development-Plan.md` § 6. Edit freely.
+
+## Inputs
+DR-081.
+
+## Deliverable
+§9.2, §9.3, §11.1, §15 updated with the two-axis frame, disposition taxonomy, and confidence-vs-importance framing.
+
+## Acceptance
+`[human]` review confirms the two axes and disposition model are recorded.
+
+---
+*Dogfooding note:* when you pick up this issue, copy the Deliverable/Acceptance into a `current-task.md` — that file becomes a real input the checker will one day ingest.

--- a/planning/backlog/M7.6.md
+++ b/planning/backlog/M7.6.md
@@ -1,0 +1,14 @@
+> **Task `M7.6` — Milestone M7**  ·  Track: checker
+> Auto-generated from `Stage-1-Development-Plan.md` § 6. Edit freely.
+
+## Inputs
+§16, DR-081, §9.2.
+
+## Deliverable
+render unrequested-change findings prominently but as advisory, separating certainty from importance — no defect-claim language; show the disposition per finding.
+
+## Acceptance
+CLI shows unrequested changes with disposition, framed "no obligation explains this — your call."
+
+---
+*Dogfooding note:* when you pick up this issue, copy the Deliverable/Acceptance into a `current-task.md` — that file becomes a real input the checker will one day ingest.

--- a/planning/backlog/issues.tsv
+++ b/planning/backlog/issues.tsv
@@ -20,6 +20,11 @@ M2.3	M2.3: Working-tree mode	M2 — Git change analysis	stage-1,track:checker	M2
 M3.1	M3.1: Obligation-to-diff classification	M3 — Implementation-coverage analysis	stage-1,track:checker	M3.1.md
 M3.2	M3.2: Unrequested-change detection	M3 — Implementation-coverage analysis	stage-1,track:checker	M3.2.md
 M3.3	M3.3: Coverage scoring hook	M3 — Implementation-coverage analysis	stage-1,track:checker	M3.3.md
+M3.5.1	M3.5.1: Unrequested-change scoring metric	M3.5 — Unrequested-change scoring & disposition	stage-1,track:benchmark	M3.5.1.md
+M3.5.2	M3.5.2: Disposition on the Finding schema	M3.5 — Unrequested-change scoring & disposition	stage-1,track:checker	M3.5.2.md
+M3.5.3	M3.5.3: Separability classification for unrequested changes	M3.5 — Unrequested-change scoring & disposition	stage-1,track:checker	M3.5.3.md
+M3.5.4	M3.5.4: Expand unrequested-change archetypes beyond #8	M3.5 — Unrequested-change scoring & disposition	stage-1,track:benchmark	M3.5.4.md
+M3.5.5	M3.5.5: Record two-axis scoring + disposition in spec/plan	M3.5 — Unrequested-change scoring & disposition	stage-1,documentation	M3.5.5.md
 M4.1	M4.1: Test discovery	M4 — Test discovery & mapping	stage-1,track:checker	M4.1.md
 M4.2	M4.2: Test-to-obligation mapping	M4 — Test discovery & mapping	stage-1,track:checker	M4.2.md
 M5.1	M5.1: Per-test structural extraction	M5 — Test-semantic analysis (core)	stage-1,track:checker	M5.1.md
@@ -34,6 +39,7 @@ M7.2	M7.2: Completion verdict	M7 — Completion result, recommendations, CLI out
 M7.3	M7.3: Next-instruction generator	M7 — Completion result, recommendations, CLI output	stage-1,track:checker	M7.3.md
 M7.4	M7.4: CLI report	M7 — Completion result, recommendations, CLI output	stage-1,track:checker	M7.4.md
 M7.5	M7.5: Incremental re-run	M7 — Completion result, recommendations, CLI output	stage-1,track:checker	M7.5.md
+M7.6	M7.6: Advisory presentation of unrequested-change findings	M7 — Completion result, recommendations, CLI output	stage-1,track:checker	M7.6.md
 M-B1	M-B1: Ready-made labeled instances	M-B1…M-B4 — Real-change benchmark datasets + accuracy report	stage-1,track:benchmark,human-gate	M-B1.md
 M-B2	M-B2: Real merged PRs + follow-up-fix labels	M-B1…M-B4 — Real-change benchmark datasets + accuracy report	stage-1,track:benchmark,human-gate	M-B2.md
 M-B3	M-B3: Offline mutants for test-strength labels	M-B1…M-B4 — Real-change benchmark datasets + accuracy report	stage-1,track:benchmark	M-B3.md

--- a/planning/backlog/milestones.tsv
+++ b/planning/backlog/milestones.tsv
@@ -4,6 +4,7 @@
 4	M1 — Requirement interpretation (task → obligations)	Depends on: M0. First real capability; obligations are the spine everything maps to.
 5	M2 — Git change analysis	Depends on: M0. Provides the diff/source context M3–M5 consume.
 6	M3 — Implementation-coverage analysis	Depends on: M1, M2. Needs obligations + change set.
+6.5	M3.5 — Unrequested-change scoring & disposition	Depends on: M3, #81. Dogfood follow-up (DR-081); pre-M4 cleanup — scores the unrequested-change axis and adds dispositions before M4/M5 build on the state model.
 7	M4 — Test discovery & mapping	Depends on: M2, M1. Needs change set + obligations.
 8	M5 — Test-semantic analysis (core)	Depends on: M4. The core hard capability; consumes the test↔obligation map.
 9	M6 — Builder-declaration comparison (optional input)	Depends on: M1, M3, M5. Compares declaration against obligations/diff/tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,7 @@ testpaths = ["tests"]
 # tests/fixtures holds archetype fixture data (its own task/base/head trees and
 # test_*.py files) that materialize into throwaway repos — never our own suite.
 addopts = "--ignore=tests/fixtures"
+# Repo root on sys.path so `tests/*` modules can import shared test helpers
+# (tests.support) as `tests.support` regardless of invocation style — bare
+# `pytest` (CI) doesn't add cwd to sys.path the way `python -m pytest` does.
+pythonpath = ["."]

--- a/src/acceptance/benchmark/coverage.py
+++ b/src/acceptance/benchmark/coverage.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from acceptance.benchmark.case import BenchmarkCase
-from acceptance.benchmark.scoring import score_case
+from acceptance.benchmark.hooks import provenance_from, scored_copy
 from acceptance.change.diff import extract_change_set
 from acceptance.coverage.classify import CoverageStatus, ImplementationCoverage, classify_coverage
 from acceptance.coverage.unrequested import UnrequestedChange, detect_unrequested_changes
@@ -30,7 +30,7 @@ from acceptance.evidence_tier import Component, EvidenceTier
 from acceptance.llm import ModelClient
 from acceptance.requirement.obligations import decompose
 from acceptance.requirement.task_file import parse_task_file
-from acceptance.review_state import Finding, Link, Obligation, Review, ReviewProvenance
+from acceptance.review_state import Finding, Link, Obligation, Review
 
 _SEVERITY_BY_STATUS = {
     CoverageStatus.NOT_ADDRESSED: "high",
@@ -105,15 +105,9 @@ def classify_case(case: BenchmarkCase, client: ModelClient) -> BenchmarkCase:
     review = Review(
         mode="local",
         reviewed_revision=case.inputs.head_revision,
-        provenance=ReviewProvenance(
-            determinism_mode=client.mode.value,
-            model=client.model,
-            temperature=client.temperature,
-            seed=client.seed,
-        ),
+        provenance=provenance_from(client),
         obligation_map=obligations,
         change_set=change_set,
         findings=findings,
     )
-    scored_case = case.model_copy(update={"reviewer_output": review})
-    return scored_case.model_copy(update={"score": score_case(scored_case)})
+    return scored_copy(case, review)

--- a/src/acceptance/benchmark/decomposition.py
+++ b/src/acceptance/benchmark/decomposition.py
@@ -11,11 +11,11 @@ resulting obligation_map, ready for score_case/score_case_set.
 from __future__ import annotations
 
 from acceptance.benchmark.case import BenchmarkCase
-from acceptance.benchmark.scoring import score_case
+from acceptance.benchmark.hooks import provenance_from, scored_copy
 from acceptance.llm import ModelClient
 from acceptance.requirement.obligations import decompose
 from acceptance.requirement.task_file import parse_task_file
-from acceptance.review_state import Review, ReviewProvenance
+from acceptance.review_state import Review
 
 
 def decompose_case(case: BenchmarkCase, client: ModelClient) -> BenchmarkCase:
@@ -26,13 +26,7 @@ def decompose_case(case: BenchmarkCase, client: ModelClient) -> BenchmarkCase:
     review = Review(
         mode="local",
         reviewed_revision=case.inputs.head_revision,
-        provenance=ReviewProvenance(
-            determinism_mode=client.mode.value,
-            model=client.model,
-            temperature=client.temperature,
-            seed=client.seed,
-        ),
+        provenance=provenance_from(client),
         obligation_map=result.obligations,
     )
-    scored_case = case.model_copy(update={"reviewer_output": review})
-    return scored_case.model_copy(update={"score": score_case(scored_case)})
+    return scored_copy(case, review)

--- a/src/acceptance/benchmark/hooks.py
+++ b/src/acceptance/benchmark/hooks.py
@@ -1,0 +1,31 @@
+"""Shared plumbing for benchmark scoring hooks.
+
+Every hook that wires a capability's output into `score_case` (M1.4's
+`decompose_case`, M3.3's `classify_case`, and the M4/M5 hooks still to come)
+follows the same shape: stamp a `ReviewProvenance` from the `ModelClient` that
+produced the output, build a `Review`, then copy it onto the case and attach
+its score. Factored out once decomposition.py and coverage.py built the same
+two steps identically.
+"""
+
+from __future__ import annotations
+
+from acceptance.benchmark.case import BenchmarkCase
+from acceptance.benchmark.scoring import score_case
+from acceptance.llm import ModelClient
+from acceptance.review_state import Review, ReviewProvenance
+
+
+def provenance_from(client: ModelClient) -> ReviewProvenance:
+    return ReviewProvenance(
+        determinism_mode=client.mode.value,
+        model=client.model,
+        temperature=client.temperature,
+        seed=client.seed,
+    )
+
+
+def scored_copy(case: BenchmarkCase, review: Review) -> BenchmarkCase:
+    """Attach `review` to a copy of `case` and score it; `case` is untouched."""
+    scored_case = case.model_copy(update={"reviewer_output": review})
+    return scored_case.model_copy(update={"score": score_case(scored_case)})

--- a/src/acceptance/coverage/classify.py
+++ b/src/acceptance/coverage/classify.py
@@ -18,10 +18,10 @@ from __future__ import annotations
 
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import Field
 
 from acceptance.coverage.prompt import DiffRef, hunk_labels, render_diff_prompt, resolve_refs
-from acceptance.llm import ModelClient
+from acceptance.llm import ModelClient, StrictResponseModel
 from acceptance.model_base import PersistableModel
 from acceptance.review_state import ChangeSet, Obligation
 
@@ -67,18 +67,14 @@ the hunks that address the obligation. For not_addressed, `diff_refs` MUST be
 empty. Link only hunks that genuinely respond to the obligation."""
 
 
-class _Classification(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class _Classification(StrictResponseModel):
     obligation_id: str
     status: CoverageStatus
     rationale: str
     diff_refs: list[str]
 
 
-class _Coverage(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class _Coverage(StrictResponseModel):
     classifications: list[_Classification]
 
 

--- a/src/acceptance/coverage/unrequested.py
+++ b/src/acceptance/coverage/unrequested.py
@@ -16,10 +16,10 @@ from __future__ import annotations
 
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import Field
 
 from acceptance.coverage.prompt import DiffRef, hunk_labels, render_diff_prompt, resolve_refs
-from acceptance.llm import ModelClient
+from acceptance.llm import ModelClient, StrictResponseModel
 from acceptance.model_base import PersistableModel
 from acceptance.review_state import ChangeSet, Obligation
 
@@ -59,17 +59,13 @@ changes that a listed obligation requires. If every change is requested, return
 an empty list."""
 
 
-class _Detected(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class _Detected(StrictResponseModel):
     kind: UnrequestedChangeKind
     rationale: str
     diff_refs: list[str]
 
 
-class _Detections(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class _Detections(StrictResponseModel):
     unrequested_changes: list[_Detected]
 
 

--- a/src/acceptance/llm.py
+++ b/src/acceptance/llm.py
@@ -31,13 +31,26 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, TypeVar
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 from acceptance.serialization import canonical_json
 
 DEFAULT_TRANSCRIPT_ROOT = Path(".acceptance/cache/transcripts")
 
 ResponseModelT = TypeVar("ResponseModelT", bound=BaseModel)
+
+
+class StrictResponseModel(BaseModel):
+    """Base for a `response_model` passed to `ModelClient.complete`.
+
+    OpenAI strict mode requires every object in the schema to forbid extra
+    properties; `extra="forbid"` yields that. Every field must also be
+    required (no defaults) — strict mode has no notion of an optional field,
+    so a response schema should list one, non-defaulted field per value and
+    return empty lists/None explicitly rather than omitting them.
+    """
+
+    model_config = ConfigDict(extra="forbid")
 
 
 class Mode(str, Enum):

--- a/src/acceptance/requirement/obligations.py
+++ b/src/acceptance/requirement/obligations.py
@@ -14,9 +14,9 @@ obligations — uncertainty is a first-class, expected result (M1.3).
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import Field
 
-from acceptance.llm import ModelClient
+from acceptance.llm import ModelClient, StrictResponseModel
 from acceptance.model_base import PersistableModel
 from acceptance.requirement.task_file import ParsedTaskFile
 from acceptance.review_state import Obligation, ObligationType, OpenQuestion
@@ -44,13 +44,8 @@ ambiguous text.
 Do not merge distinct requirements. Prefer the smallest faithful set."""
 
 
-# The model-response schemas must be OpenAI strict-mode compatible: every object
-# forbids extra properties (additionalProperties:false) and every field is
-# required (no defaults). extra="forbid" yields the former; listing all fields
-# without defaults yields the latter. Empty arrays are returned explicitly.
-class _DecomposedObligation(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+# Empty arrays are returned explicitly (StrictResponseModel: no defaults).
+class _DecomposedObligation(StrictResponseModel):
     id: str
     description: str
     type: ObligationType
@@ -60,18 +55,14 @@ class _DecomposedObligation(BaseModel):
     source_quote: str
 
 
-class _OpenQuestion(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class _OpenQuestion(StrictResponseModel):
     id: str
     question: str
     importance: str
     source_quote: str
 
 
-class _Decomposition(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class _Decomposition(StrictResponseModel):
     obligations: list[_DecomposedObligation]
     open_questions: list[_OpenQuestion]
 

--- a/tests/benchmark/test_coverage.py
+++ b/tests/benchmark/test_coverage.py
@@ -10,34 +10,14 @@ invariant the test client dispatches a fixed, hand-authored response per
 call by its response schema name — no live calls.
 """
 
-import json
-import tempfile
 from pathlib import Path
-from types import SimpleNamespace
 
 from acceptance.benchmark.coverage import classify_case
 from acceptance.benchmark.fixtures import build_benchmark_case
 from acceptance.change.diff import extract_change_set
-from acceptance.llm import Mode, ModelClient, TranscriptStore
+from tests.support import client_dispatching as _client_dispatching
 
 ARCHETYPES_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "archetypes"
-
-
-def _client_dispatching(responses_by_schema: dict) -> ModelClient:
-    def completion_fn(**kwargs):
-        schema_name = kwargs["response_format"]["json_schema"]["name"]
-        content = json.dumps(responses_by_schema[schema_name])
-        return SimpleNamespace(
-            choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
-            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
-        )
-
-    return ModelClient(
-        model="anthropic/claude-sonnet-5",
-        mode=Mode.RECORD,
-        store=TranscriptStore(tempfile.mkdtemp()),
-        completion_fn=completion_fn,
-    )
 
 
 def _decomposition_response(obligations: list[dict]) -> dict:

--- a/tests/benchmark/test_decomposition.py
+++ b/tests/benchmark/test_decomposition.py
@@ -5,34 +5,15 @@ these tests inject a recorded model response directly — replay-first, no live
 calls, same pattern as M1.2/M1.3's tests.
 """
 
-import json
-import tempfile
 from pathlib import Path
-from types import SimpleNamespace
 
 from acceptance.benchmark.decomposition import decompose_case
 from acceptance.benchmark.fixtures import build_benchmark_case
 from acceptance.benchmark.scoring import score_case_set
-from acceptance.llm import Mode, ModelClient, TranscriptStore
+from tests.support import client_returning as _client_returning
 
 ARCHETYPES_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "archetypes"
 FIXTURE_DIRS = sorted(p for p in ARCHETYPES_DIR.iterdir() if p.is_dir())
-
-
-def _client_returning(response: dict) -> ModelClient:
-    def completion_fn(**kwargs):
-        content = json.dumps(response)
-        return SimpleNamespace(
-            choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
-            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
-        )
-
-    return ModelClient(
-        model="anthropic/claude-sonnet-5",
-        mode=Mode.RECORD,
-        store=TranscriptStore(tempfile.mkdtemp()),
-        completion_fn=completion_fn,
-    )
 
 
 def _obligation_response(descriptions: list[str]) -> dict:

--- a/tests/coverage/test_classify.py
+++ b/tests/coverage/test_classify.py
@@ -9,10 +9,7 @@ the test verifies the pipeline turns it into ImplementationCoverage with real
 diff-region links. Classification *accuracy* is measured by the benchmark (M3.3).
 """
 
-import json
-import tempfile
 from pathlib import Path
-from types import SimpleNamespace
 
 from acceptance.change.diff import extract_change_set
 from acceptance.benchmark.fixtures import materialize_archetype
@@ -21,37 +18,11 @@ from acceptance.coverage.classify import (
     ImplementationCoverage,
     classify_coverage,
 )
-from acceptance.llm import Mode, ModelClient, TranscriptStore
-from acceptance.review_state import ChangeSet, Obligation, ObligationType
+from acceptance.review_state import ChangeSet, ObligationType
+from tests.support import client_returning as _client_returning
+from tests.support import make_obligation as _obligation
 
 ARCHETYPES = Path(__file__).resolve().parents[1] / "fixtures" / "archetypes"
-
-
-def _client_returning(response: dict) -> ModelClient:
-    def completion_fn(**kwargs):
-        content = json.dumps(response)
-        return SimpleNamespace(
-            choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
-            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
-        )
-
-    return ModelClient(
-        model="anthropic/claude-sonnet-5",
-        mode=Mode.RECORD,
-        store=TranscriptStore(tempfile.mkdtemp()),
-        completion_fn=completion_fn,
-    )
-
-
-def _obligation(obligation_id: str, description: str, typ: ObligationType) -> Obligation:
-    return Obligation(
-        id=obligation_id,
-        description=description,
-        type=typ,
-        importance="critical",
-        explicit=True,
-        observable_behavior="...",
-    )
 
 
 def _archetype_change_set(name: str, tmp_path: Path) -> ChangeSet:

--- a/tests/coverage/test_unrequested.py
+++ b/tests/coverage/test_unrequested.py
@@ -5,10 +5,7 @@ Detection is a schema-constrained model call; per the replay-first invariant
 these tests inject the recorded response via completion_fn — no live calls.
 Detection *accuracy* is measured by the benchmark (M3.3)."""
 
-import json
-import tempfile
 from pathlib import Path
-from types import SimpleNamespace
 
 from acceptance.benchmark.fixtures import materialize_archetype
 from acceptance.change.diff import extract_change_set
@@ -17,37 +14,11 @@ from acceptance.coverage.unrequested import (
     UnrequestedChangeKind,
     detect_unrequested_changes,
 )
-from acceptance.llm import Mode, ModelClient, TranscriptStore
-from acceptance.review_state import ChangeSet, Obligation, ObligationType
+from acceptance.review_state import ChangeSet, ObligationType
+from tests.support import client_returning as _client_returning
+from tests.support import make_obligation as _obligation
 
 ARCHETYPES = Path(__file__).resolve().parents[1] / "fixtures" / "archetypes"
-
-
-def _client_returning(response: dict) -> ModelClient:
-    def completion_fn(**kwargs):
-        content = json.dumps(response)
-        return SimpleNamespace(
-            choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
-            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
-        )
-
-    return ModelClient(
-        model="anthropic/claude-sonnet-5",
-        mode=Mode.RECORD,
-        store=TranscriptStore(tempfile.mkdtemp()),
-        completion_fn=completion_fn,
-    )
-
-
-def _obligation(obligation_id: str, description: str, typ: ObligationType) -> Obligation:
-    return Obligation(
-        id=obligation_id,
-        description=description,
-        type=typ,
-        importance="critical",
-        explicit=True,
-        observable_behavior="...",
-    )
 
 
 def _archetype_change_set(name: str, tmp_path: Path) -> ChangeSet:

--- a/tests/requirement/test_obligations.py
+++ b/tests/requirement/test_obligations.py
@@ -9,15 +9,12 @@ Obligations and OpenQuestions with ids and source spans. The model's actual
 decomposition accuracy is measured separately by the benchmark (M-B*).
 """
 
-import json
-import tempfile
 from pathlib import Path
-from types import SimpleNamespace
 
-from acceptance.llm import Mode, ModelClient, TranscriptStore
 from acceptance.requirement.obligations import Decomposition, decompose
 from acceptance.requirement.task_file import parse_task_file
 from acceptance.review_state import ObligationType
+from tests.support import client_returning as _client_returning
 
 ARCHETYPES = Path(__file__).resolve().parents[1] / "fixtures" / "archetypes"
 
@@ -77,24 +74,6 @@ FLOATING_RATE_RESPONSE = {
     ],
     "open_questions": [],
 }
-
-
-def _client_returning(response: dict) -> ModelClient:
-    def completion_fn(**kwargs):
-        content = json.dumps(response)
-        return SimpleNamespace(
-            choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
-            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
-        )
-
-    # Isolated ephemeral store so the injected response is always used and no
-    # transcript leaks into the repo's .acceptance/ cache.
-    return ModelClient(
-        model="anthropic/claude-sonnet-5",
-        mode=Mode.RECORD,
-        store=TranscriptStore(tempfile.mkdtemp()),
-        completion_fn=completion_fn,
-    )
 
 
 def test_floating_rate_example_yields_five_typed_criteria():

--- a/tests/support.py
+++ b/tests/support.py
@@ -1,0 +1,70 @@
+"""Shared test doubles for schema-constrained model calls.
+
+Every capability that calls `ModelClient.complete` (decomposition, coverage
+classification, unrequested-change detection, and their benchmark hooks) is
+tested the same way, per the replay-first invariant: inject a fake
+`completion_fn` that returns a fixed, hand-authored response and never
+touches the network, backed by an isolated ephemeral `TranscriptStore` so
+recording never leaks into the repo's real `.acceptance/` cache.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from types import SimpleNamespace
+
+from acceptance.llm import Mode, ModelClient, TranscriptStore
+from acceptance.review_state import Obligation, ObligationType
+
+_DEFAULT_MODEL = "anthropic/claude-sonnet-5"
+
+
+def _fake_response(content: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    )
+
+
+def client_returning(response: dict, model: str = _DEFAULT_MODEL) -> ModelClient:
+    """A client whose every call returns the same fixed response."""
+
+    def completion_fn(**kwargs):
+        return _fake_response(json.dumps(response))
+
+    return ModelClient(
+        model=model,
+        mode=Mode.RECORD,
+        store=TranscriptStore(tempfile.mkdtemp()),
+        completion_fn=completion_fn,
+    )
+
+
+def make_obligation(obligation_id: str, description: str, typ: ObligationType) -> Obligation:
+    """A minimal but valid Obligation for tests that don't exercise its
+    importance/explicitness/observable-behavior fields directly."""
+    return Obligation(
+        id=obligation_id,
+        description=description,
+        type=typ,
+        importance="critical",
+        explicit=True,
+        observable_behavior="...",
+    )
+
+
+def client_dispatching(responses_by_schema: dict, model: str = _DEFAULT_MODEL) -> ModelClient:
+    """A client for multi-call hooks: each call returns the response keyed by
+    its response schema's class name (e.g. `_Decomposition`, `_Coverage`)."""
+
+    def completion_fn(**kwargs):
+        schema_name = kwargs["response_format"]["json_schema"]["name"]
+        return _fake_response(json.dumps(responses_by_schema[schema_name]))
+
+    return ModelClient(
+        model=model,
+        mode=Mode.RECORD,
+        store=TranscriptStore(tempfile.mkdtemp()),
+        completion_fn=completion_fn,
+    )


### PR DESCRIPTION
## Summary
Requested cleanup/refactor pass before starting M4.1, prompted by DR-081 (#81)'s M3.5 milestone landing with GitHub issues that drifted from the plan doc's original draft numbering.

**Backlog/docs reconciliation:**
- Plan doc's M3.5 section didn't match reality: the draft's "M3.5.5 Advisory presentation" is actually issue **M7.6** (#88 — lands with M7's CLI output), and the draft's "M3.5.6 Spec + plan documentation" is actually **M3.5.5** (#87, closed — delivered in #90). Fixed the section text and the demo-scenario/§3.2 cross-references.
- `planning/backlog/` had no markdown files or `issues.tsv`/`milestones.tsv` rows for M3.5.1-5 or M7.6, breaking the "one file per task, tsv is the machine index" convention every prior milestone followed. Added them.
- Closed #87 (delivered but left open) and cleaned up the merged `docs/dr-081-...` branch.

**Code dedup** (no behavior change):
- `tests/support.py`: the identical 14-line fake-`ModelClient` test double (`_client_returning`/`_client_dispatching`) was copy-pasted across 5 test files. One shared module now, plus a shared `make_obligation` helper (was duplicated in 2 files).
- `benchmark/hooks.py`: `decompose_case` (M1.4) and `classify_case` (M3.3) built `ReviewProvenance` from a `ModelClient` and did the "copy case -> attach review -> attach score" dance identically. Extracted before a third hook (M3.5.1/M4.x/M5.x) copies it again.
- `llm.py`: added `StrictResponseModel` (the `BaseModel` + `ConfigDict(extra="forbid")` OpenAI-strict-mode boilerplate) as a shared base; 6 internal response schemas across 3 modules now subclass it instead of repeating the one-liner.

Net: -125 lines before dedup considering docs additions, -183/+58 in the code-only diff.

## Test plan
- [x] Full suite: 248 passed, unchanged from before this PR.
- [x] ruff clean.
- [x] Dogfooded live (`acceptance decompose`/`diff`/`classify` against this change's own diff) — correctly flagged two untracked project-board scripts as out of scope, which is why they're not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)