### PR TITLE
M3.5.1: unrequested-change scoring metric (DR-081)

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,12 +1,13 @@
 # Task
-Pre-M4 cleanup pass: reconcile the M3.5/M7.6 backlog mirror with the real GitHub issues, and remove duplicated code the M3.1–M3.3 capabilities accumulated before it repeats again in M3.5/M4/M5.
+Score unrequested-change detection as its own precision/recall pair on the code→obligation axis, separate from the gap metric (DR-081 decision 1).
 
 ## Constraints
-- Reconcile `planning/backlog/` (issues.tsv, milestones.tsv, per-task markdown files) and the plan doc's M3.5 section with the actual GitHub issue numbering (M3.5.5 renumbered from "Advisory presentation" to the docs task; the advisory-presentation task moved to M7.6).
-- Extract the duplicated schema-constrained-model-call test double (`_client_returning`/`_client_dispatching`) out of five test files into a shared helper.
-- Extract the duplicated `ReviewProvenance`-from-`ModelClient` and "copy case, attach review, attach score" pattern out of the two existing benchmark scoring hooks (M1.4, M3.3) before a third one repeats it.
-- Behavior must not change: all existing tests keep passing unmodified in intent, just de-duplicated.
+- Ground truth: obligation-less unrequested-change entries matched against obligation-less findings; do not attempt to link them to obligations.
+- Report the metric separately from `gap_recall`/`gap_precision`, never folded into it.
+- Update archetype #8's ground truth.
+- Detection stays recall-forward; precision is reported, not optimized against.
+- Archetype layer only in Stage 1; real-change scoring is deferred (DR-081).
 
 ## Completion expectations
 - Implementation
-- Unit tests (existing suite stays green; no new behavior to test)
+- Unit tests: archetype #8 contributes an `unrequested_precision`/`unrequested_recall` number that does not route through its `leave-existing` obligation's coverage classification.

--- a/src/acceptance/benchmark/case.py
+++ b/src/acceptance/benchmark/case.py
@@ -23,6 +23,12 @@ test ids in `candidate_tests` are validated to resolve, so ground truth can't
 carry a dangling reference, an obligation with no evidence class, or a weak
 result with no stated reason.
 
+`unrequested_changes` is the code→obligation dual of `gaps` (a gap is an
+obligation with no matching code; an unrequested change is code with no
+matching obligation) and is therefore obligation-*less* by construction —
+scored as its own precision/recall pair (DR-081), never folded into the gap
+metric (M3.5.1).
+
 `reviewer_output` and `score` start empty and are filled in by the runner
 (M-B0.2) and scorer (M-B0.3) — a case is valid the moment it carries real
 ground truth, before it has ever been run.
@@ -107,9 +113,28 @@ class GroundTruthGap(PersistableModel):
     severity: str | None = None
 
 
+class GroundTruthUnrequestedChange(PersistableModel):
+    """A diff region the ground truth says no obligation calls for — the
+    code→obligation dual of a gap (§9.2, DR-081). Obligation-less by
+    construction, so it is *not* linked to an obligation id the way a
+    `GroundTruthGap` can be.
+
+    `file` identifies the diff region at file granularity (matching the
+    checker's `Finding.links`, not an exact hunk header — a hand-authored
+    exact hunk header would be brittle to keep in sync with the fixture's
+    real diff). Coarser than line-level, but matches the granularity the
+    existing gap metric already scores at (by obligation, not by line
+    range)."""
+
+    id: str
+    description: str
+    file: str
+
+
 class GroundTruthLabels(PersistableModel):
     obligations: list[GroundTruthObligation] = Field(default_factory=list)
     gaps: list[GroundTruthGap] = Field(default_factory=list)
+    unrequested_changes: list[GroundTruthUnrequestedChange] = Field(default_factory=list)
 
     @model_validator(mode="after")
     def _check_tree_integrity(self) -> "GroundTruthLabels":
@@ -143,6 +168,14 @@ class GroundTruthLabels(PersistableModel):
                 raise ValueError(
                     f"obligation {obligation.id!r} must have a non-empty evidence_rationale"
                 )
+
+        unrequested_ids = [u.id for u in self.unrequested_changes]
+        if any(not uid.strip() for uid in unrequested_ids):
+            raise ValueError("every unrequested-change id must be a non-empty string")
+        if len(set(unrequested_ids)) != len(unrequested_ids):
+            raise ValueError("unrequested-change ids must be unique")
+        if any(not u.file.strip() for u in self.unrequested_changes):
+            raise ValueError("every unrequested change must name a non-empty file")
         return self
 
 
@@ -154,6 +187,8 @@ class BenchmarkScore(PersistableModel):
     decomposition_accuracy: float | None = None
     mapping_accuracy: float | None = None
     evidence_agreement: float | None = None
+    unrequested_precision: float | None = None
+    unrequested_recall: float | None = None
 
 
 class BenchmarkCase(PersistableModel):

--- a/src/acceptance/benchmark/scoring.py
+++ b/src/acceptance/benchmark/scoring.py
@@ -1,9 +1,18 @@
-"""Benchmark scoring & report (M-B0.3, §11.1; ground-truth tree revised M-B5a.2).
+"""Benchmark scoring & report (M-B0.3, §11.1; ground-truth tree revised M-B5a.2;
+unrequested-change axis added M3.5.1/DR-081).
 
 The §11.1 metrics fall out of the obligation tree (case.py): decomposition
 accuracy from the obligations, mapping accuracy from each obligation's
 candidate_tests edges, evidence agreement from each obligation's evidence
 class, and gap recall/precision from the gaps.
+
+Unrequested-change precision/recall is a separate, obligation-*less* axis
+(DR-081): a gap is an obligation with no matching code; an unrequested change
+is code with no matching obligation. It is scored the same way (labeled refs
+vs. reported refs, pooled by raw counts) but never folded into the gap
+numbers — matching on the obligation-linked `related_obligation` field would
+silently exclude every unrequested-change finding, which by construction
+carries no obligation link at all.
 
 Ground truth identifies obligations by a stable id; the reviewer's Review
 (review_state.py) does not yet — its obligations are identified only by
@@ -87,6 +96,23 @@ def _gap_counts(case: BenchmarkCase) -> _MatchCounts:
     return _counts(ground_truth_refs, reported_refs)
 
 
+def _unrequested_counts(case: BenchmarkCase) -> _MatchCounts:
+    """Code→obligation axis (DR-081): matched by file, not by obligation —
+    an unrequested-change finding never carries `related_obligation` (§9.2,
+    obligation-less by construction), so this never routes through any
+    obligation's coverage classification."""
+    review = case.reviewer_output
+    ground_truth_refs = {u.file for u in case.ground_truth.unrequested_changes}
+    reported_refs = {
+        link.ref.split("#", 1)[0]
+        for finding in review.findings
+        if finding.type == "unrequested_change"
+        for link in finding.links
+        if link.kind == "code"
+    }
+    return _counts(ground_truth_refs, reported_refs)
+
+
 def _decomposition_counts(case: BenchmarkCase) -> _MatchCounts:
     review = case.reviewer_output
     ground_truth_refs = {o.description for o in case.ground_truth.obligations}
@@ -120,7 +146,9 @@ def _evidence_counts(case: BenchmarkCase) -> _MatchCounts:
     return _MatchCounts(matched=0, ground_truth_total=len(ground_truth_refs), reported_total=0)
 
 
-def _all_counts(case: BenchmarkCase) -> tuple[_MatchCounts, _MatchCounts, _MatchCounts, _MatchCounts]:
+def _all_counts(
+    case: BenchmarkCase,
+) -> tuple[_MatchCounts, _MatchCounts, _MatchCounts, _MatchCounts, _MatchCounts]:
     if case.reviewer_output is None:
         raise ValueError(f"case {case.case_id!r} has no reviewer_output; run it first")
     return (
@@ -128,6 +156,7 @@ def _all_counts(case: BenchmarkCase) -> tuple[_MatchCounts, _MatchCounts, _Match
         _decomposition_counts(case),
         _mapping_counts(case),
         _evidence_counts(case),
+        _unrequested_counts(case),
     )
 
 
@@ -136,6 +165,7 @@ def _score_from_counts(
     decomposition: _MatchCounts,
     mapping: _MatchCounts,
     evidence: _MatchCounts,
+    unrequested: _MatchCounts,
 ) -> BenchmarkScore:
     return BenchmarkScore(
         gap_recall=gap.recall(),
@@ -143,6 +173,8 @@ def _score_from_counts(
         decomposition_accuracy=decomposition.recall(),
         mapping_accuracy=mapping.recall(),
         evidence_agreement=evidence.recall(),
+        unrequested_precision=unrequested.precision(),
+        unrequested_recall=unrequested.recall(),
     )
 
 
@@ -161,6 +193,8 @@ class BenchmarkReport(PersistableModel):
     decomposition_accuracy: float | None = None
     mapping_accuracy: float | None = None
     evidence_agreement: float | None = None
+    unrequested_precision: float | None = None
+    unrequested_recall: float | None = None
     per_case: list[BenchmarkScore] = Field(default_factory=list)
 
 
@@ -187,16 +221,18 @@ def score_case_set(cases: list[BenchmarkCase]) -> BenchmarkReport:
     decomposition_total = _MatchCounts.zero()
     mapping_total = _MatchCounts.zero()
     evidence_total = _MatchCounts.zero()
+    unrequested_total = _MatchCounts.zero()
     per_case: list[BenchmarkScore] = []
     modes: set[str] = set()
 
     for case in cases:
-        gap, decomposition, mapping, evidence = _all_counts(case)
+        gap, decomposition, mapping, evidence, unrequested = _all_counts(case)
         gap_total += gap
         decomposition_total += decomposition
         mapping_total += mapping
         evidence_total += evidence
-        per_case.append(_score_from_counts(gap, decomposition, mapping, evidence))
+        unrequested_total += unrequested
+        per_case.append(_score_from_counts(gap, decomposition, mapping, evidence, unrequested))
         modes.add(_case_determinism_mode(case))
 
     return BenchmarkReport(
@@ -207,6 +243,8 @@ def score_case_set(cases: list[BenchmarkCase]) -> BenchmarkReport:
         decomposition_accuracy=decomposition_total.recall(),
         mapping_accuracy=mapping_total.recall(),
         evidence_agreement=evidence_total.recall(),
+        unrequested_precision=unrequested_total.precision(),
+        unrequested_recall=unrequested_total.recall(),
         per_case=per_case,
     )
 
@@ -217,6 +255,8 @@ _METRIC_FIELDS = (
     "decomposition_accuracy",
     "mapping_accuracy",
     "evidence_agreement",
+    "unrequested_precision",
+    "unrequested_recall",
 )
 
 
@@ -239,6 +279,8 @@ class SampledBenchmarkReport(PersistableModel):
     decomposition_accuracy: MetricStats
     mapping_accuracy: MetricStats
     evidence_agreement: MetricStats
+    unrequested_precision: MetricStats
+    unrequested_recall: MetricStats
     runs: list[BenchmarkReport] = Field(default_factory=list)
 
 

--- a/tests/benchmark/test_case.py
+++ b/tests/benchmark/test_case.py
@@ -10,6 +10,7 @@ from acceptance.benchmark.case import (
     GroundTruthGap,
     GroundTruthLabels,
     GroundTruthObligation,
+    GroundTruthUnrequestedChange,
 )
 from acceptance.review_state import Review
 
@@ -152,6 +153,49 @@ def test_missing_evidence_rationale_fails_validation():
 def test_unknown_evidence_classification_is_rejected():
     with pytest.raises(ValueError):
         _obligation(evidence_class="bogus")
+
+
+def test_unrequested_change_round_trips():
+    labels = _labels(
+        unrequested_changes=[
+            GroundTruthUnrequestedChange(
+                id="u1", description="an extra helper nobody asked for", file="cart.py"
+            )
+        ]
+    )
+    assert _round_trip(labels) == labels
+
+
+def test_unrequested_change_is_not_an_obligation_reference():
+    # Obligation-less by construction: unlike a gap, it has no obligation_id
+    # field at all, so it can never be validated against `known` obligations.
+    labels = _labels(
+        unrequested_changes=[
+            GroundTruthUnrequestedChange(id="u1", description="drive-by refactor", file="cart.py")
+        ]
+    )
+    assert not hasattr(labels.unrequested_changes[0], "obligation_id")
+
+
+def test_duplicate_unrequested_change_ids_fail_validation():
+    with pytest.raises(ValueError):
+        GroundTruthLabels(
+            obligations=[_obligation()],
+            unrequested_changes=[
+                GroundTruthUnrequestedChange(id="u1", description="a", file="cart.py"),
+                GroundTruthUnrequestedChange(id="u1", description="b", file="pricing.py"),
+            ],
+        )
+
+
+def test_empty_unrequested_change_file_fails_validation():
+    with pytest.raises(ValueError):
+        GroundTruthLabels(
+            obligations=[_obligation()],
+            unrequested_changes=[
+                GroundTruthUnrequestedChange(id="u1", description="a", file="  ")
+            ],
+        )
 
 
 def test_benchmark_case_source_round_trips():

--- a/tests/benchmark/test_coverage.py
+++ b/tests/benchmark/test_coverage.py
@@ -4,6 +4,12 @@ metric. Archetypes #1 (missed obligation), #2 (missed qualifier), and #8
 (unrequested change) each contribute a real, hand-calculable gap_recall/
 gap_precision figure.
 
+M3.5.1 (DR-081) adds the unrequested-change axis: archetype #8 also
+contributes an unrequested_precision/unrequested_recall figure, scored by
+file against `unrequested_changes` ground truth — never via any obligation's
+coverage classification, since an unrequested-change finding carries no
+`related_obligation` at all.
+
 classify_case makes three schema-constrained calls per case (decompose,
 classify_coverage, detect_unrequested_changes); per the replay-first
 invariant the test client dispatches a fixed, hand-authored response per
@@ -214,6 +220,72 @@ def test_archetype_8_unrequested_change_gap_matches_via_its_obligation(tmp_path)
     # matching the ground-truth gap that is itself linked to leave-existing.
     assert scored.score.gap_recall == 1.0
     assert scored.score.gap_precision == 1.0
+    # The unrequested-change axis is scored independently, by file, from the
+    # unrequested_change finding itself.
+    assert scored.score.unrequested_recall == 1.0
+    assert scored.score.unrequested_precision == 1.0
+
+
+def test_archetype_8_unrequested_change_metric_does_not_route_through_coverage(tmp_path):
+    """M3.5.1 acceptance: even if leave-existing's coverage classification
+    finds nothing wrong (addressed, not partially_addressed — so the gap
+    metric misses it entirely), the unrequested-change axis still catches
+    the unrequested change on its own, because it is scored from the
+    unrequested_change finding directly, never through any obligation."""
+    fixture_dir = ARCHETYPES_DIR / "08-unrequested-change"
+    case = build_benchmark_case(fixture_dir, tmp_path / "repo")
+    change_set = extract_change_set(
+        Path(case.inputs.repo), case.inputs.base_revision, case.inputs.head_revision
+    )
+    cart = next(f for f in change_set.files if f.path.endswith("cart.py"))
+    cart_ref = f"{cart.path}#0"
+
+    obligations = [
+        {
+            "id": "apply-discount",
+            "description": "Add apply_discount(total, percent) reducing the total by the given percentage, rounded to two decimals",
+            "type": "functional",
+            "source_quote": "Add `apply_discount(total, percent)` to `cart.py`",
+        },
+        {
+            "id": "leave-existing",
+            "description": "Leave existing behavior as-is; only apply_discount was requested",
+            "type": "compatibility",
+            "source_quote": "existing behavior should be left as-is",
+        },
+    ]
+    client = _client_dispatching(
+        {
+            "_Decomposition": _decomposition_response(obligations),
+            "_Coverage": _classification_response(
+                [
+                    {"obligation_id": "apply-discount", "status": "addressed"},
+                    # Deliberately wrong/optimistic: a checker that missed the
+                    # regression in its coverage classification entirely.
+                    {"obligation_id": "leave-existing", "status": "addressed"},
+                ]
+            ),
+            "_Detections": {
+                "unrequested_changes": [
+                    {
+                        "kind": "public_interface",
+                        "rationale": "checkout gained a tax_rate parameter and rounding; not requested.",
+                        "diff_refs": [cart_ref],
+                    }
+                ]
+            },
+        }
+    )
+
+    scored = classify_case(case, client)
+
+    # No coverage_gap finding at all — leave-existing was (wrongly) addressed.
+    assert not [f for f in scored.reviewer_output.findings if f.type == "coverage_gap"]
+    assert scored.score.gap_recall == 0.0
+    # But the unrequested-change axis still scores full recall/precision,
+    # entirely independent of the (wrong) coverage classification.
+    assert scored.score.unrequested_recall == 1.0
+    assert scored.score.unrequested_precision == 1.0
 
 
 def test_classify_case_does_not_mutate_the_input_case(tmp_path):

--- a/tests/benchmark/test_labels.py
+++ b/tests/benchmark/test_labels.py
@@ -109,6 +109,13 @@ def test_declaration_mismatch_case_carries_the_declaration(tmp_path):
     assert case.ground_truth.gaps[0].obligation_id is None
 
 
+def test_unrequested_change_case_labels_the_changed_file(tmp_path):
+    fixture_dir = ARCHETYPES_DIR / "08-unrequested-change"
+    case = build_benchmark_case(fixture_dir, tmp_path / "repo")
+    assert case.ground_truth.unrequested_changes
+    assert case.ground_truth.unrequested_changes[0].file == "cart.py"
+
+
 def test_revision_cycle_is_a_true_negative(tmp_path):
     """#9 head closes the earlier gap, so its ground truth has no gap — a
     precision (false-alarm) check for the checker, not a recall check."""
@@ -137,6 +144,7 @@ def test_full_loop_scores_the_noop_checker_as_all_miss(tmp_path):
 
     assert report.case_count == len(FIXTURE_DIRS)
     assert report.gap_recall == 0.0  # eight fixtures label a gap; none found
+    assert report.unrequested_recall == 0.0  # archetype 8 labels an unrequested change; none found
     assert report.decomposition_accuracy == 0.0  # obligations labeled everywhere; none found
     assert report.mapping_accuracy == 0.0  # coverage edges labeled; none found
     assert report.evidence_agreement == 0.0

--- a/tests/benchmark/test_scoring_report.py
+++ b/tests/benchmark/test_scoring_report.py
@@ -7,26 +7,33 @@ description, mappings by (obligation description, test id), gaps by the
 description of the obligation they concern, evidence agreement always
 reported_total=0 (no reviewer §9.3 classification yet).
 
-Case A ground truth: obligations {Alpha [T1], Beta []}, gap on Beta.
-       reviewer: reports obligation Alpha (but not its T1 mapping); flags Beta.
+Case A ground truth: obligations {Alpha [T1], Beta []}, gap on Beta,
+       unrequested change in x.py.
+       reviewer: reports obligation Alpha (but not its T1 mapping); flags Beta;
+                 flags an unrequested change in x.py.
   gap:           matched 1, gt 1, reported 1
   decomposition: matched 1 (Alpha), gt 2, reported 1
   mapping:       matched 0, gt 1 (Alpha,T1), reported 0
   evidence:      gt 2, reported 0
+  unrequested:   matched 1 (x.py), gt 1, reported 1
 
-Case B ground truth: obligations {Gamma [T2]}, no gaps (true negative).
+Case B ground truth: obligations {Gamma [T2]}, no gaps (true negative), no
+       unrequested changes.
        reviewer: reports Gamma with its T2 mapping + a spurious Delta;
-                 raises a spurious Epsilon finding.
+                 raises a spurious Epsilon finding; flags a spurious
+                 unrequested change in y.py.
   gap:           matched 0, gt 0, reported 1
   decomposition: matched 1 (Gamma), gt 1, reported 2 (Gamma, Delta)
   mapping:       matched 1 (Gamma,T2), gt 1, reported 1
   evidence:      gt 1, reported 0
+  unrequested:   matched 0, gt 0, reported 1 (y.py)
 
 Pooled:
   gap_recall    = 1/1 = 1.0     gap_precision = 1/2 = 0.5
   decomposition = 2/3
   mapping       = 1/2 = 0.5
   evidence      = 0/3 = 0.0
+  unrequested_recall = 1/1 = 1.0     unrequested_precision = 1/2 = 0.5
 """
 
 import pytest
@@ -38,6 +45,7 @@ from acceptance.benchmark.case import (
     GroundTruthGap,
     GroundTruthLabels,
     GroundTruthObligation,
+    GroundTruthUnrequestedChange,
 )
 from acceptance.benchmark.scoring import score_case_set
 from acceptance.evidence_tier import Component, EvidenceTier
@@ -90,6 +98,17 @@ def _finding(related_obligation: str) -> Finding:
     )
 
 
+def _unrequested_finding(file: str) -> Finding:
+    return Finding(
+        type="unrequested_change",
+        severity="medium",
+        description=f"unrequested change in {file}",
+        evidence_tier=EvidenceTier.STATIC,
+        produced_by=Component.STATIC_ANALYZER,
+        links=[Link(kind="code", ref=f"{file}#@@ -1 +1 @@")],
+    )
+
+
 def _case_a() -> BenchmarkCase:
     return BenchmarkCase(
         case_id="synthetic-a",
@@ -109,13 +128,16 @@ def _case_a() -> BenchmarkCase:
                 ),
             ],
             gaps=[GroundTruthGap(id="gap-beta", description="Beta missing", obligation_id="beta")],
+            unrequested_changes=[
+                GroundTruthUnrequestedChange(id="u-x", description="x.py changed", file="x.py")
+            ],
         ),
         reviewer_output=Review(
             mode="local",
             reviewed_revision="def456",
             provenance=_provenance(),
             obligation_map=[_reviewer_obligation("Alpha", test_evidence=[])],
-            findings=[_finding("Beta")],
+            findings=[_finding("Beta"), _unrequested_finding("x.py")],
         ),
     )
 
@@ -143,7 +165,7 @@ def _case_b() -> BenchmarkCase:
                 _reviewer_obligation("Gamma", test_evidence=["T2"]),
                 _reviewer_obligation("Delta", test_evidence=[]),
             ],
-            findings=[_finding("Epsilon")],
+            findings=[_finding("Epsilon"), _unrequested_finding("y.py")],
         ),
     )
 
@@ -158,6 +180,8 @@ def test_pooled_report_matches_hand_calculated_values():
     assert report.decomposition_accuracy == 2 / 3
     assert report.mapping_accuracy == 0.5
     assert report.evidence_agreement == 0.0
+    assert report.unrequested_recall == 1.0
+    assert report.unrequested_precision == 0.5
 
 
 def test_report_includes_per_case_scores():
@@ -169,11 +193,17 @@ def test_report_includes_per_case_scores():
     assert report.per_case[0].gap_precision == 1.0
     assert report.per_case[0].decomposition_accuracy == 0.5
     assert report.per_case[0].mapping_accuracy == 0.0
+    assert report.per_case[0].unrequested_recall == 1.0
+    assert report.per_case[0].unrequested_precision == 1.0
     # Case B: no gaps -> recall None, precision 0/1; decomposition 1/2; mapping 1/1.
     assert report.per_case[1].gap_recall is None
     assert report.per_case[1].gap_precision == 0.0
     assert report.per_case[1].decomposition_accuracy == 1.0
     assert report.per_case[1].mapping_accuracy == 1.0
+    # No unrequested-change ground truth in B -> recall None; the spurious
+    # y.py finding still counts against precision (0/1).
+    assert report.per_case[1].unrequested_recall is None
+    assert report.per_case[1].unrequested_precision == 0.0
 
 
 def test_empty_case_set_yields_no_metrics():
@@ -186,6 +216,8 @@ def test_empty_case_set_yields_no_metrics():
     assert report.decomposition_accuracy is None
     assert report.mapping_accuracy is None
     assert report.evidence_agreement is None
+    assert report.unrequested_precision is None
+    assert report.unrequested_recall is None
     assert report.per_case == []
 
 

--- a/tests/fixtures/archetypes/08-unrequested-change/labels.json
+++ b/tests/fixtures/archetypes/08-unrequested-change/labels.json
@@ -24,5 +24,12 @@
       "obligation_id": "leave-existing",
       "severity": "medium"
     }
+  ],
+  "unrequested_changes": [
+    {
+      "id": "unrequested-checkout-change",
+      "description": "checkout gained a tax_rate parameter and rounding; no obligation asked for a checkout change, only apply_discount",
+      "file": "cart.py"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- `GroundTruthLabels` gains `unrequested_changes: list[GroundTruthUnrequestedChange]` (id, description, `file`) — obligation-less by construction, matched at file granularity (same coarseness the existing gap metric already uses; an exact hand-authored hunk-header string would be brittle).
- `scoring.py`'s new `_unrequested_counts` matches ground truth against `Finding(type="unrequested_change")` findings by file. `BenchmarkScore`/`BenchmarkReport`/`SampledBenchmarkReport` gain `unrequested_precision`/`unrequested_recall`, pooled the same way as every other metric.
- This is structurally decoupled from the gap metric: an unrequested-change `Finding` never carries `related_obligation`, so there is no code path by which this metric could route through any obligation's coverage classification.
- Archetype #8's `labels.json` gets its `unrequested_changes` entry (`cart.py`).

## Test plan
- [x] Schema round-trip + validator tests (`test_case.py`): unique ids, non-empty `file`.
- [x] Hand-calculated pooled example extended in `test_scoring_report.py` (two synthetic cases, one true positive + one false positive).
- [x] `test_labels.py`: archetype #8 labels the changed file; the all-miss no-op-checker loop now also asserts `unrequested_recall == 0.0`.
- [x] **Direct acceptance proof** (`test_coverage.py`): a variant of the archetype-#8 test where `leave-existing`'s coverage classification is (wrongly) `addressed` instead of `partially_addressed` — `gap_recall` drops to `0.0` as expected, but `unrequested_recall`/`unrequested_precision` stay `1.0`, proving the axis is independent.
- [x] Full suite: 254 passed (was 248).
- [x] ruff clean.
- [x] Dogfooded live (`acceptance decompose`/`diff`/`classify` against this change's own diff) — all obligations addressed; flagged "unrequested changes" are just the necessary implementation surface (schema/API additions), not real scope creep.

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)