### PR TITLE
M3.5.2: disposition on the Finding schema + scope-expansion policy (DR-081)

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,13 +1,11 @@
 # Task
-Score unrequested-change detection as its own precision/recall pair on the code→obligation axis, separate from the gap metric (DR-081 decision 1).
+Add a `disposition` field to unrequested-change findings (in_service / separable / risky), and a strict/loose scope-expansion policy setting.
 
 ## Constraints
-- Ground truth: obligation-less unrequested-change entries matched against obligation-less findings; do not attempt to link them to obligations.
-- Report the metric separately from `gap_recall`/`gap_precision`, never folded into it.
-- Update archetype #8's ground truth.
-- Detection stays recall-forward; precision is reported, not optimized against.
-- Archetype layer only in Stage 1; real-change scoring is deferred (DR-081).
+- Disposition is obligation-less by construction: it appears only on unrequested-change findings.
+- The Finding invariant permits obligation-less findings only for unrequested_change (strict), expressed via a named allow-set that M6 can extend for declaration mismatches.
+- The scope-expansion policy is a strict-vs-loose run setting; it is introduced now and consumed by the separability classifier (M3.5.3).
 
 ## Completion expectations
 - Implementation
-- Unit tests: archetype #8 contributes an `unrequested_precision`/`unrequested_recall` number that does not route through its `leave-existing` obligation's coverage classification.
+- Unit tests: an unrequested-change finding round-trips with a disposition and no related_obligation; the invariant rejects an obligation-less finding of any other type, an unrequested-change finding that carries a related_obligation, and a disposition on any non-unrequested finding.

--- a/src/acceptance/benchmark/coverage.py
+++ b/src/acceptance/benchmark/coverage.py
@@ -30,7 +30,7 @@ from acceptance.evidence_tier import Component, EvidenceTier
 from acceptance.llm import ModelClient
 from acceptance.requirement.obligations import decompose
 from acceptance.requirement.task_file import parse_task_file
-from acceptance.review_state import Finding, Link, Obligation, Review
+from acceptance.review_state import UNREQUESTED_CHANGE, Finding, Link, Obligation, Review
 
 _SEVERITY_BY_STATUS = {
     CoverageStatus.NOT_ADDRESSED: "high",
@@ -66,7 +66,7 @@ def _unrequested_finding(change: UnrequestedChange) -> Finding | None:
     if not change.diff_refs:
         return None
     return Finding(
-        type="unrequested_change",
+        type=UNREQUESTED_CHANGE,
         severity="low" if change.kind.value == "internal" else "medium",
         description=change.rationale,
         evidence_tier=EvidenceTier.STATIC,

--- a/src/acceptance/benchmark/scoring.py
+++ b/src/acceptance/benchmark/scoring.py
@@ -42,6 +42,7 @@ from pydantic import Field
 
 from acceptance.benchmark.case import BenchmarkCase, BenchmarkScore
 from acceptance.model_base import PersistableModel
+from acceptance.review_state import UNREQUESTED_CHANGE
 
 
 @dataclass(frozen=True)
@@ -106,7 +107,7 @@ def _unrequested_counts(case: BenchmarkCase) -> _MatchCounts:
     reported_refs = {
         link.ref.split("#", 1)[0]
         for finding in review.findings
-        if finding.type == "unrequested_change"
+        if finding.type == UNREQUESTED_CHANGE
         for link in finding.links
         if link.kind == "code"
     }

--- a/src/acceptance/config.py
+++ b/src/acceptance/config.py
@@ -15,6 +15,7 @@ the review so a reader can tell how it was produced.
 
 from __future__ import annotations
 
+from enum import Enum
 from pathlib import Path
 from typing import Any, Callable
 
@@ -25,6 +26,17 @@ from acceptance.review_state import ReviewProvenance
 
 # LiteLLM model string. Provider-agnostic: swap freely via --model / RunConfig.
 DEFAULT_MODEL = "openai/gpt-5.4-mini"
+
+
+class ScopeExpansionPolicy(str, Enum):
+    """How tolerant the review is of changes beyond the mandate (DR-081
+    decision 4). Where the acceptable-expansion line sits is a shop norm, so
+    it is a policy knob, not a hardcoded verdict — it tunes the separability
+    classifier (M3.5.3), not detection. Default is `strict`, matching DR-081's
+    recall-forward stance (surface more, let the user dismiss)."""
+
+    STRICT = "strict"  # flag more expansion as separable/risky
+    LOOSE = "loose"  # tolerate more bundled work
 
 
 class RunConfig(BaseModel):
@@ -41,6 +53,11 @@ class RunConfig(BaseModel):
     temperature: float = 0.0
     seed: int | None = None
     transcript_root: Path = Field(default=DEFAULT_TRANSCRIPT_ROOT)
+    # A review-interpretation knob (consumed by the M3.5.3 separability
+    # classifier), not a determinism control — so it deliberately does not
+    # feed build_client() or provenance(). If we later want it recorded for
+    # traceability, that is a deliberate addition to ReviewProvenance.
+    scope_expansion_policy: ScopeExpansionPolicy = ScopeExpansionPolicy.STRICT
 
     def build_client(self, completion_fn: Callable[..., Any] | None = None) -> ModelClient:
         return ModelClient(

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -28,6 +28,8 @@ __all__ = [
     "EvidenceTier",
     "TextSpan",
     "ObligationType",
+    "UnrequestedChangeDisposition",
+    "UNREQUESTED_CHANGE",
     "Project",
     "TaskSource",
     "MandateInterpretation",
@@ -58,6 +60,31 @@ class ObligationType(str, Enum):
     EXPLANATION_OBSERVABILITY = "explanation_observability"
     DOCS_CONFIG = "docs_config"
     HUMAN_REVIEW = "human_review"
+
+
+# The canonical `Finding.type` string for a §9.2 unrequested-change finding.
+# Single-sourced here because the obligation-less Finding invariant keys on it
+# and the M3 producers (benchmark/coverage.py) and scorer (benchmark/scoring.py)
+# must agree on the exact spelling.
+UNREQUESTED_CHANGE = "unrequested_change"
+
+# Finding types allowed to be obligation-less (related_obligation is None).
+# Almost every finding is *about* an obligation and must name it; an
+# unrequested change is the code→obligation dual and is obligation-less by
+# construction (§9.2, DR-081). M6 (builder-declaration comparison) adds
+# `declaration_mismatch` here: a claim of undone work outside the mandate is
+# obligation-less too, and advisory — see issue #31.
+_OBLIGATION_LESS_TYPES = frozenset({UNREQUESTED_CHANGE})
+
+
+class UnrequestedChangeDisposition(str, Enum):
+    """How to treat a §9.2 unrequested change (DR-081 decision 4). Set only on
+    unrequested-change findings; `separable` and `risky` are not exclusive and
+    `separable` is orthogonal to value. The classifier is M3.5.3."""
+
+    IN_SERVICE = "in_service"  # a refactor/interface edit made to deliver an obligation
+    SEPARABLE = "separable"  # coherent but distinct work — recommend its own PR/backlog item
+    RISKY = "risky"  # touches public surface/deps/adjacent behavior; scrutinize
 
 
 class Project(_Model):
@@ -197,7 +224,13 @@ class Link(_Model):
 class Finding(_Model):
     """Typed and linked (CLAUDE.md invariant): cannot be built without an
     evidence tier and at least one link target, and the producing component
-    must be authorized for the claimed tier (§8.1, M0.3)."""
+    must be authorized for the claimed tier (§8.1, M0.3).
+
+    Findings are *about* an obligation and must name it in `related_obligation`;
+    the only exception is a finding whose type is in `_OBLIGATION_LESS_TYPES`
+    (an unrequested change, §9.2, which is obligation-less by construction).
+    A `disposition` — how to treat an unrequested change — may be set only on
+    an unrequested-change finding (DR-081)."""
 
     type: str
     severity: str
@@ -206,6 +239,7 @@ class Finding(_Model):
     produced_by: Component
     links: list[Link]
     related_obligation: str | None = None
+    disposition: UnrequestedChangeDisposition | None = None
     supporting_evidence: list[str] = Field(default_factory=list)
     uncertainty: str | None = None
     recommended_action: str | None = None
@@ -220,6 +254,30 @@ class Finding(_Model):
     @model_validator(mode="after")
     def _require_authorized_tier(self) -> "Finding":
         authorize_tier(self.produced_by, self.evidence_tier)
+        return self
+
+    @model_validator(mode="after")
+    def _obligation_less_only_for_allowed_types(self) -> "Finding":
+        obligation_less_ok = self.type in _OBLIGATION_LESS_TYPES
+        if self.related_obligation is None and not obligation_less_ok:
+            raise ValueError(
+                f"Finding of type {self.type!r} must name a related_obligation; "
+                f"only {sorted(_OBLIGATION_LESS_TYPES)} may be obligation-less"
+            )
+        if self.related_obligation is not None and self.type == UNREQUESTED_CHANGE:
+            raise ValueError(
+                "an unrequested_change finding is obligation-less by construction; "
+                "it must not carry a related_obligation"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _disposition_only_for_unrequested_change(self) -> "Finding":
+        if self.disposition is not None and self.type != UNREQUESTED_CHANGE:
+            raise ValueError(
+                f"disposition is only valid on an {UNREQUESTED_CHANGE!r} finding, "
+                f"not {self.type!r}"
+            )
         return self
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,29 @@
+"""RunConfig controls, incl. the M3.5.2 scope-expansion policy (DR-081)."""
+
+from acceptance.config import RunConfig, ScopeExpansionPolicy
+
+
+def test_scope_expansion_policy_defaults_to_strict():
+    # DR-081's recall-forward stance: surface more, let the user dismiss.
+    assert RunConfig().scope_expansion_policy is ScopeExpansionPolicy.STRICT
+
+
+def test_scope_expansion_policy_is_configurable():
+    config = RunConfig(scope_expansion_policy=ScopeExpansionPolicy.LOOSE)
+    assert config.scope_expansion_policy is ScopeExpansionPolicy.LOOSE
+
+
+def test_scope_expansion_policy_round_trips():
+    config = RunConfig(scope_expansion_policy=ScopeExpansionPolicy.LOOSE)
+    restored = RunConfig.model_validate(config.model_dump())
+    assert restored.scope_expansion_policy is ScopeExpansionPolicy.LOOSE
+
+
+def test_scope_expansion_policy_is_not_a_determinism_control():
+    # It tunes review interpretation (M3.5.3), not how the model is called, so
+    # it must not leak into provenance (which feeds byte-identical replay and
+    # M-B0.4 variance) — two configs differing only in policy are provenance-equal.
+    strict = RunConfig(scope_expansion_policy=ScopeExpansionPolicy.STRICT)
+    loose = RunConfig(scope_expansion_policy=ScopeExpansionPolicy.LOOSE)
+    assert strict.provenance() == loose.provenance()
+    assert "scope_expansion" not in strict.provenance().model_dump()

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -56,6 +56,7 @@ def _produce_review(config: RunConfig, completion_fn) -> Review:
         evidence_tier=EvidenceTier.STATIC,
         produced_by=Component.STATIC_ANALYZER,
         links=[Link(kind="requirement", ref="task.md:1")],
+        related_obligation="Bonds accrue using the index curve.",
     )
     return Review(
         mode="local",

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -51,6 +51,7 @@ def test_populated_review_lists_obligations_and_findings():
                 evidence_tier=EvidenceTier.STATIC,
                 produced_by=Component.STATIC_ANALYZER,
                 links=[Link(kind="test", ref="tests/t.py:1")],
+                related_obligation="Active filters are applied",
             )
         ],
         recommendation=".acceptance/next-instruction.md",

--- a/tests/test_review_state.py
+++ b/tests/test_review_state.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 from acceptance.review_state import (
+    UNREQUESTED_CHANGE,
     BuilderDeclaration,
     ChangeSet,
     Component,
@@ -20,6 +21,7 @@ from acceptance.review_state import (
     TaskSource,
     TestEvidence,
     TextSpan,
+    UnrequestedChangeDisposition,
 )
 
 
@@ -234,7 +236,71 @@ def test_finding_requires_authorized_producer():
             evidence_tier=EvidenceTier.DEFECT_KILLED,
             produced_by=Component.STATIC_ANALYZER,
             links=[Link(kind="test", ref="tests/test_bond.py:42")],
+            related_obligation="Coupons use index + contractual spread.",
         )
+
+
+def _unrequested_finding(**overrides) -> Finding:
+    defaults = dict(
+        type=UNREQUESTED_CHANGE,
+        severity="medium",
+        description="checkout signature changed; not requested.",
+        evidence_tier=EvidenceTier.STATIC,
+        produced_by=Component.STATIC_ANALYZER,
+        links=[Link(kind="code", ref="cart.py:4")],
+        disposition=UnrequestedChangeDisposition.SEPARABLE,
+    )
+    defaults.update(overrides)
+    return Finding(**defaults)
+
+
+def test_unrequested_change_finding_round_trips_with_disposition_and_no_obligation():
+    finding = _unrequested_finding()
+    assert finding.related_obligation is None
+    assert finding.disposition is UnrequestedChangeDisposition.SEPARABLE
+    assert _round_trip(finding) == finding
+
+
+def test_obligation_less_finding_of_another_type_is_rejected():
+    # Only unrequested_change may be obligation-less; a coverage gap must name one.
+    with pytest.raises(ValueError):
+        Finding(
+            type="coverage_gap",
+            severity="high",
+            description="...",
+            evidence_tier=EvidenceTier.STATIC,
+            produced_by=Component.STATIC_ANALYZER,
+            links=[Link(kind="requirement", ref="task.md:1")],
+            related_obligation=None,
+        )
+
+
+def test_unrequested_change_finding_with_a_related_obligation_is_rejected():
+    # Obligation-less by construction: it must NOT carry an obligation link.
+    with pytest.raises(ValueError):
+        _unrequested_finding(related_obligation="Some obligation")
+
+
+def test_disposition_on_a_non_unrequested_finding_is_rejected():
+    with pytest.raises(ValueError):
+        Finding(
+            type="coverage_gap",
+            severity="high",
+            description="...",
+            evidence_tier=EvidenceTier.STATIC,
+            produced_by=Component.STATIC_ANALYZER,
+            links=[Link(kind="requirement", ref="task.md:1")],
+            related_obligation="Some obligation",
+            disposition=UnrequestedChangeDisposition.RISKY,
+        )
+
+
+def test_unrequested_change_finding_without_a_disposition_is_allowed():
+    # M3.5.2 introduces the field; M3.5.3's classifier populates it. Until then
+    # an unrequested-change finding may carry disposition=None.
+    finding = _unrequested_finding(disposition=None)
+    assert finding.disposition is None
+    assert _round_trip(finding) == finding
 
 
 def test_review_round_trips_empty():
@@ -259,6 +325,7 @@ def test_review_round_trips_populated():
         evidence_tier=EvidenceTier.STATIC,
         produced_by=Component.STATIC_ANALYZER,
         links=[Link(kind="code", ref="src/bond.py:10")],
+        related_obligation="Coupons use index + contractual spread.",
     )
     review = Review(
         mode="local",
@@ -291,6 +358,7 @@ def test_review_evidence_tier_summary_is_derived_not_stored():
         evidence_tier=EvidenceTier.STATIC,
         produced_by=Component.STATIC_ANALYZER,
         links=[Link(kind="code", ref="src/bond.py:10")],
+        related_obligation="...",
     )
     review = Review(
         mode="local",


### PR DESCRIPTION
## Summary
- **`disposition` field on `Finding`** — `UnrequestedChangeDisposition` (`in_service` / `separable` / `risky`), settable only on unrequested-change findings. Optional for now; M3.5.3's classifier populates it.
- **Strict Finding invariant** (the design fork we talked through): a finding may be obligation-less (`related_obligation is None`) **only if** its type is in a named `_OBLIGATION_LESS_TYPES` allow-set — just `unrequested_change` today. An `unrequested_change` finding is obligation-less *by construction* (must not carry a `related_obligation`), and a `disposition` is rejected on any non-unrequested finding.
  - The allow-set is named precisely so **M6** is a one-line, self-documenting extension: add `declaration_mismatch` when builder-declaration comparison lands (design note captured on #31).
- **`UNREQUESTED_CHANGE` constant** single-sources the type string, shared by the M3 producer (`benchmark/coverage.py`) and scorer (`benchmark/scoring.py`) — the string the invariant keys on is no longer a scattered literal.
- **`ScopeExpansionPolicy` (strict/loose)** on `RunConfig`, default `strict` (recall-forward, DR-081). It's a review-interpretation knob for the M3.5.3 separability classifier, so it deliberately does **not** feed `build_client()` or `provenance()` — determinism/replay is untouched (a test asserts two policy-differing configs are provenance-equal).

## The four pre-existing test stubs
Four unit-test `Finding` stubs (`weak_test_evidence` ×3, `obligation_support` ×1) were obligation-less but not unrequested changes. They were **valid** under the old optional-field rule — just minimal stubs testing other mechanics (round-trip, tier auth). Under the strict invariant they now carry a real `related_obligation`, which is the more correct modeling anyway: those findings *are* about an obligation. No production code produced obligation-less non-unrequested findings; the tool already only leaves the slot blank for unrequested changes.

## Test plan
- [x] New `Finding` tests: round-trips with a disposition and no `related_obligation`; rejects an obligation-less non-unrequested finding; rejects an unrequested finding carrying a `related_obligation`; rejects a disposition on a non-unrequested finding; allows an unrequested finding with `disposition=None`.
- [x] New `test_config.py`: policy defaults strict, is configurable, round-trips, and is provenance-neutral.
- [x] Full suite: 263 passed (was 254).
- [x] ruff clean.
- [x] Dogfooded live (`decompose`/`diff`/`classify`) — the tool correctly marked the policy-*consumption* obligation `[unclear]` (that wiring is M3.5.3, not here); flagged "unrequested changes" are the validator/config additions that are the task's own substance.

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)