### PR TITLE
M3.5.3: separability classification for unrequested changes (DR-081)

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,11 +1,13 @@
 # Task
-Add a `disposition` field to unrequested-change findings (in_service / separable / risky), and a strict/loose scope-expansion policy setting.
+Classify each unrequested change's disposition (in_service / separable / risky) via the removability litmus, and emit a split recommendation for separable changes.
 
 ## Constraints
-- Disposition is obligation-less by construction: it appears only on unrequested-change findings.
-- The Finding invariant permits obligation-less findings only for unrequested_change (strict), expressed via a named allow-set that M6 can extend for declaration mismatches.
-- The scope-expansion policy is a strict-vs-loose run setting; it is introduced now and consumed by the separability classifier (M3.5.3).
+- Apply the removability litmus — would the task still be complete if this change were removed? — reusing the M3.1 coverage output: a change whose region is load-bearing for an obligation is in_service.
+- Reconcile the two axes: a change whose region is already addressed-coverage for an obligation must classify as in_service, never a bare unrequested flag.
+- Use a hybrid: deterministic fast-paths for the unambiguous cases, a schema-constrained model judgment (recorded for replay) for the ambiguous modifies-existing cases.
+- Consume the strict/loose scope-expansion policy: strict treats adjacent-behavior edits as risky, loose as separable.
+- Emit an advisory "consider splitting into its own PR / backlog item" recommendation for separable changes.
 
 ## Completion expectations
 - Implementation
-- Unit tests: an unrequested-change finding round-trips with a disposition and no related_obligation; the invariant rejects an obligation-less finding of any other type, an unrequested-change finding that carries a related_obligation, and a disposition on any non-unrequested finding.
+- Unit tests: a load-bearing change → in_service (no model call); a planted separable feature → separable with the split recommendation; a modifies-existing change escalates to the model.

--- a/src/acceptance/benchmark/coverage.py
+++ b/src/acceptance/benchmark/coverage.py
@@ -24,19 +24,36 @@ from pathlib import Path
 from acceptance.benchmark.case import BenchmarkCase
 from acceptance.benchmark.hooks import provenance_from, scored_copy
 from acceptance.change.diff import extract_change_set
+from acceptance.config import ScopeExpansionPolicy
 from acceptance.coverage.classify import CoverageStatus, ImplementationCoverage, classify_coverage
-from acceptance.coverage.unrequested import UnrequestedChange, detect_unrequested_changes
+from acceptance.coverage.disposition import DispositionedChange, classify_dispositions
+from acceptance.coverage.unrequested import detect_unrequested_changes
 from acceptance.evidence_tier import Component, EvidenceTier
 from acceptance.llm import ModelClient
 from acceptance.requirement.obligations import decompose
 from acceptance.requirement.task_file import parse_task_file
-from acceptance.review_state import UNREQUESTED_CHANGE, Finding, Link, Obligation, Review
+from acceptance.review_state import (
+    UNREQUESTED_CHANGE,
+    Finding,
+    Link,
+    Obligation,
+    Review,
+    UnrequestedChangeDisposition,
+)
 
 _SEVERITY_BY_STATUS = {
     CoverageStatus.NOT_ADDRESSED: "high",
     CoverageStatus.PARTIALLY_ADDRESSED: "medium",
     CoverageStatus.UNCLEAR: "low",
     CoverageStatus.REQUIRES_NON_CODE_EVIDENCE: "low",
+}
+
+# An in_service change is accepted; separable should be split; risky demands
+# scrutiny — so severity tracks disposition, not the change's raw kind.
+_SEVERITY_BY_DISPOSITION = {
+    UnrequestedChangeDisposition.IN_SERVICE: "low",
+    UnrequestedChangeDisposition.SEPARABLE: "medium",
+    UnrequestedChangeDisposition.RISKY: "high",
 }
 
 
@@ -59,7 +76,8 @@ def _coverage_finding(obligation: Obligation, coverage: ImplementationCoverage) 
     )
 
 
-def _unrequested_finding(change: UnrequestedChange) -> Finding | None:
+def _unrequested_finding(dispositioned: DispositionedChange) -> Finding | None:
+    change = dispositioned.change
     # No diff location to point to means nothing a human can act on; the
     # required-link invariant (Finding._require_at_least_one_link) would
     # reject it anyway, so skip rather than fabricate a link.
@@ -67,7 +85,7 @@ def _unrequested_finding(change: UnrequestedChange) -> Finding | None:
         return None
     return Finding(
         type=UNREQUESTED_CHANGE,
-        severity="low" if change.kind.value == "internal" else "medium",
+        severity=_SEVERITY_BY_DISPOSITION[dispositioned.disposition],
         description=change.rationale,
         evidence_tier=EvidenceTier.STATIC,
         produced_by=Component.STATIC_ANALYZER,
@@ -75,12 +93,18 @@ def _unrequested_finding(change: UnrequestedChange) -> Finding | None:
             Link(kind="code", ref=f"{ref.file}#{ref.hunk_header}", text=change.rationale)
             for ref in change.diff_refs
         ],
+        disposition=dispositioned.disposition,
+        recommended_action=dispositioned.recommendation,
     )
 
 
-def classify_case(case: BenchmarkCase, client: ModelClient) -> BenchmarkCase:
-    """Decompose, classify coverage, and detect unrequested changes for a
-    case's diff; return a scored copy of `case`."""
+def classify_case(
+    case: BenchmarkCase,
+    client: ModelClient,
+    policy: ScopeExpansionPolicy = ScopeExpansionPolicy.STRICT,
+) -> BenchmarkCase:
+    """Decompose, classify coverage, detect unrequested changes and their
+    dispositions for a case's diff; return a scored copy of `case`."""
     parsed = parse_task_file(case.inputs.task_text)
     obligations = decompose(parsed, client).obligations
     change_set = extract_change_set(
@@ -89,6 +113,9 @@ def classify_case(case: BenchmarkCase, client: ModelClient) -> BenchmarkCase:
 
     coverages = classify_coverage(obligations, change_set, client)
     unrequested = detect_unrequested_changes(obligations, change_set, client)
+    dispositioned = classify_dispositions(
+        unrequested, obligations, coverages, change_set, policy, client
+    )
 
     obligations_by_id = {obligation.id: obligation for obligation in obligations}
     findings = [
@@ -98,7 +125,7 @@ def classify_case(case: BenchmarkCase, client: ModelClient) -> BenchmarkCase:
     ]
     findings.extend(
         finding
-        for finding in (_unrequested_finding(change) for change in unrequested)
+        for finding in (_unrequested_finding(change) for change in dispositioned)
         if finding is not None
     )
 

--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -23,7 +23,8 @@ from pathlib import Path
 from acceptance.change.diff import extract_change_set, extract_working_tree_change_set
 from acceptance.config import DEFAULT_MODEL, RunConfig
 from acceptance.coverage.classify import ImplementationCoverage, classify_coverage
-from acceptance.coverage.unrequested import UnrequestedChange, detect_unrequested_changes
+from acceptance.coverage.disposition import DispositionedChange, classify_dispositions
+from acceptance.coverage.unrequested import detect_unrequested_changes
 from acceptance.llm import LLMError, Mode
 from acceptance.report import render_report
 from acceptance.requirement.obligations import Decomposition, Obligation, decompose
@@ -153,10 +154,10 @@ def render_change_set(change_set: ChangeSet) -> str:
 
 def run_classify(
     task: str, base: str, head: str | None, config: RunConfig, repo: str = "."
-) -> tuple[list[Obligation], list[ImplementationCoverage], list[UnrequestedChange]]:
+) -> tuple[list[Obligation], list[ImplementationCoverage], list[DispositionedChange]]:
     """Decompose a task, extract its change set, classify each obligation against
-    the diff, and flag unrequested changes — a live end-to-end dogfood of
-    M1 + M2 + M3.1 + M3.2."""
+    the diff, flag unrequested changes and classify their dispositions — a live
+    end-to-end dogfood of M1 + M2 + M3.1 + M3.2 + M3.5.3."""
     repo_path = Path(repo)
     parsed = parse_task_file(_read_task(task))
     obligations = decompose(parsed, config.build_client()).obligations
@@ -170,13 +171,17 @@ def run_classify(
 
     coverages = classify_coverage(obligations, change_set, config.build_client())
     unrequested = detect_unrequested_changes(obligations, change_set, config.build_client())
-    return obligations, coverages, unrequested
+    dispositioned = classify_dispositions(
+        unrequested, obligations, coverages, change_set,
+        config.scope_expansion_policy, config.build_client(),
+    )
+    return obligations, coverages, dispositioned
 
 
 def render_classify(
     obligations: list[Obligation],
     coverages: list[ImplementationCoverage],
-    unrequested: list[UnrequestedChange],
+    dispositioned: list[DispositionedChange],
 ) -> str:
     descriptions = {o.id: o.description for o in obligations}
     lines = ["Implementation coverage (code only — not test evidence):"]
@@ -187,13 +192,16 @@ def render_classify(
         lines.append(f"  [{cov.status.value}] {cov.obligation_id}: {descriptions.get(cov.obligation_id, '')}")
         lines.append(f"      -> {refs}")
     lines.append("")
-    lines.append("Unrequested changes (no obligation calls for these):")
-    if not unrequested:
+    lines.append("Unrequested changes (no obligation calls for these — your call):")
+    if not dispositioned:
         lines.append("  (none)")
-    for change in unrequested:
+    for item in dispositioned:
+        change = item.change
         refs = ", ".join(f"{r.file}" for r in change.diff_refs) or "?"
-        lines.append(f"  [{change.kind.value}] {change.rationale}")
+        lines.append(f"  [{item.disposition.value}] ({change.kind.value}) {change.rationale}")
         lines.append(f"      -> {refs}")
+        if item.recommendation:
+            lines.append(f"      recommendation: {item.recommendation}")
     return "\n".join(lines)
 
 
@@ -343,7 +351,7 @@ def main(argv: list[str] | None = None) -> int:
             temperature=args.temperature,
         )
         try:
-            obligations, coverages, unrequested = run_classify(
+            obligations, coverages, dispositioned = run_classify(
                 args.task, args.base, args.head, config, args.repo
             )
         except CliError as exc:
@@ -357,13 +365,13 @@ def main(argv: list[str] | None = None) -> int:
                 json.dumps(
                     {
                         "coverage": [c.to_dict() for c in coverages],
-                        "unrequested_changes": [u.to_dict() for u in unrequested],
+                        "unrequested_changes": [d.to_dict() for d in dispositioned],
                     },
                     indent=2,
                 )
             )
         else:
-            print(render_classify(obligations, coverages, unrequested))
+            print(render_classify(obligations, coverages, dispositioned))
         return 0
 
     parser.error(f"unknown command: {args.command}")

--- a/src/acceptance/coverage/disposition.py
+++ b/src/acceptance/coverage/disposition.py
@@ -1,0 +1,232 @@
+"""Separability classification for unrequested changes (M3.5.3, §9.2, DR-081).
+
+Every unrequested change (detected by unrequested.py) gets a **disposition** —
+how a reviewer should treat it:
+
+- `in_service`  — needed to deliver an obligation (a refactor/helper the
+  requested work depends on), even though nothing asked for it directly.
+  Removing it would leave an obligation incomplete.
+- `separable`   — coherent, self-contained work, valuable but distinct; belongs
+  in its own PR / backlog item. Removing it leaves every obligation complete.
+- `risky`       — edits existing public interface, dependencies, or adjacent
+  behavior in a way that could hide a regression. Scrutinize.
+
+The classifier is a **hybrid** (chosen deliberately, not for cheapness):
+
+1. Deterministic fast-paths for the unambiguous cases, using judgments already
+   produced upstream — no new model call:
+   - the change's region overlaps a region the M3.1 coverage classifier marked
+     `addressed` for some obligation → the obligation's implementation lives
+     there → **in_service**. (This is the two-axis reconciliation from #85: a
+     coverage-mapped region is never a bare unrequested flag.) Only `addressed`
+     counts — a `partially_addressed` region can be the one that *violates* a
+     leave-as-is obligation, which is ambiguous and escalates.
+   - a pure new-file addition that no obligation's coverage claims → new,
+     self-contained work → **separable**.
+2. Everything else — edits to existing code with no clean coverage attribution —
+   is the genuinely ambiguous case (indirect dependency? distinct work?
+   regression risk?), so it escalates to a schema-constrained model judgment
+   through the M0.4 harness (recorded for replay).
+
+Known limitation (documented, not silently accepted): the deterministic
+in_service path only sees *direct* coverage overlap, and the pure-addition path
+can't tell a genuinely independent new file from a new load-bearing helper that
+a requested feature imports. Both residual cases are indirect dependencies; a
+call-graph reach analysis (M2.2 machinery) would tighten them. The model path
+covers the modifies-existing ambiguity, which is the bulk of the hard cases.
+
+Detection stays recall-forward (DR-081 dec. 3): an in_service change is still a
+correctly *detected* unrequested change and still a Finding — the disposition
+governs how it is *treated*, not whether it was found.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from acceptance.config import ScopeExpansionPolicy
+from acceptance.coverage.classify import CoverageStatus, ImplementationCoverage
+from acceptance.coverage.prompt import DiffRef
+from acceptance.coverage.unrequested import UnrequestedChange
+from acceptance.llm import ModelClient, StrictResponseModel
+from acceptance.model_base import PersistableModel
+from acceptance.review_state import ChangeSet, Obligation, UnrequestedChangeDisposition
+
+_SPLIT_RECOMMENDATION = (
+    "Consider splitting this into its own PR / backlog item — it is separable "
+    "from the mandate."
+)
+_SCRUTINIZE_RECOMMENDATION = (
+    "Scrutinize: this edits existing public/adjacent behavior and could hide a "
+    "regression."
+)
+
+_RECOMMENDATION = {
+    UnrequestedChangeDisposition.SEPARABLE: _SPLIT_RECOMMENDATION,
+    UnrequestedChangeDisposition.RISKY: _SCRUTINIZE_RECOMMENDATION,
+    UnrequestedChangeDisposition.IN_SERVICE: None,
+}
+
+
+class DispositionedChange(PersistableModel):
+    """An unrequested change with its disposition, why, and how it was decided."""
+
+    change: UnrequestedChange
+    disposition: UnrequestedChangeDisposition
+    rationale: str
+    recommendation: str | None = None
+    decided_by: Literal["structural", "model"] = "structural"
+
+
+_SYSTEM_PROMPT = """\
+You classify one UNREQUESTED code change — a change no listed obligation called
+for — into exactly one disposition, using the removability litmus:
+
+  Would EVERY obligation still be satisfied if this change were removed?
+
+- in_service: NO — some obligation depends on this change (e.g. a refactor or
+  helper the requested feature needs), even though nothing requested it
+  directly. Removing it would leave an obligation incomplete.
+- separable: YES, and it is coherent, self-contained work — valuable but a
+  DISTINCT unit that belongs in its own PR / backlog item.
+- risky: YES, but it edits existing public interface, dependencies, or adjacent
+  behavior in a way that could hide a regression. Scrutinize.
+
+Policy knob: under a STRICT scope-expansion policy, treat an edit to existing
+adjacent behavior as `risky`; under a LOOSE policy, treat it as merely
+`separable`. Load-bearing changes are `in_service` and public-interface or
+dependency edits are `risky` under BOTH policies.
+
+Return the `disposition` and a short `rationale`."""
+
+
+class _DispositionJudgment(StrictResponseModel):
+    disposition: UnrequestedChangeDisposition
+    rationale: str
+
+
+def _region_key(ref: DiffRef) -> tuple[str, str]:
+    return (ref.file, ref.hunk_header)
+
+
+def _addressed_regions(coverages: list[ImplementationCoverage]) -> set[tuple[str, str]]:
+    return {
+        _region_key(ref)
+        for coverage in coverages
+        if coverage.status == CoverageStatus.ADDRESSED
+        for ref in coverage.diff_refs
+    }
+
+
+def _is_load_bearing(change: UnrequestedChange, addressed: set[tuple[str, str]]) -> bool:
+    return any(_region_key(ref) in addressed for ref in change.diff_refs)
+
+
+def _is_pure_addition(change: UnrequestedChange, change_set: ChangeSet) -> bool:
+    if not change.diff_refs:
+        return False
+    status_by_path = {f.path: f.status for f in change_set.files}
+    return all(status_by_path.get(ref.file) == "added" for ref in change.diff_refs)
+
+
+def _dispositioned(
+    change: UnrequestedChange,
+    disposition: UnrequestedChangeDisposition,
+    rationale: str,
+    decided_by: Literal["structural", "model"],
+) -> DispositionedChange:
+    return DispositionedChange(
+        change=change,
+        disposition=disposition,
+        rationale=rationale,
+        recommendation=_RECOMMENDATION[disposition],
+        decided_by=decided_by,
+    )
+
+
+def _render_judgment_prompt(
+    change: UnrequestedChange,
+    obligations: list[Obligation],
+    coverages: list[ImplementationCoverage],
+    change_set: ChangeSet,
+    policy: ScopeExpansionPolicy,
+) -> str:
+    status_by_id = {c.obligation_id: c.status.value for c in coverages}
+    lines = [f"Scope-expansion policy: {policy.value}", "", "## Obligations (with coverage)"]
+    for obligation in obligations:
+        status = status_by_id.get(obligation.id, "unclassified")
+        lines.append(f"- id={obligation.id} [{status}]: {obligation.description}")
+    lines.append("")
+    lines.append("## Unrequested change under review")
+    lines.append(f"kind={change.kind.value}; rationale={change.rationale}")
+    lines.append("")
+    lines.append("### Changed hunks")
+    hunk_by_key = {
+        (f.path, hunk.header): hunk for f in change_set.files for hunk in f.hunks
+    }
+    for ref in change.diff_refs:
+        status = next((f.status for f in change_set.files if f.path == ref.file), "?")
+        lines.append(f"[{ref.file} ({status})] {ref.hunk_header}")
+        hunk = hunk_by_key.get((ref.file, ref.hunk_header))
+        if hunk is not None:
+            lines.append(hunk.content)
+    return "\n".join(lines)
+
+
+def _judge_disposition(
+    change: UnrequestedChange,
+    obligations: list[Obligation],
+    coverages: list[ImplementationCoverage],
+    change_set: ChangeSet,
+    policy: ScopeExpansionPolicy,
+    client: ModelClient,
+) -> DispositionedChange:
+    messages = [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {
+            "role": "user",
+            "content": _render_judgment_prompt(change, obligations, coverages, change_set, policy),
+        },
+    ]
+    result = client.complete(messages, _DispositionJudgment)
+    return _dispositioned(change, result.disposition, result.rationale, decided_by="model")
+
+
+def classify_dispositions(
+    changes: list[UnrequestedChange],
+    obligations: list[Obligation],
+    coverages: list[ImplementationCoverage],
+    change_set: ChangeSet,
+    policy: ScopeExpansionPolicy,
+    client: ModelClient,
+) -> list[DispositionedChange]:
+    """Classify each unrequested change's disposition (hybrid: deterministic
+    fast-paths, model judgment for the ambiguous rest)."""
+    addressed = _addressed_regions(coverages)
+    results: list[DispositionedChange] = []
+    for change in changes:
+        if _is_load_bearing(change, addressed):
+            results.append(
+                _dispositioned(
+                    change,
+                    UnrequestedChangeDisposition.IN_SERVICE,
+                    "The change's region is where an obligation is addressed; it is "
+                    "load-bearing for that obligation.",
+                    decided_by="structural",
+                )
+            )
+        elif _is_pure_addition(change, change_set):
+            results.append(
+                _dispositioned(
+                    change,
+                    UnrequestedChangeDisposition.SEPARABLE,
+                    "A self-contained addition in newly added file(s) that no "
+                    "obligation's coverage claims.",
+                    decided_by="structural",
+                )
+            )
+        else:
+            results.append(
+                _judge_disposition(change, obligations, coverages, change_set, policy, client)
+            )
+    return results

--- a/tests/benchmark/test_coverage.py
+++ b/tests/benchmark/test_coverage.py
@@ -208,6 +208,12 @@ def test_archetype_8_unrequested_change_gap_matches_via_its_obligation(tmp_path)
                     }
                 ]
             },
+            # cart.py is modified (not a pure addition) and leave-existing is not
+            # `addressed`, so the disposition escalates to a model judgment.
+            "_DispositionJudgment": {
+                "disposition": "risky",
+                "rationale": "edits checkout's existing public signature; could hide a regression.",
+            },
         }
     )
 
@@ -273,6 +279,12 @@ def test_archetype_8_unrequested_change_metric_does_not_route_through_coverage(t
                         "diff_refs": [cart_ref],
                     }
                 ]
+            },
+            # cart.py is modified (not a pure addition) and leave-existing is not
+            # `addressed`, so the disposition escalates to a model judgment.
+            "_DispositionJudgment": {
+                "disposition": "risky",
+                "rationale": "edits checkout's existing public signature; could hide a regression.",
             },
         }
     )

--- a/tests/coverage/test_disposition.py
+++ b/tests/coverage/test_disposition.py
@@ -1,0 +1,177 @@
+"""M3.5.3 acceptance: separability classification for unrequested changes.
+
+The classifier is a hybrid (M3.5.3 / DR-081): deterministic fast-paths for the
+unambiguous cases (coverage-overlap -> in_service; pure new-file addition ->
+separable) with no model call, and a schema-constrained model judgment for the
+ambiguous "modifies existing code" rest — recorded for replay, no live calls.
+A client that raises on use proves the fast-paths take no model call.
+"""
+
+import json
+import tempfile
+from types import SimpleNamespace
+
+from acceptance.config import ScopeExpansionPolicy
+from acceptance.coverage.classify import CoverageStatus, DiffRef, ImplementationCoverage
+from acceptance.coverage.disposition import DispositionedChange, classify_dispositions
+from acceptance.coverage.unrequested import UnrequestedChange, UnrequestedChangeKind
+from acceptance.llm import Mode, ModelClient, TranscriptStore
+from acceptance.review_state import (
+    ChangeSet,
+    DiffHunk,
+    FileChange,
+    Obligation,
+    ObligationType,
+    UnrequestedChangeDisposition,
+)
+from tests.support import client_dispatching
+
+
+def _obligation(obligation_id: str) -> Obligation:
+    return Obligation(
+        id=obligation_id, description=f"{obligation_id} obligation",
+        type=ObligationType.FUNCTIONAL, importance="critical", explicit=True,
+        observable_behavior="...",
+    )
+
+
+def _hunk(header: str = "@@ -1 +1 @@") -> DiffHunk:
+    return DiffHunk(header=header, old_start=1, old_lines=1, new_start=1, new_lines=1, content="+x")
+
+
+def _change(file: str, header: str = "@@ -1 +1 @@", kind=UnrequestedChangeKind.ADJACENT_BEHAVIOR):
+    return UnrequestedChange(
+        kind=kind, rationale=f"unrequested change in {file}",
+        diff_refs=[DiffRef(file=file, hunk_header=header)],
+    )
+
+
+def _exploding_client() -> ModelClient:
+    """A client whose completion_fn must never be called — proves a
+    deterministic fast-path issued no model call."""
+
+    def boom(**kwargs):
+        raise AssertionError("a model call was issued on a deterministic fast-path")
+
+    return ModelClient(
+        model="x", mode=Mode.RECORD, store=TranscriptStore(tempfile.mkdtemp()), completion_fn=boom
+    )
+
+
+def test_load_bearing_change_is_in_service_without_a_model_call():
+    # The change's region is exactly where an obligation is `addressed`.
+    change_set = ChangeSet(base_revision="a", head_revision="b", files=[
+        FileChange(path="pkg.py", status="modified", category="source", hunks=[_hunk()]),
+    ])
+    coverages = [ImplementationCoverage(
+        obligation_id="ob-1", status=CoverageStatus.ADDRESSED, rationale="here",
+        diff_refs=[DiffRef(file="pkg.py", hunk_header="@@ -1 +1 @@")],
+    )]
+    changes = [_change("pkg.py")]
+
+    result = classify_dispositions(
+        changes, [_obligation("ob-1")], coverages, change_set,
+        ScopeExpansionPolicy.STRICT, _exploding_client(),
+    )
+
+    assert result[0].disposition is UnrequestedChangeDisposition.IN_SERVICE
+    assert result[0].decided_by == "structural"
+    assert result[0].recommendation is None
+
+
+def test_pure_new_file_addition_is_separable_without_a_model_call():
+    change_set = ChangeSet(base_revision="a", head_revision="b", files=[
+        FileChange(path="extra.py", status="added", category="source", hunks=[_hunk()]),
+    ])
+    changes = [_change("extra.py")]
+
+    result = classify_dispositions(
+        changes, [_obligation("ob-1")], [], change_set,
+        ScopeExpansionPolicy.STRICT, _exploding_client(),
+    )
+
+    assert result[0].disposition is UnrequestedChangeDisposition.SEPARABLE
+    assert result[0].decided_by == "structural"
+    assert "splitting" in result[0].recommendation
+
+
+def test_partially_addressed_overlap_does_not_shortcut_to_in_service():
+    # A partially_addressed region can be the one that *violates* a leave-as-is
+    # obligation (archetype #8), so it must NOT deterministically become
+    # in_service — it escalates to the model.
+    change_set = ChangeSet(base_revision="a", head_revision="b", files=[
+        FileChange(path="cart.py", status="modified", category="source", hunks=[_hunk()]),
+    ])
+    coverages = [ImplementationCoverage(
+        obligation_id="leave-existing", status=CoverageStatus.PARTIALLY_ADDRESSED,
+        rationale="default still ok", diff_refs=[DiffRef(file="cart.py", hunk_header="@@ -1 +1 @@")],
+    )]
+    changes = [_change("cart.py", kind=UnrequestedChangeKind.PUBLIC_INTERFACE)]
+    client = client_dispatching({"_DispositionJudgment": {
+        "disposition": "risky", "rationale": "edits existing public signature",
+    }})
+
+    result = classify_dispositions(
+        changes, [_obligation("leave-existing")], coverages, change_set,
+        ScopeExpansionPolicy.STRICT, client,
+    )
+
+    assert result[0].disposition is UnrequestedChangeDisposition.RISKY
+    assert result[0].decided_by == "model"
+    assert "Scrutinize" in result[0].recommendation
+
+
+def test_modifies_existing_escalates_to_the_model():
+    change_set = ChangeSet(base_revision="a", head_revision="b", files=[
+        FileChange(path="mod.py", status="modified", category="source", hunks=[_hunk()]),
+    ])
+    changes = [_change("mod.py")]
+    client = client_dispatching({"_DispositionJudgment": {
+        "disposition": "separable", "rationale": "distinct helper, task complete without it",
+    }})
+
+    result = classify_dispositions(
+        changes, [_obligation("ob-1")], [], change_set,
+        ScopeExpansionPolicy.LOOSE, client,
+    )
+
+    assert result[0].disposition is UnrequestedChangeDisposition.SEPARABLE
+    assert result[0].decided_by == "model"
+
+
+def test_policy_is_surfaced_to_the_model_judgment():
+    # strict vs loose changes the adjacent-behavior verdict, so the model must
+    # see the policy. Capture the prompt and assert the policy is in it.
+    change_set = ChangeSet(base_revision="a", head_revision="b", files=[
+        FileChange(path="mod.py", status="modified", category="source", hunks=[_hunk()]),
+    ])
+    changes = [_change("mod.py")]
+    seen = {}
+
+    def capture(**kwargs):
+        seen["prompt"] = kwargs["messages"][-1]["content"]
+        content = json.dumps({"disposition": "risky", "rationale": "adjacent edit"})
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+
+    client = ModelClient(model="x", mode=Mode.RECORD,
+                         store=TranscriptStore(tempfile.mkdtemp()), completion_fn=capture)
+
+    classify_dispositions(changes, [_obligation("ob-1")], [], change_set,
+                          ScopeExpansionPolicy.LOOSE, client)
+
+    assert "loose" in seen["prompt"]
+
+
+def test_dispositioned_change_round_trips():
+    change_set = ChangeSet(base_revision="a", head_revision="b", files=[
+        FileChange(path="extra.py", status="added", category="source", hunks=[_hunk()]),
+    ])
+    result = classify_dispositions(
+        [_change("extra.py")], [_obligation("ob-1")], [], change_set,
+        ScopeExpansionPolicy.STRICT, _exploding_client(),
+    )[0]
+
+    assert DispositionedChange.from_dict(result.to_dict()) == result

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -240,8 +240,9 @@ def test_classify_replay_without_transcript_fails_cleanly(
 def test_render_classify_output():
     from acceptance.cli import render_classify
     from acceptance.coverage.classify import CoverageStatus, DiffRef, ImplementationCoverage
+    from acceptance.coverage.disposition import DispositionedChange
     from acceptance.coverage.unrequested import UnrequestedChange, UnrequestedChangeKind
-    from acceptance.review_state import Obligation, ObligationType
+    from acceptance.review_state import Obligation, ObligationType, UnrequestedChangeDisposition
 
     obligations = [
         Obligation(id="ob-1", description="Do the thing.", type=ObligationType.FUNCTIONAL,
@@ -258,19 +259,27 @@ def test_render_classify_output():
             obligation_id="ob-2", status=CoverageStatus.NOT_ADDRESSED, rationale="missing",
         ),
     ]
-    unrequested = [
-        UnrequestedChange(
-            kind=UnrequestedChangeKind.PUBLIC_INTERFACE,
-            rationale="checkout signature changed",
-            diff_refs=[DiffRef(file="cart.py", hunk_header="@@ -1 +1 @@")],
+    dispositioned = [
+        DispositionedChange(
+            change=UnrequestedChange(
+                kind=UnrequestedChangeKind.PUBLIC_INTERFACE,
+                rationale="checkout signature changed",
+                diff_refs=[DiffRef(file="cart.py", hunk_header="@@ -1 +1 @@")],
+            ),
+            disposition=UnrequestedChangeDisposition.RISKY,
+            rationale="edits an existing public signature",
+            recommendation="Scrutinize: this could hide a regression.",
         )
     ]
 
-    rendered = render_classify(obligations, coverages, unrequested)
+    rendered = render_classify(obligations, coverages, dispositioned)
     assert "[addressed] ob-1: Do the thing." in rendered
     assert "pkg.py" in rendered
     assert "[not_addressed] ob-2: Handle the edge." in rendered
     assert "no corresponding change" in rendered
     assert "Unrequested changes" in rendered
-    assert "[public_interface] checkout signature changed" in rendered
+    # Each unrequested change now leads with its disposition, keeps its kind,
+    # and carries any recommendation.
+    assert "[risky] (public_interface) checkout signature changed" in rendered
     assert "cart.py" in rendered
+    assert "Scrutinize" in rendered


### PR DESCRIPTION
## Summary
New `coverage/disposition.py` — `classify_dispositions()` assigns each unrequested change an `in_service` / `separable` / `risky` disposition via the removability litmus. **Hybrid** design (from the discussion on this):

- **Deterministic fast-paths, no model call:**
  - the change's region overlaps an `addressed` coverage region → load-bearing → **`in_service`**. This is the two-axis reconciliation from #85 — a coverage-mapped region is never a bare unrequested flag. Only `addressed` short-cuts; a `partially_addressed` region can be the one that *violates* a leave-as-is obligation (archetype #8), so it escalates.
  - a pure new-file addition → **`separable`**.
- **Model judgment (schema-constrained, recorded for replay)** for the ambiguous "modifies existing code" rest, so an indirect load-bearing dependency or a genuine regression risk gets real reasoning. Consumes the strict/loose policy: **strict** treats adjacent-behavior edits as `risky`, **loose** as `separable`.

`separable` carries a "split into its own PR / backlog item" recommendation; `risky` carries "scrutinize." Wired into the benchmark hook (`Finding` gets `disposition` + `recommended_action`; severity now tracks disposition) and the CLI (each unrequested change renders with its disposition + recommendation).

**Honest scope:** this is *not* LLM-free — it's a reducer over judgments already made (M3.1 coverage `diff_refs`, M3.2 `kind`) plus deterministic git file-status, with a new model call only on the ambiguous branch. Documented limitation: the deterministic paths see only *direct* coverage overlap, so an indirect load-bearing dependency (a helper a feature imports but coverage didn't attribute) can be mislabeled; the model path covers the modifies-existing bulk.

## Dogfood payoff
`acceptance classify` on this PR's own diff labeled its supporting changes **`[in_service]`** on its own — the judgment the reviewer had been making by hand in every prior dogfood. The bare "unrequested change" flags that I kept dismissing are now classified by the tool (closes the loop from #85).

## Test plan
- [x] `tests/coverage/test_disposition.py`: load-bearing → `in_service` **with an exploding client** (proves no model call); pure addition → `separable` + split recommendation, no model call; `partially_addressed` overlap does NOT shortcut (escalates); modifies-existing escalates to the model; policy is surfaced into the model prompt; round-trip.
- [x] Updated the M3.5.1 archetype-#8 end-to-end tests (they now escalate → inject a `_DispositionJudgment`); the unrequested **metric** is unchanged (disposition doesn't affect it).
- [x] Full suite: 269 passed (was 263); ruff clean.
- [x] Dogfooded live (`decompose`/`diff`/`classify`).

Dedicated `separable` / `in_service` / `risky` archetype fixtures land in M3.5.4.

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)