### PR TITLE
M3.5.4: expand unrequested-change archetypes beyond #8 (DR-081)

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,13 +1,11 @@
 # Task
-Classify each unrequested change's disposition (in_service / separable / risky) via the removability litmus, and emit a split recommendation for separable changes.
+Expand the unrequested-change archetypes beyond #8 with three sibling fixtures — a separable extra feature, an in-service refactor, and a risky adjacent-behavior change — each with ground-truth disposition labels.
 
 ## Constraints
-- Apply the removability litmus — would the task still be complete if this change were removed? — reusing the M3.1 coverage output: a change whose region is load-bearing for an obligation is in_service.
-- Reconcile the two axes: a change whose region is already addressed-coverage for an obligation must classify as in_service, never a bare unrequested flag.
-- Use a hybrid: deterministic fast-paths for the unambiguous cases, a schema-constrained model judgment (recorded for replay) for the ambiguous modifies-existing cases.
-- Consume the strict/loose scope-expansion policy: strict treats adjacent-behavior edits as risky, loose as separable.
-- Emit an advisory "consider splitting into its own PR / backlog item" recommendation for separable changes.
+- Each fixture must materialize as a real two-commit git repo with a non-empty base->head diff and a pytest suite that runs with its declared intended outcome.
+- Ground truth must label each unrequested change's disposition (in_service / separable / risky), backed by a plausible rationale under the removability litmus.
+- The separable and in-service scenarios must be genuinely distinct: the in-service change must be load-bearing for the requested obligation (removing it breaks completion), not merely tidier.
 
 ## Completion expectations
-- Implementation
-- Unit tests: a load-bearing change → in_service (no model call); a planted separable feature → separable with the split recommendation; a modifies-existing change escalates to the model.
+- Fixtures (task.md, base/, head/, meta.json, labels.json) for each of the three dispositions
+- Ground truth validated against the existing generic archetype test suite

--- a/src/acceptance/benchmark/case.py
+++ b/src/acceptance/benchmark/case.py
@@ -27,7 +27,8 @@ result with no stated reason.
 obligation with no matching code; an unrequested change is code with no
 matching obligation) and is therefore obligation-*less* by construction —
 scored as its own precision/recall pair (DR-081), never folded into the gap
-metric (M3.5.1).
+metric (M3.5.1). Each carries a required `disposition` (M3.5.4): in_service /
+separable / risky, human-labeled the same way `evidence_class` is.
 
 `reviewer_output` and `score` start empty and are filled in by the runner
 (M-B0.2) and scorer (M-B0.3) — a case is valid the moment it carries real
@@ -41,7 +42,7 @@ from typing import Literal
 from pydantic import Field, model_validator
 
 from acceptance.model_base import PersistableModel
-from acceptance.review_state import Review
+from acceptance.review_state import Review, UnrequestedChangeDisposition
 
 # §9.3 test-evidence strength classifications. Distinct from EvidenceTier
 # (evidence_tier.py), which grades *how* evidence was produced, not how strong
@@ -124,11 +125,19 @@ class GroundTruthUnrequestedChange(PersistableModel):
     exact hunk header would be brittle to keep in sync with the fixture's
     real diff). Coarser than line-level, but matches the granularity the
     existing gap metric already scores at (by obligation, not by line
-    range)."""
+    range).
+
+    `disposition` is required (M3.5.4): every unrequested change in the
+    ground truth is labeled in_service / separable / risky by a human, the
+    same "no result without a reason" discipline `evidence_rationale`
+    already enforces on obligations. Per-disposition scoring accuracy is
+    deferred to Stage 2 (DR-081); the label exists now for human validation
+    and to seed that future metric."""
 
     id: str
     description: str
     file: str
+    disposition: UnrequestedChangeDisposition
 
 
 class GroundTruthLabels(PersistableModel):

--- a/tests/benchmark/test_case.py
+++ b/tests/benchmark/test_case.py
@@ -159,7 +159,8 @@ def test_unrequested_change_round_trips():
     labels = _labels(
         unrequested_changes=[
             GroundTruthUnrequestedChange(
-                id="u1", description="an extra helper nobody asked for", file="cart.py"
+                id="u1", description="an extra helper nobody asked for", file="cart.py",
+                disposition="separable",
             )
         ]
     )
@@ -171,7 +172,9 @@ def test_unrequested_change_is_not_an_obligation_reference():
     # field at all, so it can never be validated against `known` obligations.
     labels = _labels(
         unrequested_changes=[
-            GroundTruthUnrequestedChange(id="u1", description="drive-by refactor", file="cart.py")
+            GroundTruthUnrequestedChange(
+                id="u1", description="drive-by refactor", file="cart.py", disposition="in_service"
+            )
         ]
     )
     assert not hasattr(labels.unrequested_changes[0], "obligation_id")
@@ -182,8 +185,12 @@ def test_duplicate_unrequested_change_ids_fail_validation():
         GroundTruthLabels(
             obligations=[_obligation()],
             unrequested_changes=[
-                GroundTruthUnrequestedChange(id="u1", description="a", file="cart.py"),
-                GroundTruthUnrequestedChange(id="u1", description="b", file="pricing.py"),
+                GroundTruthUnrequestedChange(
+                    id="u1", description="a", file="cart.py", disposition="separable"
+                ),
+                GroundTruthUnrequestedChange(
+                    id="u1", description="b", file="pricing.py", disposition="risky"
+                ),
             ],
         )
 
@@ -193,9 +200,16 @@ def test_empty_unrequested_change_file_fails_validation():
         GroundTruthLabels(
             obligations=[_obligation()],
             unrequested_changes=[
-                GroundTruthUnrequestedChange(id="u1", description="a", file="  ")
+                GroundTruthUnrequestedChange(
+                    id="u1", description="a", file="  ", disposition="risky"
+                )
             ],
         )
+
+
+def test_unrequested_change_requires_a_disposition():
+    with pytest.raises(ValueError):
+        GroundTruthUnrequestedChange(id="u1", description="a", file="cart.py")
 
 
 def test_benchmark_case_source_round_trips():

--- a/tests/benchmark/test_fixtures.py
+++ b/tests/benchmark/test_fixtures.py
@@ -1,9 +1,12 @@
 """M-B5a.1 acceptance: each archetype fixture builds, has a non-empty
 base->head diff, and its pytest suite runs with the intended outcome.
 
-The nine archetypes are the §13.5 #1-9 demonstration scenarios; each embodies
-a plausible mistake a capable coding agent could actually make, hidden behind
-a green test suite — which is exactly what the checker must learn to catch.
+The nine numbered archetypes are the §13.5 #1-9 demonstration scenarios; each
+embodies a plausible mistake a capable coding agent could actually make,
+hidden behind a green test suite — which is exactly what the checker must
+learn to catch. M3.5.4 adds three **sibling** archetypes to #8 (DR-081): they
+share its scenario number (8) but a distinct `name`, one per unrequested-change
+disposition (in_service / separable / risky) that #8 alone doesn't cover.
 """
 
 import subprocess
@@ -30,9 +33,17 @@ EXPECTED_NAMES = {
     "09-revision-cycle",
 }
 
+# The three #8 siblings (M3.5.4/DR-081): one archetype per unrequested-change
+# disposition #8 alone doesn't demonstrate.
+EXPECTED_SIBLING_NAMES = {
+    "08-unrequested-change-in-service",
+    "08-unrequested-change-separable",
+    "08-unrequested-change-risky-adjacent",
+}
 
-def test_all_nine_archetypes_are_present():
-    assert {p.name for p in FIXTURE_DIRS} == EXPECTED_NAMES
+
+def test_all_expected_archetypes_are_present():
+    assert {p.name for p in FIXTURE_DIRS} == EXPECTED_NAMES | EXPECTED_SIBLING_NAMES
 
 
 @pytest.fixture(params=FIXTURE_DIRS, ids=lambda p: p.name)

--- a/tests/benchmark/test_scoring_report.py
+++ b/tests/benchmark/test_scoring_report.py
@@ -129,7 +129,9 @@ def _case_a() -> BenchmarkCase:
             ],
             gaps=[GroundTruthGap(id="gap-beta", description="Beta missing", obligation_id="beta")],
             unrequested_changes=[
-                GroundTruthUnrequestedChange(id="u-x", description="x.py changed", file="x.py")
+                GroundTruthUnrequestedChange(
+                    id="u-x", description="x.py changed", file="x.py", disposition="separable"
+                )
             ],
         ),
         reviewer_output=Review(

--- a/tests/fixtures/archetypes/08-unrequested-change-in-service/base/cart.py
+++ b/tests/fixtures/archetypes/08-unrequested-change-in-service/base/cart.py
@@ -1,0 +1,11 @@
+def format_total(amount):
+    return f"${amount:.2f}"
+
+
+def checkout(items):
+    subtotal = sum(item["price"] for item in items)
+    return format_total(subtotal)
+
+
+def apply_discount(cart, percent):
+    raise NotImplementedError

--- a/tests/fixtures/archetypes/08-unrequested-change-in-service/head/cart.py
+++ b/tests/fixtures/archetypes/08-unrequested-change-in-service/head/cart.py
@@ -1,0 +1,14 @@
+def format_total(amount, currency="USD"):
+    symbol = "$" if currency == "USD" else currency + " "
+    return f"{symbol}{amount:.2f}"
+
+
+def checkout(items):
+    subtotal = sum(item["price"] for item in items)
+    return format_total(subtotal)
+
+
+def apply_discount(cart, percent, currency="USD"):
+    subtotal = sum(item["price"] for item in cart)
+    discounted = subtotal * (1 - percent / 100)
+    return format_total(discounted, currency)

--- a/tests/fixtures/archetypes/08-unrequested-change-in-service/head/test_cart.py
+++ b/tests/fixtures/archetypes/08-unrequested-change-in-service/head/test_cart.py
@@ -1,0 +1,15 @@
+from cart import apply_discount, checkout
+
+
+def test_apply_discount_formats_as_money():
+    cart = [{"price": 100.0}]
+    assert apply_discount(cart, 10) == "$90.00"
+
+
+def test_apply_discount_supports_other_currency():
+    cart = [{"price": 100.0}]
+    assert apply_discount(cart, 10, currency="EUR") == "EUR 90.00"
+
+
+def test_checkout_still_works():
+    assert checkout([{"price": 50.0}]) == "$50.00"

--- a/tests/fixtures/archetypes/08-unrequested-change-in-service/labels.json
+++ b/tests/fixtures/archetypes/08-unrequested-change-in-service/labels.json
@@ -1,0 +1,32 @@
+{
+  "obligations": [
+    {
+      "id": "apply-discount",
+      "description": "Reduce the cart's subtotal by the given percentage",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "The test asserts apply_discount reduces a $100 subtotal by 10% to $90; a wrong discount computation would fail.",
+      "candidate_tests": ["test_cart.py::test_apply_discount_formats_as_money"]
+    },
+    {
+      "id": "format-as-money",
+      "description": "Return the result formatted as money (e.g. \"$90.00\")",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Both tests assert the exact formatted string (\"$90.00\", \"EUR 90.00\"); wrong or missing formatting would fail.",
+      "candidate_tests": [
+        "test_cart.py::test_apply_discount_formats_as_money",
+        "test_cart.py::test_apply_discount_supports_other_currency"
+      ]
+    }
+  ],
+  "gaps": [],
+  "unrequested_changes": [
+    {
+      "id": "in-service-format-total-widening",
+      "description": "format_total's signature was widened with a currency parameter so apply_discount could format its result consistently with checkout's existing formatting. Nothing in the task asked for format_total to change, but apply_discount cannot format its result without it -- removing the widening breaks the apply_discount obligation, not just tidiness. checkout is unaffected since the parameter defaults to USD.",
+      "file": "cart.py",
+      "disposition": "in_service"
+    }
+  ]
+}

--- a/tests/fixtures/archetypes/08-unrequested-change-in-service/meta.json
+++ b/tests/fixtures/archetypes/08-unrequested-change-in-service/meta.json
@@ -1,0 +1,6 @@
+{
+  "scenario": 8,
+  "name": "unrequested-change-in-service",
+  "intended_pytest": "pass",
+  "summary": "Delivering apply_discount requires widening the existing format_total() helper with a currency parameter (defaulted, so checkout is unaffected). The task never asked for format_total to change, but apply_discount cannot work without it -- the widening is in service of the requested obligation, not scope creep."
+}

--- a/tests/fixtures/archetypes/08-unrequested-change-in-service/task.md
+++ b/tests/fixtures/archetypes/08-unrequested-change-in-service/task.md
@@ -1,0 +1,5 @@
+# Task: Apply a discount to the cart
+
+Add `apply_discount(cart, percent)` to `cart.py`. It should reduce the
+cart's subtotal by the given percentage and return the result formatted as
+money (e.g. `"$90.00"`).

--- a/tests/fixtures/archetypes/08-unrequested-change-risky-adjacent/base/orders.py
+++ b/tests/fixtures/archetypes/08-unrequested-change-risky-adjacent/base/orders.py
@@ -1,0 +1,7 @@
+def ship_order(order):
+    order["status"] = "shipped"
+    return True
+
+
+def cancel_order(order):
+    raise NotImplementedError

--- a/tests/fixtures/archetypes/08-unrequested-change-risky-adjacent/head/orders.py
+++ b/tests/fixtures/archetypes/08-unrequested-change-risky-adjacent/head/orders.py
@@ -1,0 +1,9 @@
+def ship_order(order):
+    order["status"] = "shipped"
+    order["shipped_count"] = order.get("shipped_count", 0) + 1
+    return True
+
+
+def cancel_order(order):
+    order["status"] = "cancelled"
+    return True

--- a/tests/fixtures/archetypes/08-unrequested-change-risky-adjacent/head/test_orders.py
+++ b/tests/fixtures/archetypes/08-unrequested-change-risky-adjacent/head/test_orders.py
@@ -1,0 +1,13 @@
+from orders import cancel_order, ship_order
+
+
+def test_cancel_order_marks_cancelled():
+    order = {"status": "pending"}
+    assert cancel_order(order) is True
+    assert order["status"] == "cancelled"
+
+
+def test_ship_order_still_marks_shipped():
+    order = {"status": "pending"}
+    assert ship_order(order) is True
+    assert order["status"] == "shipped"

--- a/tests/fixtures/archetypes/08-unrequested-change-risky-adjacent/labels.json
+++ b/tests/fixtures/archetypes/08-unrequested-change-risky-adjacent/labels.json
@@ -1,0 +1,21 @@
+{
+  "obligations": [
+    {
+      "id": "cancel-order",
+      "description": "Mark the order's status as \"cancelled\" and return True",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "The test asserts cancel_order returns True and sets status to \"cancelled\"; a wrong status or return value would fail.",
+      "candidate_tests": ["test_orders.py::test_cancel_order_marks_cancelled"]
+    }
+  ],
+  "gaps": [],
+  "unrequested_changes": [
+    {
+      "id": "risky-ship-order-change",
+      "description": "ship_order gained shipped_count tracking though only cancel_order was requested. It edits existing, adjacent behavior (not a new file, not needed by cancel_order), and no test covers the new shipped_count field -- an untested behavior change that could hide a regression.",
+      "file": "orders.py",
+      "disposition": "risky"
+    }
+  ]
+}

--- a/tests/fixtures/archetypes/08-unrequested-change-risky-adjacent/meta.json
+++ b/tests/fixtures/archetypes/08-unrequested-change-risky-adjacent/meta.json
@@ -1,0 +1,6 @@
+{
+  "scenario": 8,
+  "name": "unrequested-change-risky-adjacent",
+  "intended_pytest": "pass",
+  "summary": "The task only asked for cancel_order(). The change also silently alters the unrelated, pre-existing ship_order() -- adding shipped_count tracking -- with no test covering the new behavior. Not load-bearing for cancel_order, not a new file: an edit to existing adjacent behavior that could hide a regression."
+}

--- a/tests/fixtures/archetypes/08-unrequested-change-risky-adjacent/task.md
+++ b/tests/fixtures/archetypes/08-unrequested-change-risky-adjacent/task.md
@@ -1,0 +1,5 @@
+# Task: Cancel an order
+
+Add `cancel_order(order)` to `orders.py`. It should mark the order's
+status as `"cancelled"` and return `True`. Only this behavior is
+requested.

--- a/tests/fixtures/archetypes/08-unrequested-change-separable/base/inventory.py
+++ b/tests/fixtures/archetypes/08-unrequested-change-separable/base/inventory.py
@@ -1,0 +1,2 @@
+def restock(item, qty):
+    raise NotImplementedError

--- a/tests/fixtures/archetypes/08-unrequested-change-separable/head/inventory.py
+++ b/tests/fixtures/archetypes/08-unrequested-change-separable/head/inventory.py
@@ -1,0 +1,3 @@
+def restock(item, qty):
+    item["qty"] += qty
+    return item["qty"]

--- a/tests/fixtures/archetypes/08-unrequested-change-separable/head/report.py
+++ b/tests/fixtures/archetypes/08-unrequested-change-separable/head/report.py
@@ -1,0 +1,2 @@
+def low_stock_report(inventory, threshold):
+    return [item for item in inventory if item["qty"] < threshold]

--- a/tests/fixtures/archetypes/08-unrequested-change-separable/head/test_inventory.py
+++ b/tests/fixtures/archetypes/08-unrequested-change-separable/head/test_inventory.py
@@ -1,0 +1,7 @@
+from inventory import restock
+
+
+def test_restock_increases_quantity():
+    item = {"qty": 5}
+    assert restock(item, 3) == 8
+    assert item["qty"] == 8

--- a/tests/fixtures/archetypes/08-unrequested-change-separable/head/test_report.py
+++ b/tests/fixtures/archetypes/08-unrequested-change-separable/head/test_report.py
@@ -1,0 +1,6 @@
+from report import low_stock_report
+
+
+def test_low_stock_report_filters_by_threshold():
+    inventory = [{"qty": 2}, {"qty": 10}]
+    assert low_stock_report(inventory, 5) == [{"qty": 2}]

--- a/tests/fixtures/archetypes/08-unrequested-change-separable/labels.json
+++ b/tests/fixtures/archetypes/08-unrequested-change-separable/labels.json
@@ -1,0 +1,21 @@
+{
+  "obligations": [
+    {
+      "id": "restock",
+      "description": "Increase the item's qty by the given amount and return the new quantity",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "The test asserts restock({'qty':5},3)==8 and that the item's qty is mutated to 8; a wrong increment or missing mutation would fail.",
+      "candidate_tests": ["test_inventory.py::test_restock_increases_quantity"]
+    }
+  ],
+  "gaps": [],
+  "unrequested_changes": [
+    {
+      "id": "unrequested-low-stock-report",
+      "description": "low_stock_report was added in a new file (report.py) with its own test; nothing in the task asked for a reporting feature. It is self-contained -- restock's obligation is fully satisfied without it -- so it belongs in its own PR/backlog item.",
+      "file": "report.py",
+      "disposition": "separable"
+    }
+  ]
+}

--- a/tests/fixtures/archetypes/08-unrequested-change-separable/meta.json
+++ b/tests/fixtures/archetypes/08-unrequested-change-separable/meta.json
@@ -1,0 +1,6 @@
+{
+  "scenario": 8,
+  "name": "unrequested-change-separable",
+  "intended_pytest": "pass",
+  "summary": "The task only asked for restock(). The change also adds a wholly separate low_stock_report feature in a new file, with its own tests -- coherent, possibly valuable, but a distinct unit of work that belongs in its own PR/backlog item."
+}

--- a/tests/fixtures/archetypes/08-unrequested-change-separable/task.md
+++ b/tests/fixtures/archetypes/08-unrequested-change-separable/task.md
@@ -1,0 +1,5 @@
+# Task: Restock inventory
+
+Add `restock(item, qty)` to `inventory.py`. It should increase the item's
+`qty` field by the given amount and return the new quantity. This is the
+only change requested.

--- a/tests/fixtures/archetypes/08-unrequested-change/labels.json
+++ b/tests/fixtures/archetypes/08-unrequested-change/labels.json
@@ -29,7 +29,8 @@
     {
       "id": "unrequested-checkout-change",
       "description": "checkout gained a tax_rate parameter and rounding; no obligation asked for a checkout change, only apply_discount",
-      "file": "cart.py"
+      "file": "cart.py",
+      "disposition": "risky"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Three sibling archetypes to `08-unrequested-change`, one per disposition #8 alone doesn't demonstrate:

- **`08-unrequested-change-separable`** — task asks for `restock()` in `inventory.py`; head also adds a wholly self-contained `low_stock_report()` in a *new file* with its own tests → `separable` (the deterministic pure-addition fast-path from M3.5.3).
- **`08-unrequested-change-in-service`** — task asks for `apply_discount()` formatted as money; delivering it requires widening the existing `format_total()` with a `currency` parameter (defaulted, so `checkout` is unaffected) → `in_service` by the removability litmus. Deliberately designed so removing the widening actually *breaks* `apply_discount`, not just "is tidier" — that distinction was the point of the design discussion on this task.
- **`08-unrequested-change-risky-adjacent`** — task asks for `cancel_order()`; head also silently changes the unrelated, pre-existing `ship_order()` (untested `shipped_count` tracking) → `risky`: not load-bearing, not a new file, edits existing behavior with no test covering the change.

`GroundTruthUnrequestedChange.disposition` is now **required** (archetype #8 backfilled: `risky`, accurate for a `public_interface` change under both scope-expansion policies).

**Naming:** siblings share scenario `8` with a distinct `name` (`unrequested-change-{separable,in-service,risky-adjacent}`), per the existing `{scenario:02d}-{name} == directory name` invariant — not new top-level numbered scenarios (10-13 are reserved for Stage 2 GitHub scenarios). `test_all_nine_archetypes_are_present` renamed/extended to `test_all_expected_archetypes_are_present`.

Because `test_labels.py`/`test_fixtures.py` are already parametrized over every archetype directory, the existing generic validation suite automatically covers all three new fixtures — no bespoke test code needed.

## A real issue found while dogfooding — filed, not fixed here
`acceptance classify` on this PR's own diff inspected the *content* of the new `risky-adjacent` fixture (a deliberately-planted regression, the entire point of that fixture) and flagged it as a real unrequested change, with a rationale/verdict mismatch (rationale argued `risky`, verdict said `in_service`). Root cause: `_categorize()` already tags fixture paths `"test"`, but no semantic judgment (`classify_coverage`/`detect_unrequested_changes`/`classify_dispositions`) acts on it, and `"test"` is the wrong bucket anyway — fixture *data* isn't test code, it's inert corpus (this repo's own `ruff` config already excludes `tests/fixtures` for exactly this reason). Filed as **#95**, scoped generally (not tailored to this repo's directory layout) and flagged to be addressed **before** further new-capability work, since M4/M5 will add more judgments that would inherit the same blind spot.

## Test plan
- [x] Full suite: 297 passed (was 269).
- [x] ruff clean.
- [x] Every new fixture passes the generic archetype suite: builds as a real two-commit repo, non-empty diff, pytest runs with its declared `intended_pytest: pass` outcome, ground truth validates (evidence class + rationale on every obligation, gaps for anything non-strong, candidate test ids resolve to real collected tests).
- [x] Dogfooded live (`decompose`/`diff`/`classify`) — surfaced #95 above.

Human validation of the disposition labels (per #86's acceptance) welcome on review.

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)