### PR TITLE
Add user-configurable ignore patterns for reviewed paths (#105)

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,11 +1,14 @@
 # Task
-Expand the unrequested-change archetypes beyond #8 with three sibling fixtures — a separable extra feature, an in-service refactor, and a risky adjacent-behavior change — each with ground-truth disposition labels.
+Add user-configurable ignore patterns for reviewed paths, so an excluded path is invisible to every downstream capability, not just special-cased per capability.
 
 ## Constraints
-- Each fixture must materialize as a real two-commit git repo with a non-empty base->head diff and a pytest suite that runs with its declared intended outcome.
-- Ground truth must label each unrequested change's disposition (in_service / separable / risky), backed by a plausible rationale under the removability litmus.
-- The separable and in-service scenarios must be genuinely distinct: the in-service change must be load-bearing for the requested obligation (removing it breaks completion), not merely tidier.
+- Gitignore-syntax patterns, read from a `.acceptance/ignore` file in the reviewed repo.
+- Applied once at change-set extraction (the lowest layer), so decomposition, coverage classification, unrequested-change detection, and disposition all see the same already-filtered change set.
+- A file matching a configured ignore pattern does not appear in the extracted ChangeSet's files at all.
+- Ignoring a path must be visible/auditable in CLI output — no silent caps.
+- Must work in both committed-revision mode and working-tree mode (including untracked files).
+- Existing callers with no `.acceptance/ignore` file must behave exactly as before (full backward compatibility).
 
 ## Completion expectations
-- Fixtures (task.md, base/, head/, meta.json, labels.json) for each of the three dispositions
-- Ground truth validated against the existing generic archetype test suite
+- Implementation
+- Unit tests: ignore file present vs. absent, working-tree/untracked files respect it, CLI renders the ignored-paths section

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Independent acceptance review for AI-assisted software changes."
 requires-python = ">=3.10"
 readme = "README.md"
-dependencies = ["pydantic>=2", "litellm>=1.50", "markdown-it-py>=3"]
+dependencies = ["pydantic>=2", "litellm>=1.50", "markdown-it-py>=3", "pathspec>=0.12"]
 
 [project.optional-dependencies]
 dev = ["pytest", "ruff"]

--- a/src/acceptance/change/diff.py
+++ b/src/acceptance/change/diff.py
@@ -14,6 +14,15 @@ than diffed. This means a rename done via plain `mv` (not staged with
 rename — untracked files can't participate in git's similarity-based rename
 detection. A staged rename (`git mv`, or `mv` + `git add`) is detected
 correctly, same as a committed one.
+
+Ignore patterns (#105): the reviewed repo's own `.acceptance/ignore` (gitignore
+syntax) is read once per extraction and applied here, the lowest layer, so a
+matched path is structurally invisible to every downstream capability —
+decomposition, coverage classification, unrequested-change detection,
+disposition — with no per-capability special-casing. Matched paths are
+excluded from `ChangeSet.files` but listed in `ignored_paths` for
+auditability (no silent caps, same spirit as `RetrievalResult`'s truncation
+flags in change/context.py).
 """
 
 from __future__ import annotations
@@ -22,9 +31,12 @@ import re
 import subprocess
 from pathlib import Path
 
+import pathspec
+
 from acceptance.review_state import ChangeSet, DiffHunk, FileChange
 
 WORKING_TREE_SENTINEL = "<working-tree>"
+IGNORE_FILE = ".acceptance/ignore"
 
 _TEST_PATH_RE = re.compile(r"(^|/)tests?/|(^|/)test_[^/]+\.py$|_test\.py$")
 _CONFIG_NAMES = {
@@ -50,43 +62,90 @@ _HUNK_HEADER_RE = re.compile(
 )
 
 
-def extract_change_set(repo: Path, base: str, head: str) -> ChangeSet:
-    """Extract the structural change set between `base` and `head` in `repo`."""
+def read_ignore_patterns(repo: Path) -> list[str]:
+    """Gitignore-syntax patterns from the reviewed repo's `.acceptance/ignore`,
+    or `[]` if the file is absent."""
+    ignore_path = repo / IGNORE_FILE
+    if not ignore_path.is_file():
+        return []
+    return ignore_path.read_text(encoding="utf-8").splitlines()
+
+
+def _build_spec(ignore_patterns: list[str] | None, repo: Path) -> pathspec.PathSpec:
+    patterns = ignore_patterns if ignore_patterns is not None else read_ignore_patterns(repo)
+    return pathspec.PathSpec.from_lines("gitignore", patterns)
+
+
+def extract_change_set(
+    repo: Path, base: str, head: str, ignore_patterns: list[str] | None = None
+) -> ChangeSet:
+    """Extract the structural change set between `base` and `head` in `repo`.
+
+    `ignore_patterns` defaults to the repo's own `.acceptance/ignore` (#105);
+    pass `[]` explicitly to disable ignoring."""
+    spec = _build_spec(ignore_patterns, repo)
     entries = _parse_name_status(_git(repo, "diff", "--name-status", "-M", base, head))
     blocks = _split_file_blocks(_git(repo, "diff", "-U3", base, head))
+    files, ignored = _build_files(entries, blocks, spec)
+    return ChangeSet(base_revision=base, head_revision=head, files=files, ignored_paths=ignored)
+
+
+def extract_working_tree_change_set(
+    repo: Path, base: str, ignore_patterns: list[str] | None = None
+) -> ChangeSet:
+    """Extract the change set between `base` and the current working tree
+    (staged + unstaged + untracked) — no head commit required (§5.1).
+
+    `ignore_patterns` defaults to the repo's own `.acceptance/ignore` (#105);
+    pass `[]` explicitly to disable ignoring."""
+    spec = _build_spec(ignore_patterns, repo)
+    entries = _parse_name_status(_git(repo, "diff", "--name-status", "-M", base))
+    blocks = _split_file_blocks(_git(repo, "diff", "-U3", base))
+    files, ignored = _build_files(entries, blocks, spec)
+    untracked_files, untracked_ignored = _untracked_file_changes(repo, spec)
     return ChangeSet(
-        base_revision=base, head_revision=head, files=_build_files(entries, blocks)
+        base_revision=base,
+        head_revision=WORKING_TREE_SENTINEL,
+        files=files + untracked_files,
+        ignored_paths=ignored + untracked_ignored,
     )
 
 
-def extract_working_tree_change_set(repo: Path, base: str) -> ChangeSet:
-    """Extract the change set between `base` and the current working tree
-    (staged + unstaged + untracked) — no head commit required (§5.1)."""
-    entries = _parse_name_status(_git(repo, "diff", "--name-status", "-M", base))
-    blocks = _split_file_blocks(_git(repo, "diff", "-U3", base))
-    files = _build_files(entries, blocks) + _untracked_file_changes(repo)
-    return ChangeSet(base_revision=base, head_revision=WORKING_TREE_SENTINEL, files=files)
-
-
-def _build_files(entries: list[dict], blocks: dict[str, str]) -> list[FileChange]:
-    return [
-        FileChange(
-            path=entry["path"],
-            status=entry["status"],
-            category=_categorize(entry["path"]),
-            old_path=entry["old_path"],
-            hunks=_parse_hunks(blocks.get(entry["path"]) or blocks.get(entry["old_path"]) or ""),
+def _build_files(
+    entries: list[dict], blocks: dict[str, str], spec: pathspec.PathSpec
+) -> tuple[list[FileChange], list[str]]:
+    files: list[FileChange] = []
+    ignored: list[str] = []
+    for entry in entries:
+        if spec.match_file(entry["path"]):
+            ignored.append(entry["path"])
+            continue
+        files.append(
+            FileChange(
+                path=entry["path"],
+                status=entry["status"],
+                category=_categorize(entry["path"]),
+                old_path=entry["old_path"],
+                hunks=_parse_hunks(
+                    blocks.get(entry["path"]) or blocks.get(entry["old_path"]) or ""
+                ),
+            )
         )
-        for entry in entries
-    ]
+    return files, ignored
 
 
-def _untracked_file_changes(repo: Path) -> list[FileChange]:
+def _untracked_file_changes(
+    repo: Path, spec: pathspec.PathSpec
+) -> tuple[list[FileChange], list[str]]:
     """Untracked files as synthetic all-added FileChanges — git diff can't
     diff a file it doesn't know about, so these are read directly."""
-    changes = []
+    changes: list[FileChange] = []
+    ignored: list[str] = []
     for path in _git(repo, "ls-files", "--others", "--exclude-standard").splitlines():
         if not path.strip():
+            continue
+        if spec.match_file(path):
+            ignored.append(path)
             continue
         try:
             content = (repo / path).read_text(encoding="utf-8")
@@ -100,7 +159,7 @@ def _untracked_file_changes(repo: Path) -> list[FileChange]:
                 hunks=_whole_file_hunk(content),
             )
         )
-    return changes
+    return changes, ignored
 
 
 def _whole_file_hunk(content: str) -> list[DiffHunk]:

--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -149,6 +149,10 @@ def render_change_set(change_set: ChangeSet) -> str:
             f"  [{f.category}/{f.status}] {f.path}{origin}  "
             f"({hunk_count} hunk{'' if hunk_count == 1 else 's'})"
         )
+    if change_set.ignored_paths:
+        lines.append(f"Ignored by .acceptance/ignore ({len(change_set.ignored_paths)}):")
+        for path in change_set.ignored_paths:
+            lines.append(f"  {path}")
     return "\n".join(lines)
 
 

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -154,6 +154,10 @@ class ChangeSet(_Model):
     base_revision: str
     head_revision: str
     files: list[FileChange] = Field(default_factory=list)
+    # Paths matched by the reviewed repo's .acceptance/ignore (#105) —
+    # excluded from `files` (and therefore from every downstream capability),
+    # kept here for auditability rather than dropped silently.
+    ignored_paths: list[str] = Field(default_factory=list)
 
 
 class Obligation(_Model):

--- a/tests/change/test_diff.py
+++ b/tests/change/test_diff.py
@@ -170,3 +170,89 @@ def test_categorization_by_filename(repo, filename, expected_category):
 
     change_set = extract_change_set(repo, base, head)
     assert change_set.files[0].category == expected_category
+
+
+# --- ignore patterns (#105) ---
+
+
+def test_no_ignore_file_leaves_behavior_unchanged(repo):
+    (repo / "pkg.py").write_text("x = 1\n")
+    base = _commit(repo, "base")
+    (repo / "pkg.py").write_text("x = 2\n")
+    head = _commit(repo, "head")
+
+    change_set = extract_change_set(repo, base, head)
+    assert change_set.ignored_paths == []
+    assert len(change_set.files) == 1
+
+
+def test_acceptance_ignore_file_excludes_matching_paths(repo):
+    (repo / "vendor").mkdir()
+    (repo / "vendor" / "lib.py").write_text("x = 1\n")
+    (repo / "pkg.py").write_text("x = 1\n")
+    base = _commit(repo, "base")
+
+    (repo / ".acceptance").mkdir()
+    (repo / ".acceptance" / "ignore").write_text("vendor/\n")
+    (repo / "vendor" / "lib.py").write_text("x = 2\n")
+    (repo / "pkg.py").write_text("x = 2\n")
+    head = _commit(repo, "head")
+
+    change_set = extract_change_set(repo, base, head)
+
+    by_path = {f.path: f for f in change_set.files}
+    assert "vendor/lib.py" not in by_path
+    assert "pkg.py" in by_path
+    assert "vendor/lib.py" in change_set.ignored_paths
+    assert "pkg.py" not in change_set.ignored_paths
+    # The ignore file itself is a change too, and isn't self-excluded.
+    assert ".acceptance/ignore" in by_path
+
+
+def test_explicit_ignore_patterns_override_the_ignore_file(repo):
+    (repo / "pkg.py").write_text("x = 1\n")
+    (repo / "other.py").write_text("x = 1\n")
+    base = _commit(repo, "base")
+    (repo / "pkg.py").write_text("x = 2\n")
+    (repo / "other.py").write_text("x = 2\n")
+    head = _commit(repo, "head")
+
+    change_set = extract_change_set(repo, base, head, ignore_patterns=["pkg.py"])
+
+    by_path = {f.path: f for f in change_set.files}
+    assert "pkg.py" not in by_path
+    assert "other.py" in by_path
+    assert change_set.ignored_paths == ["pkg.py"]
+
+
+def test_ignore_patterns_apply_to_untracked_working_tree_files(repo):
+    from acceptance.change.diff import extract_working_tree_change_set
+
+    (repo / "pkg.py").write_text("x = 1\n")
+    base = _commit(repo, "base")
+
+    (repo / "vendor").mkdir()
+    (repo / "vendor" / "lib.py").write_text("x = 1\n")  # untracked
+    (repo / "new_module.py").write_text("y = 1\n")  # untracked
+
+    change_set = extract_working_tree_change_set(repo, base, ignore_patterns=["vendor/"])
+
+    by_path = {f.path: f for f in change_set.files}
+    assert "vendor/lib.py" not in by_path
+    assert "new_module.py" in by_path
+    assert "vendor/lib.py" in change_set.ignored_paths
+
+
+def test_read_ignore_patterns_returns_empty_when_file_absent(repo):
+    from acceptance.change.diff import read_ignore_patterns
+
+    assert read_ignore_patterns(repo) == []
+
+
+def test_read_ignore_patterns_reads_the_file(repo):
+    from acceptance.change.diff import read_ignore_patterns
+
+    (repo / ".acceptance").mkdir()
+    (repo / ".acceptance" / "ignore").write_text("# a comment\nvendor/\n*.log\n")
+
+    assert read_ignore_patterns(repo) == ["# a comment", "vendor/", "*.log"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -283,3 +283,37 @@ def test_render_classify_output():
     assert "[risky] (public_interface) checkout signature changed" in rendered
     assert "cart.py" in rendered
     assert "Scrutinize" in rendered
+
+
+# --- ignore patterns (#105) ---
+
+
+def test_render_change_set_shows_ignored_paths():
+    from acceptance.cli import render_change_set
+    from acceptance.review_state import ChangeSet, FileChange
+
+    change_set = ChangeSet(
+        base_revision="abc123",
+        head_revision="def456",
+        files=[FileChange(path="pkg.py", status="modified", category="source")],
+        ignored_paths=["vendor/lib.py"],
+    )
+
+    rendered = render_change_set(change_set)
+    assert "pkg.py" in rendered
+    assert "Ignored by .acceptance/ignore (1):" in rendered
+    assert "vendor/lib.py" in rendered
+
+
+def test_render_change_set_omits_ignored_section_when_empty():
+    from acceptance.cli import render_change_set
+    from acceptance.review_state import ChangeSet, FileChange
+
+    change_set = ChangeSet(
+        base_revision="abc123",
+        head_revision="def456",
+        files=[FileChange(path="pkg.py", status="modified", category="source")],
+    )
+
+    rendered = render_change_set(change_set)
+    assert "Ignored" not in rendered


### PR DESCRIPTION
## Summary
Split from #95 alongside #106 (see #95's closing comment for the full discussion): a general, user-controlled way to exclude paths from review, rather than relying on any auto-detected heuristic to guess every repo's fixture/vendor/generated-code conventions correctly.

- **`.acceptance/ignore`** file, gitignore syntax, read once at `change/diff.py`'s change-set extraction — the lowest layer, so a matched path is structurally invisible to *every* downstream capability (decomposition, coverage classification, unrequested-change detection, disposition) with no per-capability special-casing.
- **New dependency: `pathspec`** — gitignore semantics (`**`, negation, anchoring, directory-only patterns) are easy to get subtly wrong hand-rolled; `pathspec` is the same pure-Python library `black`/`pre-commit` use for this. Alternative considered: shelling out to `git check-ignore`, rejected because it can't cleanly point at an arbitrary pattern file without touching the repo's real git state.
- `extract_change_set`/`extract_working_tree_change_set` gain an optional `ignore_patterns` param (default `None` → auto-read from the repo) — **fully backward compatible** with every existing call site (10+ across `cli.py`, `benchmark/coverage.py`, and tests, none touched).
- Matched paths are excluded from `ChangeSet.files` but listed in the new `ignored_paths` field for auditability — no silent caps, same spirit as `RetrievalResult`'s truncation flags in `change/context.py`. Rendered by `render_change_set` (`acceptance diff`/`classify`), and free in JSON output via `to_dict()`.
- No CLI flag / `RunConfig` field yet — the file alone satisfies #105's stated acceptance criteria without coupling the structural `diff.py` layer to `config.py`; noted as a future extension if needed.

## Test plan
- [x] Ignore-pattern tests: file present vs. absent (critical regression check — a repo with no `.acceptance/ignore` behaves byte-identical to before), explicit `ignore_patterns` override, working-tree mode including untracked files, `read_ignore_patterns` unit tests.
- [x] CLI: `render_change_set` shows/omits the "Ignored by .acceptance/ignore" section correctly.
- [x] Full suite: 305 passed (was 297).
- [x] ruff clean.
- [x] Dogfooded live (`decompose`/`diff`/`classify`) — every obligation `[addressed]`; the two flagged "unrequested changes" (the `pathspec` dependency, the `ignored_paths` field) were correctly self-classified `[in_service]` by M3.5.3's own disposition classifier, with no manual dismissal needed.

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)