### PR TITLE
Auto-exclude the --task file from its own reviewed diff

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,14 +1,11 @@
 # Task
-Add user-configurable ignore patterns for reviewed paths, so an excluded path is invisible to every downstream capability, not just special-cased per capability.
+Auto-exclude the CLI's --task file from the reviewed diff, and make extra ignore patterns additive to the repo's own .acceptance/ignore rather than replacing it.
 
 ## Constraints
-- Gitignore-syntax patterns, read from a `.acceptance/ignore` file in the reviewed repo.
-- Applied once at change-set extraction (the lowest layer), so decomposition, coverage classification, unrequested-change detection, and disposition all see the same already-filtered change set.
-- A file matching a configured ignore pattern does not appear in the extracted ChangeSet's files at all.
-- Ignoring a path must be visible/auditable in CLI output — no silent caps.
-- Must work in both committed-revision mode and working-tree mode (including untracked files).
-- Existing callers with no `.acceptance/ignore` file must behave exactly as before (full backward compatibility).
+- The task file must never appear as a coverage claim or an unrequested-change flag in `classify` output, regardless of its name or location within the repo.
+- A task file outside the reviewed repo must be handled gracefully (nothing to exclude).
+- Ignore patterns from the repo's own `.acceptance/ignore` file and any caller-supplied extra patterns must both apply together — adding an extra pattern must not silently disable the repo's own ignore configuration.
 
 ## Completion expectations
 - Implementation
-- Unit tests: ignore file present vs. absent, working-tree/untracked files respect it, CLI renders the ignored-paths section
+- Unit tests: a task file inside the repo is excluded from the diff; a task file outside the repo is unaffected; extra patterns and the ignore file combine rather than override.

--- a/src/acceptance/change/diff.py
+++ b/src/acceptance/change/diff.py
@@ -16,11 +16,14 @@ detection. A staged rename (`git mv`, or `mv` + `git add`) is detected
 correctly, same as a committed one.
 
 Ignore patterns (#105): the reviewed repo's own `.acceptance/ignore` (gitignore
-syntax) is read once per extraction and applied here, the lowest layer, so a
-matched path is structurally invisible to every downstream capability —
-decomposition, coverage classification, unrequested-change detection,
-disposition — with no per-capability special-casing. Matched paths are
-excluded from `ChangeSet.files` but listed in `ignored_paths` for
+syntax) is always read and applied here, the lowest layer, so a matched path
+is structurally invisible to every downstream capability — decomposition,
+coverage classification, unrequested-change detection, disposition — with no
+per-capability special-casing. Callers may add `extra_ignore_patterns` on top
+of the file (additive, never a replacement) — the CLI uses this to
+auto-exclude the `--task` file itself, since the task is the specification
+being reviewed against, not part of the reviewed deliverable. Matched paths
+are excluded from `ChangeSet.files` but listed in `ignored_paths` for
 auditability (no silent caps, same spirit as `RetrievalResult`'s truncation
 flags in change/context.py).
 """
@@ -71,19 +74,24 @@ def read_ignore_patterns(repo: Path) -> list[str]:
     return ignore_path.read_text(encoding="utf-8").splitlines()
 
 
-def _build_spec(ignore_patterns: list[str] | None, repo: Path) -> pathspec.PathSpec:
-    patterns = ignore_patterns if ignore_patterns is not None else read_ignore_patterns(repo)
+def _build_spec(extra_patterns: list[str] | None, repo: Path) -> pathspec.PathSpec:
+    """The repo's own `.acceptance/ignore` (#105), plus any caller-supplied
+    `extra_patterns` (e.g. the CLI's `--task` file, added automatically —
+    the task is the specification being reviewed against, not part of the
+    reviewed deliverable). Additive, never a replacement: a caller can add
+    to the repo's standing ignore config but not silently disable it."""
+    patterns = read_ignore_patterns(repo) + list(extra_patterns or [])
     return pathspec.PathSpec.from_lines("gitignore", patterns)
 
 
 def extract_change_set(
-    repo: Path, base: str, head: str, ignore_patterns: list[str] | None = None
+    repo: Path, base: str, head: str, extra_ignore_patterns: list[str] | None = None
 ) -> ChangeSet:
     """Extract the structural change set between `base` and `head` in `repo`.
 
-    `ignore_patterns` defaults to the repo's own `.acceptance/ignore` (#105);
-    pass `[]` explicitly to disable ignoring."""
-    spec = _build_spec(ignore_patterns, repo)
+    Always applies the repo's own `.acceptance/ignore` (#105);
+    `extra_ignore_patterns` adds caller-supplied patterns on top of it."""
+    spec = _build_spec(extra_ignore_patterns, repo)
     entries = _parse_name_status(_git(repo, "diff", "--name-status", "-M", base, head))
     blocks = _split_file_blocks(_git(repo, "diff", "-U3", base, head))
     files, ignored = _build_files(entries, blocks, spec)
@@ -91,14 +99,14 @@ def extract_change_set(
 
 
 def extract_working_tree_change_set(
-    repo: Path, base: str, ignore_patterns: list[str] | None = None
+    repo: Path, base: str, extra_ignore_patterns: list[str] | None = None
 ) -> ChangeSet:
     """Extract the change set between `base` and the current working tree
     (staged + unstaged + untracked) — no head commit required (§5.1).
 
-    `ignore_patterns` defaults to the repo's own `.acceptance/ignore` (#105);
-    pass `[]` explicitly to disable ignoring."""
-    spec = _build_spec(ignore_patterns, repo)
+    Always applies the repo's own `.acceptance/ignore` (#105);
+    `extra_ignore_patterns` adds caller-supplied patterns on top of it."""
+    spec = _build_spec(extra_ignore_patterns, repo)
     entries = _parse_name_status(_git(repo, "diff", "--name-status", "-M", base))
     blocks = _split_file_blocks(_git(repo, "diff", "-U3", base))
     files, ignored = _build_files(entries, blocks, spec)

--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -62,6 +62,26 @@ def _read_task(task_path: str, repo: Path | None = None) -> str:
     return path.read_text()
 
 
+def _task_ignore_pattern(task_path: str, repo: Path) -> str | None:
+    """The `--task` file's path relative to `repo`, as a root-anchored
+    gitignore pattern, if the file lives inside the repo — `None` otherwise
+    (e.g. the benchmark runner's temp task files, which live outside any
+    reviewed repo and can never appear in its diff regardless).
+
+    The task is the specification being reviewed against, not part of the
+    reviewed deliverable, so it must never appear in its own diff — not as
+    a coverage claim, and never as an "unrequested change" (it always
+    changes; that would be absurd to flag)."""
+    resolved = Path(task_path)
+    if not resolved.is_absolute():
+        resolved = Path.cwd() / resolved
+    try:
+        relative = resolved.resolve().relative_to(repo.resolve())
+    except ValueError:
+        return None
+    return "/" + relative.as_posix()
+
+
 def run_check(
     task: str,
     base: str,
@@ -91,6 +111,9 @@ def run_check(
         provenance=config.provenance(),
         # Diff endpoints only; real extraction exists (change/diff.py, dogfooded
         # via `acceptance diff`) but isn't wired into this pipeline yet (M7).
+        # When it is, pass extra_ignore_patterns=[_task_ignore_pattern(task,
+        # repo)] the same way run_classify does — the task file must never
+        # appear in its own diff.
         change_set=ChangeSet(base_revision=base_sha, head_revision=head_sha),
     )
     store.write(review)
@@ -166,12 +189,19 @@ def run_classify(
     parsed = parse_task_file(_read_task(task))
     obligations = decompose(parsed, config.build_client()).obligations
 
+    task_ignore = _task_ignore_pattern(task, repo_path)
+    extra_patterns = [task_ignore] if task_ignore else []
+
     base_sha = _resolve_revision(base, repo=repo_path)
     if head is None:
-        change_set = extract_working_tree_change_set(repo_path, base_sha)
+        change_set = extract_working_tree_change_set(
+            repo_path, base_sha, extra_ignore_patterns=extra_patterns
+        )
     else:
         head_sha = _resolve_revision(head, repo=repo_path)
-        change_set = extract_change_set(repo_path, base_sha, head_sha)
+        change_set = extract_change_set(
+            repo_path, base_sha, head_sha, extra_ignore_patterns=extra_patterns
+        )
 
     coverages = classify_coverage(obligations, change_set, config.build_client())
     unrequested = detect_unrequested_changes(obligations, change_set, config.build_client())

--- a/tests/change/test_diff.py
+++ b/tests/change/test_diff.py
@@ -209,7 +209,7 @@ def test_acceptance_ignore_file_excludes_matching_paths(repo):
     assert ".acceptance/ignore" in by_path
 
 
-def test_explicit_ignore_patterns_override_the_ignore_file(repo):
+def test_extra_ignore_patterns_are_applied(repo):
     (repo / "pkg.py").write_text("x = 1\n")
     (repo / "other.py").write_text("x = 1\n")
     base = _commit(repo, "base")
@@ -217,12 +217,37 @@ def test_explicit_ignore_patterns_override_the_ignore_file(repo):
     (repo / "other.py").write_text("x = 2\n")
     head = _commit(repo, "head")
 
-    change_set = extract_change_set(repo, base, head, ignore_patterns=["pkg.py"])
+    change_set = extract_change_set(repo, base, head, extra_ignore_patterns=["pkg.py"])
 
     by_path = {f.path: f for f in change_set.files}
     assert "pkg.py" not in by_path
     assert "other.py" in by_path
     assert change_set.ignored_paths == ["pkg.py"]
+
+
+def test_extra_ignore_patterns_add_to_not_replace_the_ignore_file(repo):
+    (repo / "vendor").mkdir()
+    (repo / "vendor" / "lib.py").write_text("x = 1\n")
+    (repo / "pkg.py").write_text("x = 1\n")
+    (repo / "task.md").write_text("v1\n")
+    base = _commit(repo, "base")
+
+    (repo / ".acceptance").mkdir()
+    (repo / ".acceptance" / "ignore").write_text("vendor/\n")
+    (repo / "vendor" / "lib.py").write_text("x = 2\n")
+    (repo / "pkg.py").write_text("x = 2\n")
+    (repo / "task.md").write_text("v2\n")
+    head = _commit(repo, "head")
+
+    change_set = extract_change_set(repo, base, head, extra_ignore_patterns=["/task.md"])
+
+    by_path = {f.path: f for f in change_set.files}
+    # Both the file-based pattern (vendor/) and the extra pattern (task.md)
+    # apply together — extra patterns don't disable the repo's own config.
+    assert "vendor/lib.py" not in by_path
+    assert "task.md" not in by_path
+    assert "pkg.py" in by_path
+    assert set(change_set.ignored_paths) == {"vendor/lib.py", "task.md"}
 
 
 def test_ignore_patterns_apply_to_untracked_working_tree_files(repo):
@@ -235,7 +260,7 @@ def test_ignore_patterns_apply_to_untracked_working_tree_files(repo):
     (repo / "vendor" / "lib.py").write_text("x = 1\n")  # untracked
     (repo / "new_module.py").write_text("y = 1\n")  # untracked
 
-    change_set = extract_working_tree_change_set(repo, base, ignore_patterns=["vendor/"])
+    change_set = extract_working_tree_change_set(repo, base, extra_ignore_patterns=["vendor/"])
 
     by_path = {f.path: f for f in change_set.files}
     assert "vendor/lib.py" not in by_path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -237,6 +237,81 @@ def test_classify_replay_without_transcript_fails_cleanly(
     assert "model error" in capsys.readouterr().err
 
 
+# --- task-file auto-ignore (a change must never appear in its own diff) ---
+
+
+def test_task_ignore_pattern_for_a_file_inside_the_repo(git_repo):
+    from acceptance.cli import _task_ignore_pattern
+
+    task_path = git_repo["path"] / "current-task.md"
+    task_path.write_text("# Task\n")
+
+    pattern = _task_ignore_pattern(str(task_path), git_repo["path"])
+    assert pattern == "/current-task.md"
+
+
+def test_task_ignore_pattern_for_a_relative_path(git_repo, monkeypatch):
+    from acceptance.cli import _task_ignore_pattern
+
+    (git_repo["path"] / "current-task.md").write_text("# Task\n")
+    monkeypatch.chdir(git_repo["path"])
+
+    assert _task_ignore_pattern("current-task.md", git_repo["path"]) == "/current-task.md"
+
+
+def test_task_ignore_pattern_is_none_outside_the_repo(git_repo, tmp_path):
+    from acceptance.cli import _task_ignore_pattern
+
+    outside = tmp_path / "elsewhere" / "task.md"
+    outside.parent.mkdir()
+    outside.write_text("# Task\n")
+
+    assert _task_ignore_pattern(str(outside), git_repo["path"]) is None
+
+
+def test_run_classify_auto_ignores_the_task_file(git_repo, monkeypatch):
+    """The --task file must never appear in its own diff — not as a
+    coverage claim, and never as an absurd "unrequested change" (it always
+    changes). Verified by capturing the ignore pattern actually passed to
+    change-set extraction; the capability calls themselves are stubbed out
+    since their real behavior is tested elsewhere and would otherwise need
+    a live model call."""
+    import acceptance.cli as cli_module
+    from acceptance.requirement.obligations import Decomposition
+
+    task_path = git_repo["path"] / "current-task.md"
+    task_path.write_text("# Task\nDo the thing.\n")
+
+    captured = {}
+
+    def fake_extract_working_tree_change_set(repo, base, extra_ignore_patterns=None):
+        captured["extra_ignore_patterns"] = extra_ignore_patterns
+        from acceptance.review_state import ChangeSet
+        return ChangeSet(base_revision=base, head_revision="<working-tree>")
+
+    monkeypatch.setattr(
+        cli_module, "extract_working_tree_change_set", fake_extract_working_tree_change_set
+    )
+    monkeypatch.setattr(
+        cli_module, "decompose", lambda parsed, client: Decomposition(obligations=[])
+    )
+    monkeypatch.setattr(cli_module, "classify_coverage", lambda obligations, cs, client: [])
+    monkeypatch.setattr(
+        cli_module, "detect_unrequested_changes", lambda obligations, cs, client: []
+    )
+    monkeypatch.setattr(
+        cli_module,
+        "classify_dispositions",
+        lambda changes, obligations, coverages, cs, policy, client: [],
+    )
+
+    cli_module.run_classify(
+        str(task_path), git_repo["base"], None, RunConfig(), repo=str(git_repo["path"])
+    )
+
+    assert captured["extra_ignore_patterns"] == ["/current-task.md"]
+
+
 def test_render_classify_output():
     from acceptance.cli import render_classify
     from acceptance.coverage.classify import CoverageStatus, DiffRef, ImplementationCoverage


### PR DESCRIPTION
## Summary
Follow-up to #105, from user feedback: the CLI's `classify` pipeline never excluded the `--task` file itself from the diff it reviews, so the task description showed up as a change to be judged — a coverage claim it can never satisfy, and (worse) a candidate "unrequested change," which is absurd (the task file always changes; that's not scope creep). This showed up as noise in essentially every dogfood run this session (`current-task.md`).

- `_task_ignore_pattern(task, repo)` computes the task file's repo-relative, root-anchored gitignore pattern — `None` if the task file lives outside the repo (e.g. the benchmark runner's temp files; nothing to exclude, since git could never report it as changed regardless).
- `run_classify` passes it as an extra ignore pattern to change-set extraction.
- Required changing `extract_change_set`/`extract_working_tree_change_set`'s ignore semantics from **override** to **additive** (`extra_ignore_patterns`, renamed from `ignore_patterns`): the repo's own `.acceptance/ignore` must keep applying even when the CLI also supplies the task-file pattern — one auto-added pattern shouldn't silently disable the user's own standing config.
- `run_check` gets a forward-looking comment for when M7 wires it to real diffing (correctly self-flagged `separable` by the disposition classifier below — an optional note, not required now).

This also answers a related question: whether to hand-add `current-task.md` to `.acceptance/ignore`. With this fix that's unnecessary — the exclusion is automatic regardless of filename, more robust than a manually-maintained entry that could drift.

## Test plan
- [x] `_task_ignore_pattern`: inside repo (absolute and relative task path), outside repo (`None`).
- [x] `run_classify` wiring test: capability calls stubbed (no live model needed), `extract_working_tree_change_set` call args captured, asserts the correct pattern is passed.
- [x] `change/diff.py`: additive semantics — a repo's own `.acceptance/ignore` and caller-supplied extra patterns both apply together, neither overriding the other.
- [x] Full suite: 310 passed (was 305).
- [x] ruff clean.
- [x] **Dogfooded live against this very change** — `current-task.md` no longer appears anywhere in `acceptance classify`'s output (previously present in every dogfood run this session). The two flagged "unrequested changes" (the `ignore_patterns`→`extra_ignore_patterns` rename, the `run_check` forward-looking comment) were correctly self-classified `in_service` and `separable` by M3.5.3's own disposition classifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)