### PR TITLE
Fix obligation-attribution for artifact-content diffs (#106)

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,11 +1,12 @@
 # Task
-Auto-exclude the CLI's --task file from the reviewed diff, and make extra ignore patterns additive to the repo's own .acceptance/ignore rather than replacing it.
+Fix obligation-attribution so a diff region that literally delivers an obligation — including obligations that ask for fixture/test/example artifact content whose content resembles a questionable change — is no longer misclassified as an unrequested or not-addressed change.
 
 ## Constraints
-- The task file must never appear as a coverage claim or an unrequested-change flag in `classify` output, regardless of its name or location within the repo.
-- A task file outside the reviewed repo must be handled gracefully (nothing to exclude).
-- Ignore patterns from the repo's own `.acceptance/ignore` file and any caller-supplied extra patterns must both apply together — adding an extra pattern must not silently disable the repo's own ignore configuration.
+- Sharpen the classify_coverage and detect_unrequested_changes system prompts so a region is checked against the full text of every obligation, including obligations phrased as "add/include a fixture/test/example representing X", before being classified not_addressed or unrequested.
+- A region whose content is literally what such an artifact obligation asks for must classify as addressed coverage, and must not be flagged as an unrequested change.
+- Recall must not drop: a genuinely unrequested change that no obligation explains must still be flagged (bias toward surfacing the unexplained).
+- File category may feed the prompt as a hint, but the fix is the model's attribution reasoning, not a structural filter.
 
 ## Completion expectations
-- Implementation
-- Unit tests: a task file inside the repo is excluded from the diff; a task file outside the repo is unaffected; extra patterns and the ignore file combine rather than override.
+- The two sharpened prompts
+- Live before/after verification, since prompt quality cannot be asserted by injected-response unit tests

--- a/src/acceptance/coverage/classify.py
+++ b/src/acceptance/coverage/classify.py
@@ -62,6 +62,17 @@ For each obligation return a `status`:
 - requires_non_code_evidence: satisfying it needs docs, visual behavior, or
   deploy config rather than code.
 
+Judge each region against the FULL text of the obligation, not against a fixed
+idea of "correct production code." An obligation may ask for an ARTIFACT — a
+fixture, test, example, sample, or data file — whose content is deliberately
+meant to resemble something a reviewer would otherwise question: a planted bug,
+an odd edit to existing code, a deprecated call, an intentionally weak test.
+When an obligation calls for such an artifact and the diff delivers exactly
+that content, it is `addressed` — judge it by whether it contains what the
+obligation says the artifact should show, NOT by whether it is correct runtime
+behavior. Each file is tagged `(status, category)`; treat a `test`-category
+file as a deliverable artifact, not as production code held to correctness.
+
 Also return a short `rationale` and `diff_refs`: the labels (like `path#0`) of
 the hunks that address the obligation. For not_addressed, `diff_refs` MUST be
 empty. Link only hunks that genuinely respond to the obligation."""

--- a/src/acceptance/coverage/unrequested.py
+++ b/src/acceptance/coverage/unrequested.py
@@ -53,6 +53,16 @@ Give extra weight to (classify each `kind`):
 - internal: a purely internal refactor with no external effect.
 - other: anything else unrequested.
 
+Before reporting a change, check it against the FULL text of EVERY obligation.
+An obligation may explicitly call for an ARTIFACT — a fixture, test, example, or
+sample — whose content is deliberately meant to look like a change a reviewer
+would question: a planted bug, an odd edit to existing code, a deprecated call,
+an intentionally weak test. Content an obligation asked for AS such an artifact
+is REQUESTED by that obligation, even though in isolation it resembles scope
+creep — do NOT report it. Only report a change when NO obligation, read in full,
+calls for it. (When you are genuinely unsure whether any obligation covers a
+change, still report it — bias toward surfacing the unexplained.)
+
 For each unrequested change return its `kind`, a short `rationale`, and
 `diff_refs`: the labels (like `path#0`) of the hunks it concerns. Do not report
 changes that a listed obligation requires. If every change is requested, return


### PR DESCRIPTION
## Summary
Sharpens two system prompts (`coverage/classify.py`, `coverage/unrequested.py`) so a diff region is judged against the **full text of every obligation** before being called `not_addressed`/unrequested. The root cause (from #106, surfaced dogfooding M3.5.4): the detector judged a region only against "does this look like correct production code" and never checked whether an obligation's own literal text — e.g. *"include a fixture representing a risky adjacent-behavior change"* — already calls for exactly that content.

Both prompts now state that an obligation may ask for an **artifact** (fixture, test, example, sample) whose content is *deliberately* meant to resemble a change a reviewer would question — a planted bug, an odd edit to existing code, a deprecated call. Such content is `addressed`/requested, not scope creep. The `(status, category)` tag is now an explicit hint: a `test`-category file is a deliverable artifact, not production code held to correctness.

**Recall is deliberately preserved** (DR-081 dec 3): the "if genuinely unsure whether any obligation covers a change, still report it" bias stays — this only fixes cases where an obligation *plainly* explains the change.

## Verification — live before/after, not injected-response tests
Prompt quality can't be asserted by our injected-response unit tests (they bypass the prompt entirely), so the acceptance evidence is a live `RECORD` run on a crafted repro (a fixture that modifies `ship_order` to add untested `shipped_count` tracking — the exact misclassifying pattern — alongside a genuinely-unrequested production edit in the same diff):

```
Unrequested changes (no obligation calls for these — your call):
  [risky] (adjacent_behavior) The production change in src/orders.py adds logging inside
      ship_order, which is not required by the obligations; the task only asked for a risky
      demo fixture under tests/fixtures/risky-demo/ that modifies ship_order and adds
      shipped_count tracking there.
      -> src/orders.py
```

- **The fix:** the fixture's `ship_order` edit → `[addressed]`, **not** flagged (previously flagged as unrequested/risky).
- **Recall preserved:** the unrequested production edit → still `[risky]`. Both touch `ship_order`-like behavior; the tool now discriminates by obligation, not surface appearance — and the rationale articulates the distinction.

## Test plan
- [x] Existing coverage/unrequested tests still pass (they test pipeline mechanics via injected responses — not prompt quality, which is why the live run above is the real evidence).
- [x] Full suite: 310 passed; ruff clean. (No new unit tests — prompt-only change; injected-response tests can't verify it and would give false assurance.)
- [x] Live before/after RECORD run (above) — the origin scenario is fixed and recall is intact.
- [x] Standard dogfood of this PR's own diff (`decompose` + `classify`) — all code obligations `[addressed]`.

## Follow-up
The benchmark-archetype encoding suggested in #106's acceptance is deferred to **#110**: the archetype schema is `obligation → test-evidence` oriented and can't cleanly represent an artifact-creation obligation (no natural `evidence_class`) — a real expressiveness gap worth fixing on its own rather than forcing an awkward fixture here.

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)