### PR TITLE
M4.1: test discovery (§9.1 candidate tests)

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,12 +1,13 @@
 # Task
-Fix obligation-attribution so a diff region that literally delivers an obligation — including obligations that ask for fixture/test/example artifact content whose content resembles a questionable change — is no longer misclassified as an unrequested or not-addressed change.
+Collect added/modified tests plus relevant existing tests (by touched symbols, imports, naming, and call graph).
 
 ## Constraints
-- Sharpen the classify_coverage and detect_unrequested_changes system prompts so a region is checked against the full text of every obligation, including obligations phrased as "add/include a fixture/test/example representing X", before being classified not_addressed or unrequested.
-- A region whose content is literally what such an artifact obligation asks for must classify as addressed coverage, and must not be flagged as an unrequested change.
-- Recall must not drop: a genuinely unrequested change that no obligation explains must still be flagged (bias toward surfacing the unexplained).
-- File category may feed the prompt as a hint, but the fix is the model's attribution reasoning, not a structural filter.
+- Structural only, no LLM call — Python AST, matching the M2 change/diff extraction and M2.2 context retrieval.
+- Every added/modified test in the change set is discovered directly.
+- An existing, untouched test is discovered when it calls a changed symbol, references a changed symbol without calling it, imports a changed module, or is named after a changed symbol.
+- Every discovered test records why it was discovered (never zero reasons).
+- Bound the repo-wide scan with a budget, flagged (not silently dropped) when the cap is hit.
 
 ## Completion expectations
-- The two sharpened prompts
-- Live before/after verification, since prompt quality cannot be asserted by injected-response unit tests
+- Implementation
+- Unit tests: on a fixture where an existing untouched test covers a changed function, that test is discovered.

--- a/src/acceptance/change/context.py
+++ b/src/acceptance/change/context.py
@@ -78,12 +78,11 @@ _EXCLUDED_DIRS = {
 }
 
 
-def retrieve_context(
-    repo: Path, change_set: ChangeSet, budget: RetrievalBudget | None = None
-) -> RetrievalResult:
-    """Retrieve enclosing definitions of changed regions and their callers."""
-    budget = budget or RetrievalBudget()
-
+def changed_definitions(repo: Path, change_set: ChangeSet) -> list[CodeDefinition]:
+    """The innermost function/class/method enclosing each changed line, across
+    every changed source file — the structural anchor both for surrounding-code
+    retrieval (this module) and test discovery (evidence/discovery.py, M4.1),
+    which reuses this to find the symbols a candidate test should reference."""
     definitions: dict[str, CodeDefinition] = {}
     for file_change in change_set.files:
         if file_change.category != "source" or file_change.status == "deleted":
@@ -100,7 +99,16 @@ def retrieve_context(
             enclosing = _innermost_enclosing(index, changed_lines)
             if enclosing is not None:
                 definitions[enclosing.qualname] = enclosing
+    return list(definitions.values())
 
+
+def retrieve_context(
+    repo: Path, change_set: ChangeSet, budget: RetrievalBudget | None = None
+) -> RetrievalResult:
+    """Retrieve enclosing definitions of changed regions and their callers."""
+    budget = budget or RetrievalBudget()
+
+    definitions = {defn.qualname: defn for defn in changed_definitions(repo, change_set)}
     target_names = {defn.qualname.rsplit(".", 1)[-1]: defn for defn in definitions.values()}
     call_sites: dict[str, list[CallSite]] = {q: [] for q in definitions}
     truncated: dict[str, bool] = {q: False for q in definitions}

--- a/src/acceptance/evidence/__init__.py
+++ b/src/acceptance/evidence/__init__.py
@@ -1,0 +1,1 @@
+"""Test evidence: discovery, mapping, and semantic analysis (M4/M5)."""

--- a/src/acceptance/evidence/discovery.py
+++ b/src/acceptance/evidence/discovery.py
@@ -1,0 +1,251 @@
+"""Test discovery (M4.1, §9.1 "candidate tests").
+
+Collects the tests relevant to a change set: every added/modified test, plus
+existing (untouched) tests connected to a changed symbol — by call graph,
+non-call reference, import, or naming — via Python AST, no LLM call (this is
+structural, like M2's diff/context extraction). This produces the *candidate*
+set M4.2 maps to obligations and M5 analyzes test-by-test; it does not judge
+test strength or relevance beyond "this test touches changed code."
+
+Changed-symbol names come from `change/context.py`'s `changed_definitions` —
+the same enclosing-definition extraction M2.2 uses for surrounding-code
+retrieval, reused here rather than recomputed. Existing-test-file discovery
+scans the repo by pytest's own naming convention (`test_*.py`/`*_test.py`),
+excluding vendored/generated directories (the same denylist as
+change/context.py's caller scan — kept local here rather than imported, since
+these are small, stable utilities and the two scans walk the tree for
+different purposes).
+"""
+
+from __future__ import annotations
+
+import ast
+from enum import Enum
+from pathlib import Path
+
+from pydantic import Field
+
+from acceptance.change.context import changed_definitions
+from acceptance.model_base import PersistableModel
+from acceptance.review_state import ChangeSet
+
+_EXCLUDED_DIRS = {
+    ".venv",
+    "venv",
+    ".git",
+    "__pycache__",
+    "node_modules",
+    "build",
+    "dist",
+    ".tox",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    "site-packages",
+    ".eggs",
+}
+
+
+class TestDiscoveryBudget(PersistableModel):
+    __test__ = False  # not a pytest test class; matches TestEvidence's precedent
+
+    max_files_scanned: int = 500
+
+
+class DiscoveryReason(str, Enum):
+    ADDED_OR_MODIFIED = "added_or_modified"
+    CALLS_CHANGED_SYMBOL = "calls_changed_symbol"
+    REFERENCES_CHANGED_SYMBOL = "references_changed_symbol"
+    IMPORTS_CHANGED_MODULE = "imports_changed_module"
+    NAME_MATCHES_SYMBOL = "name_matches_symbol"
+
+
+class DiscoveredTest(PersistableModel):
+    """A candidate test, and why it was discovered — never zero reasons."""
+
+    test_id: str  # pytest nodeid: "path/test_x.py::test_fn" or "...::TestC::test_m"
+    file: str
+    reasons: list[DiscoveryReason] = Field(default_factory=list)
+
+
+class TestDiscoveryResult(PersistableModel):
+    __test__ = False  # not a pytest test class; matches TestEvidence's precedent
+
+    tests: list[DiscoveredTest] = Field(default_factory=list)
+    files_scanned: int = 0
+    files_scanned_truncated: bool = False
+
+
+class _TestItem:
+    def __init__(self, node: ast.AST, name: str, class_name: str | None):
+        self.node = node
+        self.name = name
+        self.class_name = class_name
+
+
+def _test_items(module: ast.Module) -> list[_TestItem]:
+    """Pytest-collectible test functions: top-level `test_*` functions, and
+    `test_*` methods on a top-level `Test*` class — pytest's own default
+    collection convention (`python_functions`/`python_classes`)."""
+    items: list[_TestItem] = []
+    for node in module.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith(
+            "test_"
+        ):
+            items.append(_TestItem(node, node.name, None))
+        elif isinstance(node, ast.ClassDef) and node.name.startswith("Test"):
+            for child in node.body:
+                if isinstance(
+                    child, (ast.FunctionDef, ast.AsyncFunctionDef)
+                ) and child.name.startswith("test_"):
+                    items.append(_TestItem(child, child.name, node.name))
+    return items
+
+
+def _node_id(path: str, item: _TestItem) -> str:
+    if item.class_name:
+        return f"{path}::{item.class_name}::{item.name}"
+    return f"{path}::{item.name}"
+
+
+def _is_test_file(path: Path) -> bool:
+    name = path.name
+    return name.startswith("test_") or name.endswith("_test.py")
+
+
+def _names_called(node: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for child in ast.walk(node):
+        if isinstance(child, ast.Call):
+            func = child.func
+            if isinstance(func, ast.Name):
+                names.add(func.id)
+            elif isinstance(func, ast.Attribute):
+                names.add(func.attr)
+    return names
+
+
+def _names_referenced(node: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for child in ast.walk(node):
+        if isinstance(child, ast.Name):
+            names.add(child.id)
+        elif isinstance(child, ast.Attribute):
+            names.add(child.attr)
+    return names
+
+
+def _imported_module_stems(module: ast.Module) -> set[str]:
+    stems: set[str] = set()
+    for node in ast.walk(module):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                stems.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            stems.add(node.module.split(".")[0])
+    return stems
+
+
+def _changed_symbol_names(repo: Path, change_set: ChangeSet) -> set[str]:
+    return {defn.qualname.rsplit(".", 1)[-1] for defn in changed_definitions(repo, change_set)}
+
+
+def _changed_module_stems(change_set: ChangeSet) -> set[str]:
+    return {
+        Path(f.path).stem
+        for f in change_set.files
+        if f.category == "source" and f.status != "deleted" and f.path.endswith(".py")
+    }
+
+
+def _added_or_modified_tests(repo: Path, change_set: ChangeSet) -> dict[str, DiscoveredTest]:
+    discovered: dict[str, DiscoveredTest] = {}
+    for file_change in change_set.files:
+        if file_change.category != "test" or file_change.status == "deleted":
+            continue
+        source = _read(repo / file_change.path)
+        module = _parse(source) if source is not None else None
+        if module is None:
+            continue
+        for item in _test_items(module):
+            test_id = _node_id(file_change.path, item)
+            discovered[test_id] = DiscoveredTest(
+                test_id=test_id,
+                file=file_change.path,
+                reasons=[DiscoveryReason.ADDED_OR_MODIFIED],
+            )
+    return discovered
+
+
+def _existing_test_files(repo: Path, budget: TestDiscoveryBudget) -> tuple[list[Path], bool]:
+    files = sorted(
+        path
+        for path in repo.rglob("*.py")
+        if _is_test_file(path)
+        and not (_EXCLUDED_DIRS & set(path.relative_to(repo).parts[:-1]))
+    )
+    return files[: budget.max_files_scanned], len(files) > budget.max_files_scanned
+
+
+def discover_tests(
+    repo: Path, change_set: ChangeSet, budget: TestDiscoveryBudget | None = None
+) -> TestDiscoveryResult:
+    """Discover the tests relevant to a change set."""
+    budget = budget or TestDiscoveryBudget()
+
+    discovered = _added_or_modified_tests(repo, change_set)
+    already_covered = {f.path for f in change_set.files}
+
+    symbol_names = _changed_symbol_names(repo, change_set)
+    module_stems = _changed_module_stems(change_set)
+
+    files, files_truncated = _existing_test_files(repo, budget)
+    files_scanned = 0
+    for path in files:
+        rel = str(path.relative_to(repo))
+        if rel in already_covered:
+            continue  # added/modified tests are handled above, with their own reason
+        source = _read(path)
+        module = _parse(source) if source is not None else None
+        if module is None:
+            continue
+        files_scanned += 1
+
+        module_import_hit = bool(_imported_module_stems(module) & module_stems)
+        for item in _test_items(module):
+            called = _names_called(item.node) & symbol_names
+            touched_only = (_names_referenced(item.node) & symbol_names) - called
+
+            reasons = []
+            if called:
+                reasons.append(DiscoveryReason.CALLS_CHANGED_SYMBOL)
+            if touched_only:
+                reasons.append(DiscoveryReason.REFERENCES_CHANGED_SYMBOL)
+            if module_import_hit:
+                reasons.append(DiscoveryReason.IMPORTS_CHANGED_MODULE)
+            if any(name in item.name for name in symbol_names):
+                reasons.append(DiscoveryReason.NAME_MATCHES_SYMBOL)
+
+            if reasons:
+                test_id = _node_id(rel, item)
+                discovered[test_id] = DiscoveredTest(test_id=test_id, file=rel, reasons=reasons)
+
+    return TestDiscoveryResult(
+        tests=sorted(discovered.values(), key=lambda t: t.test_id),
+        files_scanned=files_scanned,
+        files_scanned_truncated=files_truncated,
+    )
+
+
+def _read(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _parse(source: str) -> ast.Module | None:
+    try:
+        return ast.parse(source)
+    except SyntaxError:
+        return None

--- a/tests/evidence/test_discovery.py
+++ b/tests/evidence/test_discovery.py
@@ -1,0 +1,225 @@
+"""M4.1 acceptance: on a fixture where an existing untouched test covers a
+changed function, that test is discovered — plus unit coverage of each
+discovery signal (added/modified, call graph, touched-not-called reference,
+import, naming) and the file-scan budget."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from acceptance.change.diff import extract_change_set
+from acceptance.evidence.discovery import (
+    DiscoveryReason,
+    TestDiscoveryBudget,
+    discover_tests,
+)
+from acceptance.review_state import ChangeSet, DiffHunk, FileChange
+
+
+def _hunk(new_start: int, new_lines: int) -> DiffHunk:
+    return DiffHunk(
+        header=f"@@ -{new_start},{new_lines} +{new_start},{new_lines} @@",
+        old_start=new_start,
+        old_lines=new_lines,
+        new_start=new_start,
+        new_lines=new_lines,
+        content="",
+    )
+
+
+def _change_set(*files: FileChange) -> ChangeSet:
+    return ChangeSet(base_revision="base", head_revision="head", files=list(files))
+
+
+def _source_change(path: str, new_start: int = 1, new_lines: int = 2, status: str = "modified") -> FileChange:
+    return FileChange(path=path, status=status, category="source", hunks=[_hunk(new_start, new_lines)])
+
+
+def _test_change(path: str, status: str = "added") -> FileChange:
+    return FileChange(path=path, status=status, category="test", hunks=[_hunk(1, 3)])
+
+
+def _write(repo: Path, name: str, content: str) -> None:
+    (repo / name).write_text(content)
+
+
+# --- unit-level: hand-built change sets, no git needed ---
+
+
+def test_added_test_file_contributes_every_test_it_defines(tmp_path):
+    repo = tmp_path
+    _write(
+        repo,
+        "test_new.py",
+        "def test_a():\n    assert True\n\n\ndef test_b():\n    assert True\n",
+    )
+    change_set = _change_set(_test_change("test_new.py"))
+
+    result = discover_tests(repo, change_set)
+
+    test_ids = {t.test_id for t in result.tests}
+    assert test_ids == {"test_new.py::test_a", "test_new.py::test_b"}
+    assert all(t.reasons == [DiscoveryReason.ADDED_OR_MODIFIED] for t in result.tests)
+
+
+def test_class_based_test_method_gets_a_pytest_style_node_id(tmp_path):
+    repo = tmp_path
+    _write(
+        repo,
+        "test_new.py",
+        "class TestThing:\n    def test_it(self):\n        assert True\n",
+    )
+    change_set = _change_set(_test_change("test_new.py"))
+
+    result = discover_tests(repo, change_set)
+
+    assert result.tests[0].test_id == "test_new.py::TestThing::test_it"
+
+
+def test_deleted_test_file_is_not_discovered(tmp_path):
+    repo = tmp_path
+    change_set = _change_set(_test_change("test_gone.py", status="deleted"))
+
+    result = discover_tests(repo, change_set)
+
+    assert result.tests == []
+
+
+def test_untouched_test_calling_a_changed_symbol_is_discovered_by_call_graph(tmp_path):
+    repo = tmp_path
+    _write(repo, "mod.py", "def target():\n    return 1\n")
+    _write(
+        repo,
+        "test_mod.py",
+        "from mod import target\n\n\ndef test_target():\n    assert target() == 1\n",
+    )
+    # mod.py changed; test_mod.py is untouched (not in the change set).
+    change_set = _change_set(_source_change("mod.py", new_start=1, new_lines=2))
+
+    result = discover_tests(repo, change_set)
+
+    found = next(t for t in result.tests if t.test_id == "test_mod.py::test_target")
+    assert DiscoveryReason.CALLS_CHANGED_SYMBOL in found.reasons
+
+
+def test_untouched_test_referencing_without_calling_is_a_distinct_reason(tmp_path):
+    repo = tmp_path
+    _write(repo, "mod.py", "class Thing:\n    pass\n")
+    _write(
+        repo,
+        "test_mod.py",
+        "from mod import Thing\n\n\ndef test_is_thing():\n    assert isinstance(object(), Thing) is False\n",
+    )
+    change_set = _change_set(_source_change("mod.py", new_start=1, new_lines=2))
+
+    result = discover_tests(repo, change_set)
+
+    found = next(t for t in result.tests if t.test_id == "test_mod.py::test_is_thing")
+    assert DiscoveryReason.REFERENCES_CHANGED_SYMBOL in found.reasons
+    assert DiscoveryReason.CALLS_CHANGED_SYMBOL not in found.reasons
+
+
+def test_untouched_test_importing_the_changed_module_is_discovered(tmp_path):
+    repo = tmp_path
+    _write(repo, "mod.py", "def unrelated_helper():\n    return 1\nCONST = 2\n")
+    _write(
+        repo,
+        "test_mod.py",
+        "import mod\n\n\ndef test_const():\n    assert mod.CONST == 2\n",
+    )
+    # Change targets a *different* symbol than the test touches, so the only
+    # signal available is the module-level import.
+    change_set = _change_set(_source_change("mod.py", new_start=1, new_lines=2))
+
+    result = discover_tests(repo, change_set)
+
+    found = next((t for t in result.tests if t.test_id == "test_mod.py::test_const"), None)
+    assert found is not None
+    assert DiscoveryReason.IMPORTS_CHANGED_MODULE in found.reasons
+
+
+def test_untouched_test_named_after_the_changed_symbol_is_discovered(tmp_path):
+    repo = tmp_path
+    _write(repo, "mod.py", "def widget():\n    return 1\n")
+    _write(
+        repo,
+        "test_mod.py",
+        "def test_widget_behavior():\n    from mod import widget\n    assert widget\n",
+    )
+    change_set = _change_set(_source_change("mod.py", new_start=1, new_lines=2))
+
+    result = discover_tests(repo, change_set)
+
+    found = next(t for t in result.tests if t.test_id == "test_mod.py::test_widget_behavior")
+    assert DiscoveryReason.NAME_MATCHES_SYMBOL in found.reasons
+
+
+def test_unrelated_test_is_not_discovered(tmp_path):
+    repo = tmp_path
+    _write(repo, "mod.py", "def target():\n    return 1\n")
+    _write(
+        repo,
+        "test_other.py",
+        "def test_unrelated():\n    assert 1 + 1 == 2\n",
+    )
+    change_set = _change_set(_source_change("mod.py", new_start=1, new_lines=2))
+
+    result = discover_tests(repo, change_set)
+
+    assert result.tests == []
+
+
+def test_file_scan_budget_is_respected_and_flagged(tmp_path):
+    repo = tmp_path
+    for i in range(3):
+        _write(repo, f"test_{i}.py", "def test_x():\n    assert True\n")
+    change_set = _change_set()
+
+    result = discover_tests(repo, change_set, budget=TestDiscoveryBudget(max_files_scanned=1))
+
+    assert result.files_scanned == 1
+    assert result.files_scanned_truncated is True
+
+
+# --- acceptance: real git repo, real extract_change_set (M4.1's own wording) ---
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+
+def _commit(repo: Path, message: str) -> str:
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", message)
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path) -> Path:
+    path = tmp_path / "repo"
+    path.mkdir()
+    _git(path, "init", "-q")
+    _git(path, "config", "user.email", "test@example.com")
+    _git(path, "config", "user.name", "Test")
+    return path
+
+
+def test_existing_untouched_test_covering_a_changed_function_is_discovered(repo):
+    (repo / "mod.py").write_text("def f():\n    return 1\n")
+    (repo / "test_mod.py").write_text(
+        "from mod import f\n\n\ndef test_f():\n    assert f() == 1\n"
+    )
+    base = _commit(repo, "base")
+
+    (repo / "mod.py").write_text("def f():\n    return 2\n")
+    head = _commit(repo, "head")
+
+    change_set = extract_change_set(repo, base, head)
+    result = discover_tests(repo, change_set)
+
+    test_ids = {t.test_id for t in result.tests}
+    assert "test_mod.py::test_f" in test_ids


### PR DESCRIPTION
## Summary
New `evidence/` package (M4/M5's home going forward — mapping, then test-semantic analysis) with `discovery.py`: `discover_tests(repo, change_set, budget)` collects the tests relevant to a change set, purely structurally (Python AST, no LLM call — matching M2's diff extraction and M2.2's context retrieval).

- Every **added/modified** test in the change set, directly.
- An existing, **untouched** test is discovered when it: **calls** a changed symbol (call graph), **references** a changed symbol without calling it (a distinct signal — `referenced - called`, not just a superset of calls), **imports** a changed module, or is **named** after a changed symbol.
- Every `DiscoveredTest` records *why* (`reasons`, never empty) — typed and linked, not a bare boolean.
- The repo-wide scan is budget-bounded (`TestDiscoveryBudget`, default 500 files) and flags truncation rather than silently dropping (`files_scanned_truncated`) — same pattern as M2.2's `RetrievalResult`.

**Small motivated refactor:** extracted `change/context.py`'s changed-definition computation into a new public `changed_definitions(repo, change_set)` — the same enclosing-definition-of-changed-lines logic `retrieve_context` already computed internally, now reused by discovery instead of recomputed. Pure extraction, behavior unchanged (all 40 existing `change/` tests pass unmodified).

`decompose` surfaced two legitimate open questions (the budget cap value; how to flag it) — resolved by following M2.2's own established convention rather than inventing a new one.

## Test plan
- [x] Unit tests for each discovery reason (added/modified, call graph, touched-not-called, import, naming), a negative case (unrelated test not discovered), deleted-file handling, class-method nodeid formatting, budget truncation.
- [x] Acceptance test (M4.1's own wording): a real git repo where an existing, untouched test calling a changed function is discovered.
- [x] Full suite: 320 passed (was 310).
- [x] ruff clean.
- [x] Dogfooded live (`decompose`/`classify`) — all 18 obligations `[addressed]`; 3 of 4 "unrequested changes" correctly self-classified `[in_service]` by M3.5.3's disposition classifier; one false-positive `[separable]` flag on the package `__init__.py` (boilerplate required for the new package, not a separable unit of work) — not acted on.

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)