### PR TITLE
M4.2: test-to-obligation mapping (§9.1)

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,13 +1,14 @@
 # Task
-Collect added/modified tests plus relevant existing tests (by touched symbols, imports, naming, and call graph).
+Map each candidate test to the obligation(s) it purports to evidence, and flag obligations with no mapped test.
 
 ## Constraints
-- Structural only, no LLM call — Python AST, matching the M2 change/diff extraction and M2.2 context retrieval.
-- Every added/modified test in the change set is discovered directly.
-- An existing, untouched test is discovered when it calls a changed symbol, references a changed symbol without calling it, imports a changed module, or is named after a changed symbol.
-- Every discovered test records why it was discovered (never zero reasons).
-- Bound the repo-wide scan with a budget, flagged (not silently dropped) when the cap is hit.
+- Candidate tests come from M4.1 discovery; obligations from M1.
+- Mapping is the precision step over recall-forward discovery: judge which obligation(s), if any, a test's assertions are actually aimed at — not merely that it touches changed code.
+- A test may map to zero, one, or several obligations; obligations with no mapped test are flagged unmapped.
+- "Purports to evidence" is weaker than "proves" — do not judge test strength here; that is a later step.
+- The mapping is a schema-constrained model call recorded for replay; capability tests run off the recorded transcript with no live calls.
+- Populate each obligation's test_evidence so the §11.1 mapping-accuracy metric scores a real number against archetype labels.
 
 ## Completion expectations
 - Implementation
-- Unit tests: on a fixture where an existing untouched test covers a changed function, that test is discovered.
+- Unit tests: on the §9.1-style example each derived criterion is either mapped to a test or flagged unmapped, and mapping-accuracy reports a number vs archetype labels.

--- a/src/acceptance/benchmark/coverage.py
+++ b/src/acceptance/benchmark/coverage.py
@@ -28,6 +28,8 @@ from acceptance.config import ScopeExpansionPolicy
 from acceptance.coverage.classify import CoverageStatus, ImplementationCoverage, classify_coverage
 from acceptance.coverage.disposition import DispositionedChange, classify_dispositions
 from acceptance.coverage.unrequested import detect_unrequested_changes
+from acceptance.evidence.discovery import discover_tests
+from acceptance.evidence.mapping import apply_test_mapping, map_tests_to_obligations
 from acceptance.evidence_tier import Component, EvidenceTier
 from acceptance.llm import ModelClient
 from acceptance.requirement.obligations import decompose
@@ -103,13 +105,20 @@ def classify_case(
     client: ModelClient,
     policy: ScopeExpansionPolicy = ScopeExpansionPolicy.STRICT,
 ) -> BenchmarkCase:
-    """Decompose, classify coverage, detect unrequested changes and their
-    dispositions for a case's diff; return a scored copy of `case`."""
+    """Decompose; discover and map candidate tests; classify coverage, detect
+    unrequested changes and their dispositions for a case's diff; return a
+    scored copy of `case`. The benchmark's assembled static pipeline — each
+    capability lands here as it ships so its §11.1 metric is scored (M3-M5)."""
     parsed = parse_task_file(case.inputs.task_text)
     obligations = decompose(parsed, client).obligations
+    repo = Path(case.inputs.repo)
     change_set = extract_change_set(
-        Path(case.inputs.repo), case.inputs.base_revision, case.inputs.head_revision
+        repo, case.inputs.base_revision, case.inputs.head_revision
     )
+
+    discovered = discover_tests(repo, change_set)
+    mapping = map_tests_to_obligations(obligations, discovered.tests, client)
+    obligations = apply_test_mapping(obligations, mapping)
 
     coverages = classify_coverage(obligations, change_set, client)
     unrequested = detect_unrequested_changes(obligations, change_set, client)

--- a/src/acceptance/evidence/discovery.py
+++ b/src/acceptance/evidence/discovery.py
@@ -61,11 +61,14 @@ class DiscoveryReason(str, Enum):
 
 
 class DiscoveredTest(PersistableModel):
-    """A candidate test, and why it was discovered — never zero reasons."""
+    """A candidate test, why it was discovered (never zero reasons), and its
+    source (so M4.2 mapping and M5 analysis judge its assertions without
+    re-parsing — discovery already has the AST node in hand)."""
 
     test_id: str  # pytest nodeid: "path/test_x.py::test_fn" or "...::TestC::test_m"
     file: str
     reasons: list[DiscoveryReason] = Field(default_factory=list)
+    source: str = ""
 
 
 class TestDiscoveryResult(PersistableModel):
@@ -106,6 +109,12 @@ def _node_id(path: str, item: _TestItem) -> str:
     if item.class_name:
         return f"{path}::{item.class_name}::{item.name}"
     return f"{path}::{item.name}"
+
+
+def _node_source(source: str, item: _TestItem) -> str:
+    lines = source.splitlines()
+    end = getattr(item.node, "end_lineno", item.node.lineno)
+    return "\n".join(lines[item.node.lineno - 1 : end])
 
 
 def _is_test_file(path: Path) -> bool:
@@ -173,6 +182,7 @@ def _added_or_modified_tests(repo: Path, change_set: ChangeSet) -> dict[str, Dis
                 test_id=test_id,
                 file=file_change.path,
                 reasons=[DiscoveryReason.ADDED_OR_MODIFIED],
+                source=_node_source(source, item),
             )
     return discovered
 
@@ -228,7 +238,9 @@ def discover_tests(
 
             if reasons:
                 test_id = _node_id(rel, item)
-                discovered[test_id] = DiscoveredTest(test_id=test_id, file=rel, reasons=reasons)
+                discovered[test_id] = DiscoveredTest(
+                    test_id=test_id, file=rel, reasons=reasons, source=_node_source(source, item)
+                )
 
     return TestDiscoveryResult(
         tests=sorted(discovered.values(), key=lambda t: t.test_id),

--- a/src/acceptance/evidence/mapping.py
+++ b/src/acceptance/evidence/mapping.py
@@ -1,0 +1,141 @@
+"""Test-to-obligation mapping (M4.2, §9.1).
+
+Maps each candidate test (from M4.1 discovery) to the obligation(s) it
+*purports* to evidence, and flags obligations with no mapped test. Discovery
+is recall-forward — it surfaces every test that touches changed code (by call
+graph, reference, import, or naming). This is the precision step: which
+obligation(s), if any, is a test's *assertions* actually aimed at?
+
+"Purports to evidence" is deliberately weaker than "proves": a test maps to an
+obligation when its assertions target that obligation's observable behavior,
+not when it does so *well*. Whether the test genuinely discriminates the
+behavior (its strength) is M5's job, judged separately over this map.
+
+The judgment is semantic, so it is a schema-constrained model call through the
+M0.4 harness — recorded for replay, never a live call in tests. `apply_test_mapping`
+then writes each obligation's mapped test ids into `Obligation.test_evidence`,
+the field the §11.1 mapping-accuracy metric (scoring.py) already scores.
+"""
+
+from __future__ import annotations
+
+from acceptance.evidence.discovery import DiscoveredTest
+from acceptance.llm import ModelClient, StrictResponseModel
+from acceptance.model_base import PersistableModel
+from acceptance.review_state import Obligation
+
+_SYSTEM_PROMPT = """\
+You map each candidate test to the acceptance obligation(s) it PURPORTS to
+evidence. The candidate tests were found because they touch changed code (they
+call, reference, import, or are named after a changed symbol) — that is a
+RECALL signal, not proof they test any obligation. Your job is the precision
+step: for each test, decide which obligation(s), if any, its assertions are
+actually aimed at.
+
+A test evidences an obligation when its assertions check that obligation's
+observable behavior — the test would be expected to fail if that behavior were
+missing or wrong. Map on what the test is AIMED at, not how strong it is:
+whether the test genuinely discriminates the behavior is judged separately
+(later), not here.
+
+- A test may evidence MULTIPLE obligations — return several ids.
+- A test may evidence NONE — it touches changed code only incidentally (setup,
+  a helper, an unrelated assertion) and asserts nothing about any obligation.
+  Return an empty `obligation_ids` for it; that is expected and correct.
+
+For each test return its `test_id`, the `obligation_ids` it purports to
+evidence (possibly empty), and a short `rationale`. Use only obligation ids
+from the list; use only test ids from the candidate list."""
+
+
+class TestMapping(PersistableModel):
+    """Which obligation(s) one candidate test purports to evidence."""
+
+    __test__ = False  # not a pytest test class
+
+    test_id: str
+    obligation_ids: list[str]
+    rationale: str
+
+
+class MappingResult(PersistableModel):
+    mappings: list[TestMapping]
+    unmapped_obligation_ids: list[str]  # obligations no test purports to evidence
+
+
+class _TestMapping(StrictResponseModel):
+    test_id: str
+    obligation_ids: list[str]
+    rationale: str
+
+
+class _Mappings(StrictResponseModel):
+    mappings: list[_TestMapping]
+
+
+def _render_prompt(obligations: list[Obligation], tests: list[DiscoveredTest]) -> str:
+    lines = ["## Obligations", ""]
+    for obligation in obligations:
+        lines.append(f"- id={obligation.id}: {obligation.description}")
+        if obligation.observable_behavior:
+            lines.append(f"  observable behavior: {obligation.observable_behavior}")
+    lines.append("")
+    lines.append("## Candidate tests")
+    for test in tests:
+        lines.append("")
+        lines.append(f"### {test.test_id}")
+        lines.append(test.source or "(source unavailable)")
+    return "\n".join(lines)
+
+
+def map_tests_to_obligations(
+    obligations: list[Obligation], tests: list[DiscoveredTest], client: ModelClient
+) -> MappingResult:
+    """Map each candidate test to the obligation(s) it purports to evidence."""
+    valid_obligation_ids = {o.id for o in obligations}
+    if not tests:
+        # No candidates to map — every obligation is unmapped. No model call.
+        return MappingResult(mappings=[], unmapped_obligation_ids=sorted(valid_obligation_ids))
+
+    messages = [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {"role": "user", "content": _render_prompt(obligations, tests)},
+    ]
+    result = client.complete(messages, _Mappings)
+
+    valid_test_ids = {t.test_id for t in tests}
+    mapped_obligation_ids: set[str] = set()
+    mappings: list[TestMapping] = []
+    for mapping in result.mappings:
+        if mapping.test_id not in valid_test_ids:
+            continue  # a returned id that isn't a real candidate — drop it
+        obligation_ids = [oid for oid in mapping.obligation_ids if oid in valid_obligation_ids]
+        mapped_obligation_ids.update(obligation_ids)
+        mappings.append(
+            TestMapping(
+                test_id=mapping.test_id,
+                obligation_ids=obligation_ids,
+                rationale=mapping.rationale,
+            )
+        )
+
+    unmapped = sorted(valid_obligation_ids - mapped_obligation_ids)
+    return MappingResult(mappings=mappings, unmapped_obligation_ids=unmapped)
+
+
+def apply_test_mapping(
+    obligations: list[Obligation], result: MappingResult
+) -> list[Obligation]:
+    """Return copies of `obligations` with `test_evidence` populated from the
+    mapping — the join the §11.1 mapping-accuracy metric scores."""
+    tests_by_obligation: dict[str, list[str]] = {}
+    for mapping in result.mappings:
+        for obligation_id in mapping.obligation_ids:
+            tests_by_obligation.setdefault(obligation_id, []).append(mapping.test_id)
+
+    return [
+        obligation.model_copy(
+            update={"test_evidence": sorted(tests_by_obligation.get(obligation.id, []))}
+        )
+        for obligation in obligations
+    ]

--- a/tests/benchmark/test_coverage.py
+++ b/tests/benchmark/test_coverage.py
@@ -89,6 +89,7 @@ def test_archetype_1_missed_obligation_yields_full_recall_and_precision(tmp_path
     ]
     client = _client_dispatching(
         {
+            "_Mappings": {"mappings": []},
             "_Decomposition": _decomposition_response(obligations),
             "_Coverage": _classification_response(
                 [
@@ -138,6 +139,7 @@ def test_archetype_2_missed_qualifier_yields_full_recall_and_precision(tmp_path)
     ]
     client = _client_dispatching(
         {
+            "_Mappings": {"mappings": []},
             "_Decomposition": _decomposition_response(obligations),
             "_Coverage": _classification_response(
                 [
@@ -188,6 +190,7 @@ def test_archetype_8_unrequested_change_gap_matches_via_its_obligation(tmp_path)
     ]
     client = _client_dispatching(
         {
+            "_Mappings": {"mappings": []},
             "_Decomposition": _decomposition_response(obligations),
             "_Coverage": _classification_response(
                 [
@@ -262,6 +265,7 @@ def test_archetype_8_unrequested_change_metric_does_not_route_through_coverage(t
     ]
     client = _client_dispatching(
         {
+            "_Mappings": {"mappings": []},
             "_Decomposition": _decomposition_response(obligations),
             "_Coverage": _classification_response(
                 [
@@ -304,6 +308,7 @@ def test_classify_case_does_not_mutate_the_input_case(tmp_path):
     case = build_benchmark_case(ARCHETYPES_DIR / "01-missed-obligation", tmp_path / "repo")
     client = _client_dispatching(
         {
+            "_Mappings": {"mappings": []},
             "_Decomposition": _decomposition_response([]),
             "_Coverage": {"classifications": []},
             "_Detections": {"unrequested_changes": []},

--- a/tests/evidence/test_mapping.py
+++ b/tests/evidence/test_mapping.py
@@ -1,0 +1,216 @@
+"""M4.2 acceptance: each obligation is either mapped to a candidate test or
+flagged unmapped, and the §11.1 mapping-accuracy metric reports a real number
+against archetype labels.
+
+Mapping is a schema-constrained model call; per the replay-first invariant
+these tests inject the recorded response via completion_fn — no live calls.
+A client that raises proves the no-candidate-tests path takes no model call.
+"""
+
+import tempfile
+from pathlib import Path
+
+from acceptance.benchmark.fixtures import build_benchmark_case
+from acceptance.benchmark.scoring import score_case
+from acceptance.change.diff import extract_change_set
+from acceptance.evidence.discovery import DiscoveredTest, DiscoveryReason, discover_tests
+from acceptance.evidence.mapping import apply_test_mapping, map_tests_to_obligations
+from acceptance.llm import Mode, ModelClient, TranscriptStore
+from acceptance.review_state import Obligation, ObligationType, Review
+from tests.support import client_returning, make_obligation
+
+ARCHETYPES_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "archetypes"
+
+
+def _test(test_id: str, source: str = "def t():\n    pass") -> DiscoveredTest:
+    return DiscoveredTest(
+        test_id=test_id, file=test_id.split("::", 1)[0],
+        reasons=[DiscoveryReason.CALLS_CHANGED_SYMBOL], source=source,
+    )
+
+
+def _exploding_client() -> ModelClient:
+    def boom(**kwargs):
+        raise AssertionError("a model call was issued when there were no candidate tests")
+
+    return ModelClient(
+        model="x", mode=Mode.RECORD, store=TranscriptStore(tempfile.mkdtemp()), completion_fn=boom
+    )
+
+
+# --- unit: map_tests_to_obligations ---
+
+
+def test_a_test_maps_to_the_obligation_it_evidences():
+    obligations = [
+        make_obligation("ob-1", "Discount reduces the total", ObligationType.FUNCTIONAL),
+        make_obligation("ob-2", "Result is money-formatted", ObligationType.FUNCTIONAL),
+    ]
+    tests = [_test("test_cart.py::test_discount")]
+    response = {"mappings": [
+        {"test_id": "test_cart.py::test_discount", "obligation_ids": ["ob-1"], "rationale": "asserts total"},
+    ]}
+
+    result = map_tests_to_obligations(obligations, tests, client_returning(response))
+
+    assert len(result.mappings) == 1
+    assert result.mappings[0].obligation_ids == ["ob-1"]
+    # ob-2 has no mapped test.
+    assert result.unmapped_obligation_ids == ["ob-2"]
+
+
+def test_a_test_can_map_to_multiple_obligations():
+    obligations = [
+        make_obligation("ob-1", "A", ObligationType.FUNCTIONAL),
+        make_obligation("ob-2", "B", ObligationType.FUNCTIONAL),
+    ]
+    tests = [_test("t.py::test_both")]
+    response = {"mappings": [
+        {"test_id": "t.py::test_both", "obligation_ids": ["ob-1", "ob-2"], "rationale": "both"},
+    ]}
+
+    result = map_tests_to_obligations(obligations, tests, client_returning(response))
+
+    assert result.mappings[0].obligation_ids == ["ob-1", "ob-2"]
+    assert result.unmapped_obligation_ids == []
+
+
+def test_a_test_evidencing_nothing_leaves_obligations_unmapped():
+    # Discovery is recall-forward; mapping is the precision filter. A test that
+    # touches changed code but asserts nothing about an obligation maps to none.
+    obligations = [make_obligation("ob-1", "A", ObligationType.FUNCTIONAL)]
+    tests = [_test("t.py::test_incidental")]
+    response = {"mappings": [
+        {"test_id": "t.py::test_incidental", "obligation_ids": [], "rationale": "setup only"},
+    ]}
+
+    result = map_tests_to_obligations(obligations, tests, client_returning(response))
+
+    assert result.mappings[0].obligation_ids == []
+    assert result.unmapped_obligation_ids == ["ob-1"]
+
+
+def test_unknown_ids_are_dropped():
+    obligations = [make_obligation("ob-1", "A", ObligationType.FUNCTIONAL)]
+    tests = [_test("t.py::test_real")]
+    response = {"mappings": [
+        {"test_id": "t.py::test_ghost", "obligation_ids": ["ob-1"], "rationale": "not a real test"},
+        {"test_id": "t.py::test_real", "obligation_ids": ["ob-nope", "ob-1"], "rationale": "one bad id"},
+    ]}
+
+    result = map_tests_to_obligations(obligations, tests, client_returning(response))
+
+    # The ghost test id is dropped entirely; the bogus obligation id is filtered.
+    assert len(result.mappings) == 1
+    assert result.mappings[0].test_id == "t.py::test_real"
+    assert result.mappings[0].obligation_ids == ["ob-1"]
+
+
+def test_no_candidate_tests_makes_no_model_call_and_flags_all_unmapped():
+    obligations = [
+        make_obligation("ob-1", "A", ObligationType.FUNCTIONAL),
+        make_obligation("ob-2", "B", ObligationType.FUNCTIONAL),
+    ]
+
+    result = map_tests_to_obligations(obligations, [], _exploding_client())
+
+    assert result.mappings == []
+    assert result.unmapped_obligation_ids == ["ob-1", "ob-2"]
+
+
+# --- unit: apply_test_mapping ---
+
+
+def test_apply_test_mapping_populates_test_evidence():
+    obligations = [
+        make_obligation("ob-1", "A", ObligationType.FUNCTIONAL),
+        make_obligation("ob-2", "B", ObligationType.FUNCTIONAL),
+    ]
+    tests = [_test("t.py::test_a"), _test("t.py::test_ab")]
+    response = {"mappings": [
+        {"test_id": "t.py::test_a", "obligation_ids": ["ob-1"], "rationale": "."},
+        {"test_id": "t.py::test_ab", "obligation_ids": ["ob-1", "ob-2"], "rationale": "."},
+    ]}
+    result = map_tests_to_obligations(obligations, tests, client_returning(response))
+
+    mapped = {o.id: o for o in apply_test_mapping(obligations, result)}
+
+    assert mapped["ob-1"].test_evidence == ["t.py::test_a", "t.py::test_ab"]
+    assert mapped["ob-2"].test_evidence == ["t.py::test_ab"]
+
+
+def test_apply_test_mapping_does_not_mutate_the_inputs():
+    obligations = [make_obligation("ob-1", "A", ObligationType.FUNCTIONAL)]
+    tests = [_test("t.py::test_a")]
+    response = {"mappings": [{"test_id": "t.py::test_a", "obligation_ids": ["ob-1"], "rationale": "."}]}
+    result = map_tests_to_obligations(obligations, tests, client_returning(response))
+
+    apply_test_mapping(obligations, result)
+
+    assert obligations[0].test_evidence == []  # original untouched
+
+
+# --- acceptance: mapping-accuracy metric vs archetype #1 labels ---
+
+
+def test_archetype_1_mapping_accuracy_reports_a_real_number(tmp_path):
+    case = build_benchmark_case(ARCHETYPES_DIR / "01-missed-obligation", tmp_path / "repo")
+    repo = Path(case.inputs.repo)
+    change_set = extract_change_set(repo, case.inputs.base_revision, case.inputs.head_revision)
+
+    discovered = discover_tests(repo, change_set)
+    test_ids = {t.test_id for t in discovered.tests}
+    pos = "test_receipt.py::test_positive_line"
+    two = "test_receipt.py::test_two_decimal_formatting"
+    assert {pos, two} <= test_ids  # both real tests are discovered
+
+    # Reviewer obligations mirror ground truth (description is the scoring join
+    # key today; ids reused so the injected mapping can target them).
+    obligations = [
+        Obligation(
+            id=o.id, description=o.description, type=ObligationType.FUNCTIONAL,
+            importance="critical", explicit=True, observable_behavior="...",
+        )
+        for o in case.ground_truth.obligations
+    ]
+
+    # Map both tests to show-fields and line-total, but NOT money-format:
+    # 4 of the 6 ground-truth (obligation, test) pairs -> mapping recall 4/6.
+    response = {"mappings": [
+        {"test_id": pos, "obligation_ids": ["show-fields", "line-total"], "rationale": "."},
+        {"test_id": two, "obligation_ids": ["show-fields", "line-total"], "rationale": "."},
+    ]}
+    result = map_tests_to_obligations(obligations, discovered.tests, client_returning(response))
+    mapped = apply_test_mapping(obligations, result)
+
+    review = Review(mode="local", reviewed_revision=case.inputs.head_revision, obligation_map=mapped)
+    scored = score_case(case.model_copy(update={"reviewer_output": review}))
+
+    assert scored.mapping_accuracy == 4 / 6
+
+
+def test_archetype_1_unmapped_obligations_are_flagged(tmp_path):
+    """The other half of the acceptance: an obligation with no mapped test is
+    flagged unmapped. returns-in-parens (ground truth: no candidate tests) has
+    nothing evidencing it, so a faithful mapping leaves it unmapped."""
+    case = build_benchmark_case(ARCHETYPES_DIR / "01-missed-obligation", tmp_path / "repo")
+    repo = Path(case.inputs.repo)
+    change_set = extract_change_set(repo, case.inputs.base_revision, case.inputs.head_revision)
+    discovered = discover_tests(repo, change_set)
+
+    obligations = [
+        Obligation(
+            id=o.id, description=o.description, type=ObligationType.FUNCTIONAL,
+            importance="critical", explicit=True, observable_behavior="...",
+        )
+        for o in case.ground_truth.obligations
+    ]
+    pos = "test_receipt.py::test_positive_line"
+    two = "test_receipt.py::test_two_decimal_formatting"
+    response = {"mappings": [
+        {"test_id": pos, "obligation_ids": ["show-fields", "line-total", "money-format"], "rationale": "."},
+        {"test_id": two, "obligation_ids": ["show-fields", "line-total", "money-format"], "rationale": "."},
+    ]}
+    result = map_tests_to_obligations(obligations, discovered.tests, client_returning(response))
+
+    assert "returns-in-parens" in result.unmapped_obligation_ids


### PR DESCRIPTION
## Summary
`evidence/mapping.py` — `map_tests_to_obligations()` maps each candidate test (from M4.1 discovery) to the obligation(s) it **purports** to evidence, via a schema-constrained model call. This is the **precision** counterpart to M4.1's recall-forward discovery: discovery surfaces any test that *touches* changed code; mapping asks which obligation(s), if any, a test's **assertions** are actually aimed at.

- A test may map to **zero** (touches changed code only incidentally — setup, helper, unrelated assertion), **one**, or **several** obligations; obligations with no mapped test are flagged `unmapped_obligation_ids`.
- **"Purports to evidence" is deliberately weaker than "proves"** — mapping is about what a test is *aimed at*, not how strongly it discriminates. That strength judgment is M5, over this map.
- `apply_test_mapping()` writes each obligation's mapped test ids into `Obligation.test_evidence` — the field the §11.1 mapping-accuracy metric has read since M0.2 but which **nothing had ever populated** (it scored `0.0` until now, as M1.4's own test noted). `classify_case` (the benchmark's assembled static pipeline) now runs discovery + mapping, so `mapping_accuracy` is scored end-to-end.
- `DiscoveredTest` gains a `source` field (populated in discovery from the AST node already in hand), so the mapper — and M5 later — judge assertions without re-parsing.

## Test plan
- [x] Unit: a test → one / multiple / zero obligations; unknown test/obligation ids filtered; the no-candidate-tests path makes **no model call** (proven with an exploding client) and flags all obligations unmapped; `apply_test_mapping` populates `test_evidence` and doesn't mutate inputs.
- [x] **Acceptance (M4.2's own wording):** on archetype #1, each criterion is mapped or flagged unmapped, and `mapping_accuracy` reports a real hand-computed number (**4/6**) against the fixture's `candidate_tests` labels — closing the loop M1.4 flagged as unfinished.
- [x] Existing `classify_case` tests updated to inject an (empty) `_Mappings` response; their assertions are unchanged.
- [x] Full suite: 329 passed (was 320); ruff clean.
- [x] Dogfooded (`decompose`/`classify`) — all 11 obligations `[addressed]`; 4 of 5 unrequested flags self-classified `[in_service]`; the 5th (`DiscoveredTest.source`) mislabeled `[separable]` — actually in-service (the mapper reads `test.source`), a fair miss the tool couldn't infer from task text, not acted on.

## Note
Not a `Finding`/CLI-rendered gap for unmapped obligations yet — surfacing unmapped obligations as gaps and judging evidence strength is M5/M7 territory, out of this task's scope.

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)