### PR TITLE
M5.1: per-test structural extraction (§9.3)

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,14 +1,13 @@
 # Task
-Map each candidate test to the obligation(s) it purports to evidence, and flag obligations with no mapped test.
+For each mapped candidate test, extract its structural facts: what production code it exercises, what it asserts, the fixtures and mocks it uses, its inputs, and — the key one — the provenance of its expected value.
 
 ## Constraints
-- Candidate tests come from M4.1 discovery; obligations from M1.
-- Mapping is the precision step over recall-forward discovery: judge which obligation(s), if any, a test's assertions are actually aimed at — not merely that it touches changed code.
-- A test may map to zero, one, or several obligations; obligations with no mapped test are flagged unmapped.
-- "Purports to evidence" is weaker than "proves" — do not judge test strength here; that is a later step.
-- The mapping is a schema-constrained model call recorded for replay; capability tests run off the recorded transcript with no live calls.
-- Populate each obligation's test_evidence so the §11.1 mapping-accuracy metric scores a real number against archetype labels.
+- Structural only, Python AST, no model call — the semantic discrimination judgment (would the test fail under a plausible defect?) is a later step.
+- Populate the existing §15 TestEvidence fields: identifier, location, inputs, fixtures, assertions, expected_value_provenance, mocks, mapped_obligations.
+- Expected-value provenance must flag circular evidence: when the expected value is computed from the same production code the test claims to verify, so a defect corrupts both sides of the assertion equally.
+- The production symbols under test are the names a test imports from a changed source module.
+- Take mapped tests from M4.1 discovery + M4.2 mapping.
 
 ## Completion expectations
 - Implementation
-- Unit tests: on the §9.1-style example each derived criterion is either mapped to a test or flagged unmapped, and mapping-accuracy reports a number vs archetype labels.
+- Unit tests: for archetype #5 the analyzer identifies that the expected value is produced by the same production function (circular provenance); an independent literal expected value is not flagged circular.

--- a/src/acceptance/evidence/extraction.py
+++ b/src/acceptance/evidence/extraction.py
@@ -1,0 +1,264 @@
+"""Per-test structural extraction (M5.1, §9.3).
+
+For each mapped candidate test, extract the structural facts §9.3's evidence
+analysis reasons over: what production code it exercises, what it asserts, its
+fixtures/mocks, its inputs, and — the load-bearing one — its expected-value
+**provenance**. This is Python AST, no LLM: the *discrimination judgment* (would
+the test fail under a plausible defect?) is the semantic step, and lands in
+M5.2 over what this extracts. Keeping M5.1 structural also makes it
+deterministic and directly testable.
+
+Expected-value provenance is the circular-evidence signal (§9.4). A test that
+computes its expected value from the same production code it claims to verify
+can never fail — a defect corrupts both sides of the equality equally. We detect
+this structurally: the "production symbols under test" are the names a test
+imports from a **changed source module** (`from orders import _apply_tax, ...`);
+if BOTH operands of an equality assertion reference such a symbol — after
+resolving local variable assignments — the expected value is production-derived,
+i.e. circular. A side that is a literal/constant is independent evidence.
+
+Limitation: only `from <changed_module> import name` bindings are treated as
+production symbols today; a plain `import orders; orders.f()` isn't traced (the
+archetypes and typical circular tests use from-imports). Refining that is a
+future step, not a silent gap.
+"""
+
+from __future__ import annotations
+
+import ast
+import textwrap
+from pathlib import Path
+
+from acceptance.evidence.discovery import DiscoveredTest
+from acceptance.evidence.mapping import MappingResult
+from acceptance.review_state import ChangeSet, TestEvidence
+
+_MOCK_NAMES = {
+    "Mock",
+    "MagicMock",
+    "AsyncMock",
+    "NonCallableMock",
+    "patch",
+    "mock_open",
+    "create_autospec",
+}
+_ASSERT_EQ_METHODS = {"assertEqual", "assertNotEqual", "assertAlmostEqual"}
+
+
+def extract_test_evidence(
+    repo: Path,
+    discovered_tests: list[DiscoveredTest],
+    change_set: ChangeSet,
+    mapping: MappingResult,
+) -> list[TestEvidence]:
+    """Extract a TestEvidence record for each discovered test (§15)."""
+    changed_modules = {
+        Path(f.path).stem
+        for f in change_set.files
+        if f.category == "source" and f.status != "deleted" and f.path.endswith(".py")
+    }
+    obligations_by_test = {m.test_id: m.obligation_ids for m in mapping.mappings}
+
+    production_by_file: dict[str, set[str]] = {}
+    evidence: list[TestEvidence] = []
+    for test in discovered_tests:
+        if test.file not in production_by_file:
+            production_by_file[test.file] = _production_import_names(
+                repo / test.file, changed_modules
+            )
+        func = _parse_test_function(test.source)
+        if func is None:
+            continue
+        evidence.append(
+            _extract_one(
+                test,
+                func,
+                production_by_file[test.file],
+                obligations_by_test.get(test.test_id, []),
+            )
+        )
+    return evidence
+
+
+def _production_import_names(file_path: Path, changed_modules: set[str]) -> set[str]:
+    """Names a test file imports from a changed source module — the production
+    symbols under test, whose appearance on both sides of an assertion is the
+    circular-evidence signal."""
+    try:
+        module = ast.parse(file_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, SyntaxError):
+        return set()
+    names: set[str] = set()
+    for node in ast.walk(module):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            if node.module.split(".")[0] in changed_modules:
+                for alias in node.names:
+                    names.add(alias.asname or alias.name)
+    return names
+
+
+def _parse_test_function(source: str) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+    try:
+        module = ast.parse(textwrap.dedent(source))  # dedent: class methods are indented
+    except SyntaxError:
+        return None
+    node = module.body[0] if module.body else None
+    return node if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) else None
+
+
+def _extract_one(
+    test: DiscoveredTest,
+    func: ast.FunctionDef | ast.AsyncFunctionDef,
+    production_symbols: set[str],
+    mapped_obligations: list[str],
+) -> TestEvidence:
+    assignments = _collect_assignments(func)
+    comparisons = _equality_comparisons(func)
+
+    return TestEvidence(
+        identifier=test.test_id,
+        location=test.file,
+        inputs=_production_call_sources(func, production_symbols),
+        fixtures=_fixture_params(func),
+        assertions=[ast.unparse(node) for node in _assert_nodes(func)],
+        expected_value_provenance=_expected_value_provenance(
+            comparisons, assignments, production_symbols
+        ),
+        mocks=_mock_usages(func),
+        mapped_obligations=mapped_obligations,
+    )
+
+
+def _collect_assignments(func: ast.AST) -> dict[str, ast.expr]:
+    """Local `name -> value` bindings (last assignment wins), including simple
+    tuple unpacking, so an operand named `expected` can be traced to what built it."""
+    assignments: dict[str, ast.expr] = {}
+    for node in ast.walk(func):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    assignments[target.id] = node.value
+                elif (
+                    isinstance(target, ast.Tuple)
+                    and isinstance(node.value, ast.Tuple)
+                    and len(target.elts) == len(node.value.elts)
+                ):
+                    for elt, value in zip(target.elts, node.value.elts):
+                        if isinstance(elt, ast.Name):
+                            assignments[elt.id] = value
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) and node.value:
+            assignments[node.target.id] = node.value
+    return assignments
+
+
+def _names_in(expr: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(expr):
+        if isinstance(node, ast.Name):
+            names.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            names.add(node.attr)
+    return names
+
+
+def _production_refs(
+    expr: ast.expr, assignments: dict[str, ast.expr], production: set[str], _depth: int = 0
+) -> set[str]:
+    """Production symbols an expression references, resolving local variables
+    through their assignments (bounded) so `expected` reaches `_apply_tax`."""
+    names = _names_in(expr)
+    refs = names & production
+    if _depth < 3:
+        for name in names:
+            if name in assignments:
+                refs |= _production_refs(assignments[name], assignments, production, _depth + 1)
+    return refs
+
+
+def _equality_comparisons(func: ast.AST) -> list[tuple[ast.expr, ast.expr]]:
+    """(left, right) operand pairs of equality checks — `a == b` in asserts and
+    `assertEqual(a, b)`-style calls."""
+    pairs: list[tuple[ast.expr, ast.expr]] = []
+    for node in ast.walk(func):
+        if isinstance(node, ast.Compare) and any(
+            isinstance(op, (ast.Eq, ast.NotEq)) for op in node.ops
+        ):
+            left = node.left
+            for op, right in zip(node.ops, node.comparators):
+                if isinstance(op, (ast.Eq, ast.NotEq)):
+                    pairs.append((left, right))
+                left = right
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in _ASSERT_EQ_METHODS
+            and len(node.args) >= 2
+        ):
+            pairs.append((node.args[0], node.args[1]))
+    return pairs
+
+
+def _expected_value_provenance(
+    comparisons: list[tuple[ast.expr, ast.expr]],
+    assignments: dict[str, ast.expr],
+    production: set[str],
+) -> str | None:
+    independent_seen = False
+    for left, right in comparisons:
+        left_prod = _production_refs(left, assignments, production)
+        right_prod = _production_refs(right, assignments, production)
+        if left_prod and right_prod:
+            symbols = ", ".join(sorted(left_prod | right_prod))
+            return (
+                f"Circular: both sides of the assertion derive from production code "
+                f"under test ({symbols}); the expected value cannot independently "
+                f"detect a defect, since a bug corrupts both sides equally."
+            )
+        # Exactly one side references production (the actual); the other is an
+        # independent literal/constant — normal, non-circular evidence.
+        if bool(left_prod) != bool(right_prod):
+            independent_seen = True
+    if independent_seen:
+        return (
+            "Independent: the expected value is a literal/constant, not derived "
+            "from the code under test."
+        )
+    return None
+
+
+def _production_call_sources(func: ast.AST, production: set[str]) -> list[str]:
+    """Unparsed calls to production symbols — what code the test exercises, with
+    what inputs."""
+    sources: set[str] = set()
+    for node in ast.walk(func):
+        if isinstance(node, ast.Call):
+            name = _call_name(node)
+            if name in production:
+                sources.add(ast.unparse(node))
+    return sorted(sources)
+
+
+def _call_name(call: ast.Call) -> str | None:
+    if isinstance(call.func, ast.Name):
+        return call.func.id
+    if isinstance(call.func, ast.Attribute):
+        return call.func.attr
+    return None
+
+
+def _fixture_params(func: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    return [arg.arg for arg in func.args.args if arg.arg != "self"]
+
+
+def _assert_nodes(func: ast.AST) -> list[ast.Assert]:
+    return [node for node in ast.walk(func) if isinstance(node, ast.Assert)]
+
+
+def _mock_usages(func: ast.AST) -> list[str]:
+    used: set[str] = set()
+    for node in ast.walk(func):
+        if isinstance(node, ast.Name) and node.id in _MOCK_NAMES:
+            used.add(node.id)
+        elif isinstance(node, ast.Attribute) and node.attr in _MOCK_NAMES:
+            used.add(node.attr)
+    return sorted(used)

--- a/tests/evidence/test_extraction.py
+++ b/tests/evidence/test_extraction.py
@@ -1,0 +1,154 @@
+"""M5.1 acceptance: per-test structural extraction — for archetype #5 the
+analyzer identifies that the expected value is produced by the same production
+function (circular provenance) — plus unit coverage of the other extracted
+fields and the non-circular (independent expected value) case.
+
+Extraction is pure AST (no model call), so these assert real structural
+judgments directly rather than injected responses. Tests write real repos so
+the extractor can see file-level imports (the production-symbol signal).
+"""
+
+from pathlib import Path
+
+from acceptance.change.diff import extract_change_set
+from acceptance.evidence.discovery import discover_tests
+from acceptance.evidence.extraction import extract_test_evidence
+from acceptance.evidence.mapping import MappingResult, TestMapping
+from acceptance.review_state import ChangeSet, DiffHunk, FileChange
+
+
+def _hunk(new_lines: int) -> DiffHunk:
+    return DiffHunk(
+        header=f"@@ -1,{new_lines} +1,{new_lines} @@",
+        old_start=1, old_lines=new_lines, new_start=1, new_lines=new_lines, content="",
+    )
+
+
+def _change_set(path: str, new_lines: int) -> ChangeSet:
+    return ChangeSet(
+        base_revision="base", head_revision="head",
+        files=[FileChange(path=path, status="modified", category="source", hunks=[_hunk(new_lines)])],
+    )
+
+
+def _mapping(*pairs: tuple[str, list[str]]) -> MappingResult:
+    return MappingResult(
+        mappings=[TestMapping(test_id=t, obligation_ids=o, rationale=".") for t, o in pairs],
+        unmapped_obligation_ids=[],
+    )
+
+
+def _extract(repo: Path, change_set: ChangeSet, *mapped: tuple[str, list[str]]):
+    discovered = discover_tests(repo, change_set)
+    return extract_test_evidence(repo, discovered.tests, change_set, _mapping(*mapped))
+
+
+# --- unit-level: hand-built repos (no git needed) ---
+
+
+def test_circular_expected_value_is_detected(tmp_path):
+    (tmp_path / "orders.py").write_text(
+        "def _apply_tax(subtotal, tax_rate):\n"
+        "    return subtotal * (1 + tax_rate)\n\n\n"
+        "def order_total(subtotal, tax_rate):\n"
+        "    return round(_apply_tax(subtotal, tax_rate), 2)\n"
+    )
+    (tmp_path / "test_orders.py").write_text(
+        "from orders import _apply_tax, order_total\n\n\n"
+        "def test_total():\n"
+        "    subtotal, tax_rate = 100.0, 0.08\n"
+        "    expected = round(_apply_tax(subtotal, tax_rate), 2)\n"
+        "    assert order_total(subtotal, tax_rate) == expected\n"
+    )
+    change_set = _change_set("orders.py", new_lines=6)
+
+    evidence = _extract(tmp_path, change_set, ("test_orders.py::test_total", ["add-tax"]))
+
+    ev = next(e for e in evidence if e.identifier == "test_orders.py::test_total")
+    assert ev.expected_value_provenance is not None
+    assert ev.expected_value_provenance.startswith("Circular")
+    assert "_apply_tax" in ev.expected_value_provenance
+    assert ev.mapped_obligations == ["add-tax"]
+
+
+def test_independent_literal_expected_value_is_not_circular(tmp_path):
+    (tmp_path / "orders.py").write_text(
+        "def order_total(subtotal, tax_rate):\n"
+        "    return round(subtotal * (1 + tax_rate), 2)\n"
+    )
+    (tmp_path / "test_orders.py").write_text(
+        "from orders import order_total\n\n\n"
+        "def test_total():\n"
+        "    assert order_total(100.0, 0.08) == 108.0\n"
+    )
+    change_set = _change_set("orders.py", new_lines=2)
+
+    evidence = _extract(tmp_path, change_set, ("test_orders.py::test_total", ["add-tax"]))
+
+    ev = next(e for e in evidence if e.identifier == "test_orders.py::test_total")
+    assert ev.expected_value_provenance is not None
+    assert ev.expected_value_provenance.startswith("Independent")
+
+
+def test_extraction_captures_assertions_inputs_fixtures_and_mocks(tmp_path):
+    (tmp_path / "svc.py").write_text(
+        "def charge(amount, gateway):\n    return gateway.pay(amount)\n"
+    )
+    (tmp_path / "test_svc.py").write_text(
+        "from unittest.mock import Mock\n"
+        "from svc import charge\n\n\n"
+        "def test_charge(monkeypatch):\n"
+        "    gateway = Mock()\n"
+        "    assert charge(50, gateway) == gateway.pay.return_value\n"
+    )
+    change_set = _change_set("svc.py", new_lines=2)
+
+    evidence = _extract(tmp_path, change_set, ("test_svc.py::test_charge", ["pay"]))
+
+    ev = next(e for e in evidence if e.identifier == "test_svc.py::test_charge")
+    assert ev.fixtures == ["monkeypatch"]
+    assert "Mock" in ev.mocks
+    assert any("charge(50, gateway)" in a for a in ev.assertions)
+    assert "charge(50, gateway)" in ev.inputs
+
+
+def test_class_method_is_extracted(tmp_path):
+    (tmp_path / "mod.py").write_text("def f():\n    return 1\n")
+    (tmp_path / "test_mod.py").write_text(
+        "from mod import f\n\n\n"
+        "class TestC:\n"
+        "    def test_it(self):\n"
+        "        assert f() == 1\n"
+    )
+    change_set = _change_set("mod.py", new_lines=2)
+
+    evidence = _extract(tmp_path, change_set, ("test_mod.py::TestC::test_it", []))
+
+    ev = next(e for e in evidence if e.identifier == "test_mod.py::TestC::test_it")
+    assert ev.fixtures == []  # self is dropped
+    assert any("f()" in a for a in ev.assertions)
+
+
+# --- acceptance: real archetype #5 via the full discover -> map -> extract path ---
+
+ARCHETYPES_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "archetypes"
+
+
+def test_archetype_5_circular_provenance_is_identified(tmp_path):
+    from acceptance.benchmark.fixtures import materialize_archetype
+
+    fixture = materialize_archetype(ARCHETYPES_DIR / "05-circular-expected-result", tmp_path / "repo")
+    repo = fixture.repo_path
+    change_set = extract_change_set(repo, fixture.base_sha, fixture.head_sha)
+
+    discovered = discover_tests(repo, change_set)
+    test_id = "test_orders.py::test_total_applies_tax"
+    assert test_id in {t.test_id for t in discovered.tests}
+
+    mapping = _mapping((test_id, ["add-tax", "round-2"]))
+    evidence = extract_test_evidence(repo, discovered.tests, change_set, mapping)
+
+    ev = next(e for e in evidence if e.identifier == test_id)
+    assert ev.expected_value_provenance is not None
+    assert ev.expected_value_provenance.startswith("Circular")
+    assert "_apply_tax" in ev.expected_value_provenance


### PR DESCRIPTION
## Summary
`evidence/extraction.py` — `extract_test_evidence()` produces a §15 `TestEvidence` record per mapped candidate test: `identifier`, `location`, `inputs` (production calls exercised), `fixtures` (test params), `assertions`, `mocks`, `mapped_obligations`, and the load-bearing one — `expected_value_provenance`. **Pure Python AST, no model call**: the semantic *discrimination* judgment (would the test fail under a plausible defect?) is M5.2, over what this extracts. Keeping M5.1 structural makes it deterministic — the archetype #5 acceptance is a **real assertion**, not an injected response.

**Circular-evidence detection (§9.4).** A test that computes its expected value from the same production code it verifies can never fail — a defect corrupts both sides of the equality equally. Detected structurally: the "production symbols under test" are the names a test imports from a **changed source module** (`from orders import _apply_tax, order_total`); if **both** operands of an equality assertion reference such a symbol — after resolving local variable assignments through a bounded trace (incl. tuple unpacking) — the expected value is production-derived → **circular**. One side a literal → independent.

**Design note worth flagging:** my first cut keyed production symbols off M2.2's `changed_definitions`, but that returns only *one* enclosing def per diff hunk — so archetype #5 (both functions in a single hunk) yielded just one symbol and the "both sides" check failed (caught by the failing acceptance test, not shipped). The test's own **imports from the changed module** are the correct, complete signal.

## Test plan
- [x] **Acceptance (M5.1's own wording):** archetype #5 → the test's `expected_value_provenance` is flagged `Circular`, naming `_apply_tax`.
- [x] Independent-literal expected value → *not* flagged circular.
- [x] Extraction of assertions / inputs / fixtures / mocks; class-method source (dedented) handled.
- [x] Full suite: 334 passed (was 329); ruff clean.
- [x] Dogfooded (`decompose`/`classify`) — all 7 obligations `[addressed]`; all 4 unrequested flags correctly self-classified `[in_service]` (no false positives).

## Scope / limitations (documented, not silent)
- Only `from <changed_module> import name` bindings are treated as production symbols; plain `import module; module.f()` isn't traced yet — a future refinement.
- `relevant_path` / `static_assessment` left `None` — M5.2 / M8 territory.
- Not wired into `classify_case` — the evidence-agreement metric is M5.3 (strength) / M5.5 (scoring hook), not raw extraction.

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)