### PR TITLE
Fix decomposition granularity: isolate distinct computations (#117)

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,12 +1,11 @@
 # Task
-Per criterion, judge whether the mapped tests would fail under a named plausible defect — considering whether inputs distinguish competing interpretations, whether boundaries and negatives exist, and whether assertions target the required result. The output includes the named plausible defect.
+Fix decomposition so an embedded definitional sub-clause that is a distinct computation is isolated as its own criterion, without over-splitting a single cohesive behavior into facets.
 
 ## Constraints
-- Inputs are M5.1's per-test extraction and the §9.3 central question.
-- This is a semantic judgment (a static prediction of which plausible defects a mapped test would catch), so it is a schema-constrained model call recorded for replay, with no live calls in capability tests.
-- A criterion is discriminating when its mapped tests catch at least one plausible defect, non-discriminating when every plausible defect survives.
-- Only criteria that have a mapped test are judged here; a criterion with no mapped test is unsupported and classified later.
+- Sharpen the decompose system prompt so a sub-clause that defines a distinct computation or derived value (a formula with its own logic, introduced by "where", "using", "based on") is isolated as its own obligation.
+- Keep a single cohesive behavior — a parse, a lookup/mapping, a formatting or display rule — as one obligation even when it spans several inputs or fields.
+- The behavior change is prompt-only; injected-response capability tests are unaffected.
 
 ## Completion expectations
-- Implementation
-- Unit tests: a non-discriminating input is judged non-discriminating with the specific reason; a genuinely strong test is judged discriminating. Prompt quality is verified by a live before/after run, since injected-response tests cannot assert it.
+- The sharpened prompt
+- Live before/after verification, since prompt quality cannot be asserted by injected-response tests: archetype #4 isolates the daily-rate computation; archetypes #1 and #2 do not over-split a cohesive behavior.

--- a/src/acceptance/requirement/obligations.py
+++ b/src/acceptance/requirement/obligations.py
@@ -41,7 +41,27 @@ an obligation for it. Instead return an `open_question` with a stable `id`, the
 `question` to put to the user, an `importance`, and a `source_quote` for the
 ambiguous text.
 
-Do not merge distinct requirements. Prefer the smallest faithful set."""
+Granularity — isolate distinct computations, keep cohesive behaviors whole:
+
+- Isolate a sub-clause that defines a DISTINCT COMPUTATION or derived value — a
+  formula or calculation with its own logic, embedded via "where ...",
+  "using ...", "based on ..." — that could be computed wrongly on its own,
+  independently of the step that uses it. E.g. "charge for the hours worked at
+  the overtime rate, where the overtime rate is 1.5x base pay" is TWO
+  obligations: charging for the hours, and the overtime-rate formula (the rate
+  can be wrong independently of the multiplication). Do not fold such a
+  computation into its host clause.
+
+- Keep as ONE obligation a single cohesive behavior — a parse, a
+  lookup/mapping, a formatting or display rule — even when it spans several
+  inputs, fields, or cases. "Parse the token into its type and value" is one
+  obligation, not a separate 'read the token' and 'classify it'; "render each
+  column right-aligned" is one display rule, not one per column.
+
+The test: is the sub-clause a SEPARATE calculation that could be individually
+wrong, or one behavior applied across cases? Separate the former; keep the
+latter whole. Prefer the smallest set that still isolates every distinct
+computation."""
 
 
 # Empty arrays are returned explicitly (StrictResponseModel: no defaults).


### PR DESCRIPTION
## Summary
Sharpens the M1.2 decompose system prompt to fix the under-decomposition found dogfooding M5.2 (#117). The prior "do not merge distinct requirements / smallest faithful set" guidance was **two-directionally wrong**:
- **under**-decomposed embedded computations — archetype #4 folded *"the daily rate is monthly_price / days_in_month"* into the charge obligation, hiding the exact criterion that carries the `/30` non-discrimination trap;
- **over**-split cohesive behaviors — archetype #1 split "show returns in parentheses" into separate quantity + total obligations.

New guidance is explicitly two-directional: **isolate** a sub-clause defining a *distinct computation / derived value* (a formula with its own logic, via "where"/"using"/"based on") that could be wrong on its own; **keep whole** a single cohesive behavior (a parse, lookup/mapping, formatting/display rule) even across several fields. Examples are **neutral** (overtime rate; token parsing) — deliberately *not* the archetypes — so the before/after eval isn't just memorization.

## Verification — live before/after (prompt quality can't be asserted by injected-response tests)
| Archetype | Before | After |
|---|---|---|
| **#4** | daily-rate merged into charge obligation | ✅ `daily-rate-formula` isolated as its own criterion |
| **#1** | returns split into `negative-quantity-parentheses` + `negative-total-parentheses` | ✅ one `returns-parentheses-for-negative-quantity`; money-format still one |
| **#2** | correct (3) | ✅ still 3 (an intermediate wording over-split symbol-parse from ISO-map; the shipped wording keeps them one) |

All three now match the ground-truth granularity on their core criteria (a minor extra "implement the function" obligation remains — over-inclusion, not the harmful under-inclusion).

## Test plan
- [x] Full suite: 340 passed; ruff clean. Injected-response decompose tests are unaffected (prompt-only change).
- [x] Live before/after on #4/#1/#2 (above).
- [x] Dogfooded (`decompose`/`classify`) — the tool decomposed *its own* task into the two-directional principle as distinct obligations; all code obligations `[addressed]`; live-verification obligation accurately `[not_addressed]` (not code); the one unrequested flag self-`[in_service]`.

## The other half of #117 (deferred, tracked)
#117's second bullet — a benchmark that regression-guards this on live output — is **blocked on #118**: the §11.1 accuracy metrics join reviewer↔ground-truth obligations by **exact description string**, so they read ~0 on real (correctly-but-differently-worded) decompose output and can't measure decomposition quality. Filed #118 (semantic/id matching) as the prerequisite. This PR delivers the actual fix; the automated regression-guard follows once #118 lands.

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)