### PR TITLE
Semantic obligation matching for §11.1 metrics (#118)

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,11 +1,12 @@
 # Task
-Fix decomposition so an embedded definitional sub-clause that is a distinct computation is isolated as its own criterion, without over-splitting a single cohesive behavior into facets.
+Make the §11.1 accuracy metrics match reviewer criteria to ground truth semantically, so a correct-but-differently-worded criterion counts as matched instead of scoring zero under exact-string matching.
 
 ## Constraints
-- Sharpen the decompose system prompt so a sub-clause that defines a distinct computation or derived value (a formula with its own logic, introduced by "where", "using", "based on") is isolated as its own obligation.
-- Keep a single cohesive behavior — a parse, a lookup/mapping, a formatting or display rule — as one obligation even when it spans several inputs or fields.
-- The behavior change is prompt-only; injected-response capability tests are unaffected.
+- The obligation-keyed joins (gap detection, decomposition accuracy, mapping accuracy) currently match reviewer output to ground truth by exact description string; a real model decomposition never matches verbatim, so it scores near zero.
+- Align semantically-equivalent criteria via a schema-constrained model judgment, recorded for replay, bijective so an over-decomposed extra criterion stays unmatched and costs precision.
+- Remap reviewer-side descriptions through the alignment before the existing set intersection.
+- Preserve backward compatibility: with no client, the alignment is empty (identity remap, exact-string match), so existing hand-aligned fixtures score unchanged.
 
 ## Completion expectations
-- The sharpened prompt
-- Live before/after verification, since prompt quality cannot be asserted by injected-response tests: archetype #4 isolates the daily-rate computation; archetypes #1 and #2 do not over-split a cohesive behavior.
+- Implementation
+- Unit tests: a reworded reviewer criterion scores zero under exact match and matched under semantic alignment; the alignment is bijective; empty sides make no model call. A live run shows decomposition_accuracy on real decompose output is meaningful, not near zero.

--- a/src/acceptance/benchmark/alignment.py
+++ b/src/acceptance/benchmark/alignment.py
@@ -1,0 +1,92 @@
+"""Semantic obligation alignment for §11.1 scoring (#118).
+
+The benchmark metrics (scoring.py) join reviewer output to ground truth by
+obligation *description*. A real `decompose` run produces semantically-correct
+criteria whose wording never matches the human-authored ground truth verbatim
+("Use monthly_price / days_in_month as the daily rate" vs "Daily rate is
+monthly_price divided by days_in_month"), so an exact-string join scores ~0 for
+a perfect decomposition.
+
+This aligns reviewer criteria to the ground-truth criteria they describe the
+same requirement as, via a schema-constrained model judgment (LLM-as-judge) —
+robust to paraphrase where a string compare is not, and deterministic in tests
+through the M0.4 replay harness. The alignment is bijective (each side matched
+at most once, enforced greedily), so an over-decomposed extra criterion is left
+unmatched and correctly costs precision.
+
+This is benchmark *measurement* infrastructure — it runs against known ground
+truth, not in the product's own review path.
+"""
+
+from __future__ import annotations
+
+from acceptance.llm import ModelClient, StrictResponseModel
+
+_SYSTEM_PROMPT = """\
+You align two lists of acceptance criteria: GROUND TRUTH (human-authored) and
+REVIEWER (produced by a tool). Match each reviewer criterion to the ONE
+ground-truth criterion that states the SAME requirement — the same behavior or
+rule, even if worded differently. Not every criterion has a match; leave
+unmatched ones out. Each ground-truth criterion and each reviewer criterion may
+appear in at most one match.
+
+Match on the underlying requirement, not surface wording. Do NOT match two
+criteria that concern different rules just because they mention the same nouns.
+
+Return the matches as pairs of the given labels (e.g. ground_truth "g0",
+reviewer "r2")."""
+
+
+class _LabelMatch(StrictResponseModel):
+    ground_truth: str
+    reviewer: str
+
+
+class _Alignment(StrictResponseModel):
+    matches: list[_LabelMatch]
+
+
+def _render_prompt(gt_labels: dict[str, str], rv_labels: dict[str, str]) -> str:
+    lines = ["## Ground-truth criteria", ""]
+    for label, desc in gt_labels.items():
+        lines.append(f"[{label}] {desc}")
+    lines.append("")
+    lines.append("## Reviewer criteria")
+    for label, desc in rv_labels.items():
+        lines.append(f"[{label}] {desc}")
+    return "\n".join(lines)
+
+
+def align_obligations(
+    ground_truth_descriptions: list[str],
+    reviewer_descriptions: list[str],
+    client: ModelClient,
+) -> dict[str, str]:
+    """Return a `reviewer_description -> ground_truth_description` map for
+    semantically-equivalent criteria (a bijection over the matched subset)."""
+    if not ground_truth_descriptions or not reviewer_descriptions:
+        return {}
+
+    gt_labels = {f"g{i}": desc for i, desc in enumerate(ground_truth_descriptions)}
+    rv_labels = {f"r{i}": desc for i, desc in enumerate(reviewer_descriptions)}
+
+    messages = [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {"role": "user", "content": _render_prompt(gt_labels, rv_labels)},
+    ]
+    result = client.complete(messages, _Alignment)
+
+    alignment: dict[str, str] = {}
+    used_gt: set[str] = set()
+    used_rv: set[str] = set()
+    for match in result.matches:
+        if (
+            match.ground_truth in gt_labels
+            and match.reviewer in rv_labels
+            and match.ground_truth not in used_gt
+            and match.reviewer not in used_rv
+        ):
+            alignment[rv_labels[match.reviewer]] = gt_labels[match.ground_truth]
+            used_gt.add(match.ground_truth)
+            used_rv.add(match.reviewer)
+    return alignment

--- a/src/acceptance/benchmark/scoring.py
+++ b/src/acceptance/benchmark/scoring.py
@@ -28,6 +28,15 @@ Aggregation pools raw match counts across cases before dividing
 figures; a macro-averaged variant may be added later. A ratio is None when
 undefined (no ground truth, or nothing reported) rather than a misleading 0.0.
 
+Semantic matching (#118): the obligation-keyed joins (gap, decomposition,
+mapping) match reviewer criteria to ground truth by description. Pass a
+`client` to score_case/score_case_set and an LLM aligns semantically-equivalent
+criteria first (alignment.py), so a correct-but-reworded criterion counts as
+matched; the reviewer-side descriptions are remapped through that alignment
+before the set intersection. With no client the alignment is empty — identity
+remap, i.e. exact-string match, the original behavior — so hand-aligned fixtures
+score unchanged.
+
 Variance disclosure: every BenchmarkReport discloses its determinism_mode
 (from the cases' ReviewProvenance); disclose_variance() computes a mean and
 spread per metric across N runs of the same case set.
@@ -40,7 +49,9 @@ from typing import Literal
 
 from pydantic import Field
 
+from acceptance.benchmark.alignment import align_obligations
 from acceptance.benchmark.case import BenchmarkCase, BenchmarkScore
+from acceptance.llm import ModelClient
 from acceptance.model_base import PersistableModel
 from acceptance.review_state import UNREQUESTED_CHANGE
 
@@ -81,7 +92,13 @@ def _counts(ground_truth_refs: set, reported_refs: set) -> _MatchCounts:
     )
 
 
-def _gap_counts(case: BenchmarkCase) -> _MatchCounts:
+def _remap(description: str, alignment: dict[str, str]) -> str:
+    """Reviewer description -> its aligned ground-truth description (or itself
+    if unmatched / no alignment). Empty alignment = identity = exact match."""
+    return alignment.get(description, description)
+
+
+def _gap_counts(case: BenchmarkCase, alignment: dict[str, str]) -> _MatchCounts:
     review = case.reviewer_output
     obligation_desc = {o.id: o.description for o in case.ground_truth.obligations}
     # A gap is keyed by the obligation it concerns (so "found" means the checker
@@ -92,7 +109,9 @@ def _gap_counts(case: BenchmarkCase) -> _MatchCounts:
         obligation_desc.get(gap.obligation_id, gap.id) for gap in case.ground_truth.gaps
     }
     reported_refs = {
-        f.related_obligation for f in review.findings if f.related_obligation is not None
+        _remap(f.related_obligation, alignment)
+        for f in review.findings
+        if f.related_obligation is not None
     }
     return _counts(ground_truth_refs, reported_refs)
 
@@ -114,14 +133,14 @@ def _unrequested_counts(case: BenchmarkCase) -> _MatchCounts:
     return _counts(ground_truth_refs, reported_refs)
 
 
-def _decomposition_counts(case: BenchmarkCase) -> _MatchCounts:
+def _decomposition_counts(case: BenchmarkCase, alignment: dict[str, str]) -> _MatchCounts:
     review = case.reviewer_output
     ground_truth_refs = {o.description for o in case.ground_truth.obligations}
-    reported_refs = {o.description for o in review.obligation_map}
+    reported_refs = {_remap(o.description, alignment) for o in review.obligation_map}
     return _counts(ground_truth_refs, reported_refs)
 
 
-def _mapping_counts(case: BenchmarkCase) -> _MatchCounts:
+def _mapping_counts(case: BenchmarkCase, alignment: dict[str, str]) -> _MatchCounts:
     review = case.reviewer_output
     ground_truth_refs = {
         (obligation.description, test_id)
@@ -129,7 +148,7 @@ def _mapping_counts(case: BenchmarkCase) -> _MatchCounts:
         for test_id in obligation.candidate_tests
     }
     reported_refs = {
-        (obligation.description, test_id)
+        (_remap(obligation.description, alignment), test_id)
         for obligation in review.obligation_map
         for test_id in obligation.test_evidence
     }
@@ -147,15 +166,28 @@ def _evidence_counts(case: BenchmarkCase) -> _MatchCounts:
     return _MatchCounts(matched=0, ground_truth_total=len(ground_truth_refs), reported_total=0)
 
 
+def _alignment(case: BenchmarkCase, client: ModelClient | None) -> dict[str, str]:
+    """Reviewer->ground-truth description remap for this case. Empty (identity /
+    exact match) when no client is given; an LLM semantic alignment otherwise."""
+    if client is None:
+        return {}
+    return align_obligations(
+        [o.description for o in case.ground_truth.obligations],
+        [o.description for o in case.reviewer_output.obligation_map],
+        client,
+    )
+
+
 def _all_counts(
-    case: BenchmarkCase,
+    case: BenchmarkCase, client: ModelClient | None = None
 ) -> tuple[_MatchCounts, _MatchCounts, _MatchCounts, _MatchCounts, _MatchCounts]:
     if case.reviewer_output is None:
         raise ValueError(f"case {case.case_id!r} has no reviewer_output; run it first")
+    alignment = _alignment(case, client)
     return (
-        _gap_counts(case),
-        _decomposition_counts(case),
-        _mapping_counts(case),
+        _gap_counts(case, alignment),
+        _decomposition_counts(case, alignment),
+        _mapping_counts(case, alignment),
         _evidence_counts(case),
         _unrequested_counts(case),
     )
@@ -179,8 +211,10 @@ def _score_from_counts(
     )
 
 
-def score_case(case: BenchmarkCase) -> BenchmarkScore:
-    return _score_from_counts(*_all_counts(case))
+def score_case(case: BenchmarkCase, client: ModelClient | None = None) -> BenchmarkScore:
+    """Score one case. Pass a `client` for semantic obligation matching (#118);
+    with none, the obligation-keyed metrics fall back to exact-string match."""
+    return _score_from_counts(*_all_counts(case, client))
 
 
 class BenchmarkReport(PersistableModel):
@@ -217,7 +251,9 @@ def _reconcile_determinism_modes(modes: set[str]) -> str | None:
     return next(iter(modes))
 
 
-def score_case_set(cases: list[BenchmarkCase]) -> BenchmarkReport:
+def score_case_set(
+    cases: list[BenchmarkCase], client: ModelClient | None = None
+) -> BenchmarkReport:
     gap_total = _MatchCounts.zero()
     decomposition_total = _MatchCounts.zero()
     mapping_total = _MatchCounts.zero()
@@ -227,7 +263,7 @@ def score_case_set(cases: list[BenchmarkCase]) -> BenchmarkReport:
     modes: set[str] = set()
 
     for case in cases:
-        gap, decomposition, mapping, evidence, unrequested = _all_counts(case)
+        gap, decomposition, mapping, evidence, unrequested = _all_counts(case, client)
         gap_total += gap
         decomposition_total += decomposition
         mapping_total += mapping

--- a/tests/benchmark/test_alignment.py
+++ b/tests/benchmark/test_alignment.py
@@ -1,0 +1,145 @@
+"""#118: semantic obligation alignment, and semantic scoring built on it.
+
+Alignment is a schema-constrained model call; per the replay-first invariant
+these tests inject the recorded response — no live calls. The point being
+proven: a correct-but-REWORDED reviewer criterion counts as matched, where an
+exact-string join would score it 0.
+"""
+
+from acceptance.benchmark.alignment import align_obligations
+from acceptance.benchmark.case import (
+    BenchmarkCase,
+    BenchmarkCaseInputs,
+    BenchmarkCaseSource,
+    GroundTruthGap,
+    GroundTruthLabels,
+    GroundTruthObligation,
+)
+from acceptance.benchmark.scoring import score_case
+from acceptance.evidence_tier import Component, EvidenceTier
+from acceptance.review_state import (
+    Finding,
+    Link,
+    Obligation,
+    ObligationType,
+    Review,
+    ReviewProvenance,
+)
+from tests.support import client_returning
+
+
+# --- align_obligations ---
+
+
+def test_reworded_criteria_are_aligned():
+    gt = ["Daily rate is monthly_price divided by days_in_month"]
+    rv = ["Use monthly_price / days_in_month as the daily rate"]
+    response = {"matches": [{"ground_truth": "g0", "reviewer": "r0"}]}
+
+    alignment = align_obligations(gt, rv, client_returning(response))
+
+    assert alignment == {rv[0]: gt[0]}
+
+
+def test_alignment_is_bijective_extra_reviewer_criterion_is_dropped():
+    # Two reviewer criteria claim the same ground-truth criterion (over-
+    # decomposition); only the first match is kept, so the extra stays unmatched.
+    gt = ["A"]
+    rv = ["A prime", "A double-prime"]
+    response = {"matches": [
+        {"ground_truth": "g0", "reviewer": "r0"},
+        {"ground_truth": "g0", "reviewer": "r1"},
+    ]}
+
+    alignment = align_obligations(gt, rv, client_returning(response))
+
+    assert alignment == {"A prime": "A"}
+
+
+def test_unknown_labels_are_ignored():
+    alignment = align_obligations(
+        ["A"], ["B"], client_returning({"matches": [{"ground_truth": "g9", "reviewer": "r0"}]})
+    )
+    assert alignment == {}
+
+
+def test_empty_sides_make_no_call():
+    # No obligations on a side -> no possible match, no model call needed.
+    import tempfile
+    from acceptance.llm import Mode, ModelClient, TranscriptStore
+
+    def boom(**kwargs):
+        raise AssertionError("no model call should be made with an empty side")
+
+    client = ModelClient(model="x", mode=Mode.RECORD,
+                         store=TranscriptStore(tempfile.mkdtemp()), completion_fn=boom)
+    assert align_obligations([], ["A"], client) == {}
+    assert align_obligations(["A"], [], client) == {}
+
+
+# --- semantic scoring built on the alignment ---
+
+
+def _reviewer_obligation(description: str) -> Obligation:
+    return Obligation(id=description.lower().replace(" ", "-"), description=description,
+                      type=ObligationType.FUNCTIONAL, importance="critical", explicit=True,
+                      observable_behavior="...")
+
+
+def _case_with_reworded_reviewer_output() -> BenchmarkCase:
+    ground_truth = GroundTruthLabels(
+        obligations=[
+            GroundTruthObligation(
+                id="daily-rate", description="Daily rate is monthly_price divided by days_in_month",
+                explicit=True, evidence_class="strongly_supported", evidence_rationale="asserted",
+                candidate_tests=["test_billing.py::test_rate"],
+            ),
+        ],
+        gaps=[GroundTruthGap(id="g", description="rate wrong", obligation_id="daily-rate")],
+    )
+    reviewer = Review(
+        mode="local", reviewed_revision="def456",
+        provenance=ReviewProvenance(determinism_mode="replay", model="m", temperature=0.0),
+        obligation_map=[
+            # Same criterion, different wording, AND its mapped test.
+            _reviewer_obligation("Use monthly_price / days_in_month as the daily rate").model_copy(
+                update={"test_evidence": ["test_billing.py::test_rate"]}
+            ),
+        ],
+        findings=[Finding(
+            type="coverage_gap", severity="high", description="rate not established",
+            evidence_tier=EvidenceTier.STATIC, produced_by=Component.STATIC_ANALYZER,
+            links=[Link(kind="requirement", ref="task.md:1")],
+            related_obligation="Use monthly_price / days_in_month as the daily rate",
+        )],
+    )
+    return BenchmarkCase(
+        case_id="reworded",
+        source=BenchmarkCaseSource(kind="archetype", identifier="reworded"),
+        inputs=BenchmarkCaseInputs(repo="r", task_text="...", base_revision="a", head_revision="def456"),
+        ground_truth=ground_truth,
+        reviewer_output=reviewer,
+    )
+
+
+def test_exact_match_scores_reworded_output_as_zero():
+    # Baseline: with no client, the reworded criterion doesn't string-match.
+    case = _case_with_reworded_reviewer_output()
+
+    score = score_case(case)  # no client -> exact match
+
+    assert score.decomposition_accuracy == 0.0
+    assert score.mapping_accuracy == 0.0
+    assert score.gap_recall == 0.0
+
+
+def test_semantic_match_scores_reworded_output_correctly():
+    case = _case_with_reworded_reviewer_output()
+    # The aligner matches the single reworded reviewer criterion to the gt one.
+    client = client_returning({"matches": [{"ground_truth": "g0", "reviewer": "r0"}]})
+
+    score = score_case(case, client)
+
+    assert score.decomposition_accuracy == 1.0
+    assert score.mapping_accuracy == 1.0
+    assert score.gap_recall == 1.0


### PR DESCRIPTION
## Summary
The obligation-keyed benchmark joins — **gap, decomposition, and mapping** — matched reviewer criteria to ground truth by **exact description string**, so a real `decompose` run (semantically correct but never worded verbatim) scored ~0. The metrics could only ever be exercised by hand-crafted reviewer output whose descriptions were *copied* from the ground truth.

- **`benchmark/alignment.py`** — `align_obligations()` aligns semantically-equivalent criteria via a schema-constrained model judgment (LLM-as-judge), recorded for replay. **Bijective** (greedy one-to-one), so an over-decomposed extra criterion stays unmatched and correctly costs precision.
- **`scoring.py`** — `score_case` / `score_case_set` gain an optional `client`. When given, the alignment is computed once per case and reviewer-side descriptions are **remapped through it before the existing set intersection**. When absent, the alignment is empty → identity remap → **exact-string match = the original behavior**, so every existing test and the `classify_case` hook path is untouched (**all 158 benchmark tests pass unchanged**). Semantic matching is strictly opt-in.

**Mechanism choice:** LLM-as-judge (over fuzzy string / embeddings) — robust to genuine paraphrase, fits the project's semantic-judgment ethos, and deterministic in tests through the replay harness. Fuzzy is brittle on paraphrase; embeddings add a provider + threshold.

## Live acceptance demo — real `decompose`, exact vs semantic
| Archetype | decomposition_accuracy (exact) | decomposition_accuracy (semantic) |
|---|---|---|
| #4 | **0.0** | **1.0** |
| #1 | **0.0** | **1.0** |
| #2 | **0.0** | **1.0** |

The reviewer criteria are correct but reworded (e.g. *"Compute the daily rate as `monthly_price / days_in_month`"* vs ground truth *"Daily rate is monthly_price divided by days_in_month"*) — exact-match scores 0, the aligner matches all. Also validates the **#117** fix end-to-end: #4's now-isolated daily-rate criterion aligns to the ground-truth one.

## Test plan
- [x] `align_obligations`: reworded criteria aligned; bijective (extra reviewer criterion dropped); unknown labels ignored; empty side → **no model call**.
- [x] Semantic scoring: a reworded reviewer criterion scores **0.0 exact / 1.0 semantic** for decomposition, mapping, and gap_recall (the explicit before/after).
- [x] All 158 pre-existing benchmark tests pass unchanged (no-client → exact match).
- [x] Full suite: 346 passed (was 340); ruff clean.
- [x] Live demo above.
- [x] Dogfooded — all code obligations `[addressed]`; live-run obligation `[requires_non_code_evidence]`.

## Scope
This delivers the semantic-matching **enabler** that unblocks the metrics. The CI-gated benchmark run over live `decompose` (via committed replay transcripts, asserting a `decomposition_accuracy` threshold) belongs with **M-B\*.report** (the accuracy-report milestone), where the full live-benchmark harness lives.

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)