### PR TITLE
M5.3: test-evidence strength classification (§9.3)

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,12 +1,12 @@
 # Task
-Make the §11.1 accuracy metrics match reviewer criteria to ground truth semantically, so a correct-but-differently-worded criterion counts as matched instead of scoring zero under exact-string matching.
+Classify each criterion's test-evidence strength into the §9.3 classes — strongly / partially / nominally / unsupported / indeterminate — at the static tier, with a linked, self-justifying explanation.
 
 ## Constraints
-- The obligation-keyed joins (gap detection, decomposition accuracy, mapping accuracy) currently match reviewer output to ground truth by exact description string; a real model decomposition never matches verbatim, so it scores near zero.
-- Align semantically-equivalent criteria via a schema-constrained model judgment, recorded for replay, bijective so an over-decomposed extra criterion stays unmatched and costs precision.
-- Remap reviewer-side descriptions through the alignment before the existing set intersection.
-- Preserve backward compatibility: with no client, the alignment is empty (identity remap, exact-string match), so existing hand-aligned fixtures score unchanged.
+- Consume M5.2's per-criterion discrimination verdicts; this is a deterministic reduce, not a fresh model judgment.
+- Map on the single bright line: all named plausible defects caught is strongly supported; at least one but not all is partially supported; a mapped test that catches none is nominally supported; no mapped test at all is unsupported; a mapped test with no defect judged is indeterminate.
+- Do not invent requires_other_evidence from discrimination alone — there is no such signal in the verdicts.
+- Each classification links to the exact mapped tests, and a nominal test that bypasses the behavior via a mock cites the mock (from M5.1's extracted mocks).
 
 ## Completion expectations
 - Implementation
-- Unit tests: a reworded reviewer criterion scores zero under exact match and matched under semantic alignment; the alignment is bijective; empty sides make no model call. A live run shows decomposition_accuracy on real decompose output is meaningful, not near zero.
+- Unit tests: archetype #3's superficial test yields nominal for the rules it never checks; archetype #6's mocked-out core behavior is nominal with the mock cited; each classification links to the exact mapped tests.

--- a/src/acceptance/benchmark/case.py
+++ b/src/acceptance/benchmark/case.py
@@ -42,31 +42,12 @@ from typing import Literal
 from pydantic import Field, model_validator
 
 from acceptance.model_base import PersistableModel
-from acceptance.review_state import Review, UnrequestedChangeDisposition
+from acceptance.review_state import EvidenceClassification, Review, UnrequestedChangeDisposition
 
-# §9.3 test-evidence strength classifications. Distinct from EvidenceTier
-# (evidence_tier.py), which grades *how* evidence was produced, not how strong
-# it is. Defined over the plausible-violation space — the §8.2 mapped mutants —
-# with one bright line: does the mapped test catch at least one plausible
-# violation? These are static PREDICTIONS of which mutants a mapped test would
-# kill, validated against executed ground truth (§8.2); that agreement is what
-# §11.1 scores. Keep in sync with spec §9.3 (the full definitions live there):
-#   strongly_supported      - kills all mapped mutants
-#   partially_supported     - kills at least one, but not all, mapped mutants
-#   nominally_supported     - a present, relevant-looking test survives all
-#                             mapped mutants (zero discriminating power); with
-#                             no relevant test it is unsupported, not nominal
-#   unsupported             - no mapped, obligation-relevant test at all
-#   requires_other_evidence - needs non-test evidence (docs, visual, deploy)
-#   indeterminate           - cannot run / cannot decide statically
-EvidenceClassification = Literal[
-    "strongly_supported",
-    "partially_supported",
-    "nominally_supported",
-    "unsupported",
-    "requires_other_evidence",
-    "indeterminate",
-]
+# EvidenceClassification (§9.3 strength classes) is defined in review_state.py so
+# the checker (evidence/strength.py, M5.3) and the benchmark both use it without
+# the checker depending on this benchmark module. Used by the ground-truth models
+# below (GroundTruthObligation.evidence_class).
 
 
 class BenchmarkCaseSource(PersistableModel):

--- a/src/acceptance/evidence/strength.py
+++ b/src/acceptance/evidence/strength.py
@@ -1,0 +1,146 @@
+"""Test-evidence strength classification (M5.3, §9.3).
+
+Maps M5.2's per-criterion discrimination verdicts onto the §9.3 evidence
+classes. This is a deterministic reduce, not a fresh judgment: M5.2 already did
+the hard semantic work (which plausible defects each mapped test would catch);
+M5.3 turns that into a class over the single bright line "catches at least one
+plausible violation":
+
+    all named defects caught     -> strongly_supported
+    some (>=1) but not all       -> partially_supported
+    a mapped test, none caught   -> nominally_supported
+    no mapped test at all        -> unsupported
+    mapped test, no defect judged -> indeterminate
+
+`requires_other_evidence` is NOT produced here — the discrimination verdicts
+carry no signal that a criterion needs non-code evidence (docs, visual, deploy);
+that routing is left to coverage's `requires_non_code_evidence` status
+downstream (M5.5/M7), not invented from test discrimination.
+
+Each classification links to the exact mapped tests (their pytest nodeids) and
+explains itself — for a nominal test that bypasses the behavior via a mock, the
+mock is cited (from M5.1's extracted `TestEvidence.mocks`), per §9.4.
+
+Classification is at the `static` evidence tier: these are static predictions;
+M8 execution can later confirm them and raise the tier.
+"""
+
+from __future__ import annotations
+
+from acceptance.evidence.discrimination import ObligationDiscrimination
+from acceptance.model_base import PersistableModel
+from acceptance.review_state import EvidenceClassification, Obligation, TestEvidence
+
+
+class EvidenceStrength(PersistableModel):
+    """One criterion's §9.3 strength class, with a linked, self-justifying
+    explanation (M5.3)."""
+
+    obligation_id: str
+    evidence_class: EvidenceClassification
+    explanation: str
+    test_links: list[str] = []  # pytest nodeids of the mapped tests
+
+
+def _evidence_by_obligation(
+    obligations: list[Obligation], test_evidence: list[TestEvidence]
+) -> dict[str, list[TestEvidence]]:
+    by_obligation: dict[str, list[TestEvidence]] = {o.id: [] for o in obligations}
+    for evidence in test_evidence:
+        for obligation_id in evidence.mapped_obligations:
+            if obligation_id in by_obligation:
+                by_obligation[obligation_id].append(evidence)
+    return by_obligation
+
+
+def _defect_list(descriptions: list[str]) -> str:
+    return "; ".join(descriptions) if descriptions else "(none)"
+
+
+def _mock_note(tests: list[TestEvidence]) -> str:
+    mocks = sorted({mock for ev in tests for mock in ev.mocks})
+    if not mocks:
+        return ""
+    return f" The mapped test mocks {', '.join(mocks)}, bypassing the behavior under review."
+
+
+def _explain(
+    evidence_class: EvidenceClassification,
+    discrimination: ObligationDiscrimination,
+    tests: list[TestEvidence],
+) -> str:
+    caught = [d.description for d in discrimination.defects if d.would_be_caught]
+    survived = [d.description for d in discrimination.defects if not d.would_be_caught]
+    if evidence_class == "strongly_supported":
+        return f"The mapped test would fail under every plausible defect considered: {_defect_list(caught)}."
+    if evidence_class == "partially_supported":
+        return (
+            f"The mapped test catches some plausible defects ({_defect_list(caught)}) "
+            f"but not others ({_defect_list(survived)})."
+        )
+    # nominally_supported
+    return (
+        f"A present, relevant test that catches no plausible defect; these survive it: "
+        f"{_defect_list(survived)}.{_mock_note(tests)}"
+    )
+
+
+def classify_strength(
+    obligations: list[Obligation],
+    test_evidence: list[TestEvidence],
+    discriminations: list[ObligationDiscrimination],
+) -> list[EvidenceStrength]:
+    """Classify each obligation's §9.3 evidence strength from M5.1 extraction and
+    M5.2 discrimination."""
+    evidence_by_obligation = _evidence_by_obligation(obligations, test_evidence)
+    discrimination_by_obligation = {d.obligation_id: d for d in discriminations}
+
+    results: list[EvidenceStrength] = []
+    for obligation in obligations:
+        tests = evidence_by_obligation.get(obligation.id, [])
+        links = sorted({ev.identifier for ev in tests})
+
+        if not tests:
+            results.append(
+                EvidenceStrength(
+                    obligation_id=obligation.id,
+                    evidence_class="unsupported",
+                    explanation="No mapped test evidences this criterion.",
+                    test_links=[],
+                )
+            )
+            continue
+
+        discrimination = discrimination_by_obligation.get(obligation.id)
+        if discrimination is None or not discrimination.defects:
+            results.append(
+                EvidenceStrength(
+                    obligation_id=obligation.id,
+                    evidence_class="indeterminate",
+                    explanation=(
+                        "A mapped test exists but no plausible defect was judged against it, "
+                        "so its discriminating power cannot be decided statically."
+                    ),
+                    test_links=links,
+                )
+            )
+            continue
+
+        caught = sum(1 for d in discrimination.defects if d.would_be_caught)
+        total = len(discrimination.defects)
+        if caught == total:
+            evidence_class: EvidenceClassification = "strongly_supported"
+        elif caught:
+            evidence_class = "partially_supported"
+        else:
+            evidence_class = "nominally_supported"
+
+        results.append(
+            EvidenceStrength(
+                obligation_id=obligation.id,
+                evidence_class=evidence_class,
+                explanation=_explain(evidence_class, discrimination, tests),
+                test_links=links,
+            )
+        )
+    return results

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -28,6 +28,7 @@ __all__ = [
     "EvidenceTier",
     "TextSpan",
     "ObligationType",
+    "EvidenceClassification",
     "UnrequestedChangeDisposition",
     "UNREQUESTED_CHANGE",
     "Project",
@@ -190,6 +191,31 @@ class OpenQuestion(_Model):
     question: str
     importance: Literal["critical", "normal"] = "normal"
     source_spans: list[TextSpan] = Field(default_factory=list)
+
+
+# §9.3 test-evidence strength classifications. Distinct from EvidenceTier
+# (evidence_tier.py), which grades *how* evidence was produced, not how strong
+# it is. Defined over the plausible-violation space — the §8.2 mapped mutants —
+# with one bright line: does the mapped test catch at least one plausible
+# violation? These are static PREDICTIONS of which mutants a mapped test would
+# kill, validated against executed ground truth (§8.2); that agreement is what
+# §11.1 scores. Keep in sync with spec §9.3 (the full definitions live there):
+#   strongly_supported      - kills all mapped mutants
+#   partially_supported     - kills at least one, but not all, mapped mutants
+#   nominally_supported     - a present, relevant-looking test survives all
+#                             mapped mutants (zero discriminating power); with
+#                             no relevant test it is unsupported, not nominal
+#   unsupported             - no mapped, obligation-relevant test at all
+#   requires_other_evidence - needs non-test evidence (docs, visual, deploy)
+#   indeterminate           - cannot run / cannot decide statically
+EvidenceClassification = Literal[
+    "strongly_supported",
+    "partially_supported",
+    "nominally_supported",
+    "unsupported",
+    "requires_other_evidence",
+    "indeterminate",
+]
 
 
 class TestEvidence(_Model):

--- a/tests/evidence/test_strength.py
+++ b/tests/evidence/test_strength.py
@@ -1,0 +1,138 @@
+"""M5.3 acceptance: classify each criterion's §9.3 evidence strength.
+
+Archetype #3 -> superficial test yields Nominal for the rules it never checks;
+archetype #6 -> the mocked-out core behavior is Nominal with the mock cited.
+Each classification links to the exact mapped tests.
+
+M5.3 is a deterministic reduce over M5.2's discrimination verdicts (no model
+call), so these inject the verdicts and assert the resulting class directly.
+"""
+
+from acceptance.evidence.discrimination import ObligationDiscrimination, PlausibleDefect
+from acceptance.evidence.strength import classify_strength
+from acceptance.review_state import Obligation, ObligationType, TestEvidence
+
+
+def _obligation(obligation_id: str) -> Obligation:
+    return Obligation(
+        id=obligation_id, description=f"{obligation_id} rule", type=ObligationType.FUNCTIONAL,
+        importance="critical", explicit=True, observable_behavior="...",
+    )
+
+
+def _evidence(identifier: str, obligation_ids: list[str], mocks: list[str] | None = None) -> TestEvidence:
+    return TestEvidence(
+        identifier=identifier, location=identifier.split("::", 1)[0],
+        mapped_obligations=obligation_ids, mocks=mocks or [],
+    )
+
+
+def _disc(obligation_id: str, *caught: bool) -> ObligationDiscrimination:
+    defects = [
+        PlausibleDefect(description=f"defect {i}", would_be_caught=c, reason=".")
+        for i, c in enumerate(caught)
+    ]
+    return ObligationDiscrimination(
+        obligation_id=obligation_id, defects=defects,
+        discriminating=any(caught),
+    )
+
+
+def _by_id(results):
+    return {r.obligation_id: r for r in results}
+
+
+# --- class-mapping branches ---
+
+
+def test_all_defects_caught_is_strongly_supported():
+    obs = [_obligation("ob")]
+    ev = [_evidence("t.py::test", ["ob"])]
+    result = classify_strength(obs, ev, [_disc("ob", True, True)])[0]
+    assert result.evidence_class == "strongly_supported"
+    assert result.test_links == ["t.py::test"]
+
+
+def test_some_defects_caught_is_partially_supported():
+    obs = [_obligation("ob")]
+    ev = [_evidence("t.py::test", ["ob"])]
+    result = classify_strength(obs, ev, [_disc("ob", True, False)])[0]
+    assert result.evidence_class == "partially_supported"
+    assert "not others" in result.explanation
+
+
+def test_no_defects_caught_is_nominally_supported():
+    obs = [_obligation("ob")]
+    ev = [_evidence("t.py::test", ["ob"])]
+    result = classify_strength(obs, ev, [_disc("ob", False, False)])[0]
+    assert result.evidence_class == "nominally_supported"
+
+
+def test_no_mapped_test_is_unsupported():
+    obs = [_obligation("ob")]
+    result = classify_strength(obs, [], [])[0]
+    assert result.evidence_class == "unsupported"
+    assert result.test_links == []
+
+
+def test_mapped_test_but_no_defect_judged_is_indeterminate():
+    obs = [_obligation("ob")]
+    ev = [_evidence("t.py::test", ["ob"])]
+    result = classify_strength(obs, ev, [_disc("ob")])[0]  # zero defects
+    assert result.evidence_class == "indeterminate"
+
+
+# --- archetype #3: superficial test ---
+
+
+def test_archetype_3_superficial_test_classes():
+    obs = [_obligation("one-per-month"), _obligation("equal-payments"), _obligation("fully-amortizing")]
+    test_id = "test_loan.py::test_returns_a_payment_for_each_month"
+    ev = [_evidence(test_id, ["one-per-month", "equal-payments", "fully-amortizing"])]
+    discriminations = [
+        # len(schedule)==12 catches a wrong-count defect.
+        _disc("one-per-month", True),
+        # the test never asserts payments are EQUAL -> that defect survives.
+        _disc("equal-payments", False),
+        # the test never asserts the loan is fully paid off -> survives.
+        _disc("fully-amortizing", False),
+    ]
+
+    result = _by_id(classify_strength(obs, ev, discriminations))
+
+    assert result["one-per-month"].evidence_class == "strongly_supported"
+    assert result["equal-payments"].evidence_class == "nominally_supported"
+    assert result["fully-amortizing"].evidence_class == "nominally_supported"
+    assert result["equal-payments"].test_links == [test_id]
+
+
+# --- archetype #6: mocked-out behavior, mock cited ---
+
+
+def test_archetype_6_mocked_out_behavior_is_nominal_with_the_mock_cited():
+    obs = [_obligation("select-rate"), _obligation("compute-coupon")]
+    test_id = "test_coupon.py::test_coupon_uses_selected_rate"
+    ev = [_evidence(test_id, ["select-rate", "compute-coupon"], mocks=["Mock"])]
+    discriminations = [
+        # rate_for is mocked to a constant -> the core select-by-date behavior
+        # is bypassed; every defect survives.
+        _disc("select-rate", False),
+        # coupon(...) == 50.0 catches a multiplication defect, but rounding is
+        # not exercised (50.0 is whole) -> partial.
+        _disc("compute-coupon", True, False),
+    ]
+
+    result = _by_id(classify_strength(obs, ev, discriminations))
+
+    assert result["select-rate"].evidence_class == "nominally_supported"
+    assert "Mock" in result["select-rate"].explanation  # the mock is cited
+    assert result["compute-coupon"].evidence_class == "partially_supported"
+
+
+def test_strength_round_trips():
+    obs = [_obligation("ob")]
+    ev = [_evidence("t.py::test", ["ob"])]
+    result = classify_strength(obs, ev, [_disc("ob", True)])[0]
+    from acceptance.evidence.strength import EvidenceStrength
+
+    assert EvidenceStrength.from_dict(result.to_dict()) == result


### PR DESCRIPTION
## Summary
`evidence/strength.py` — `classify_strength()` maps M5.2's per-criterion discrimination verdicts onto the §9.3 evidence classes. A **deterministic reduce, not a fresh judgment**: M5.2 already decided which plausible defects each mapped test catches; M5.3 turns that into a class over the bright line "catches at least one plausible violation":

| verdicts | class |
|---|---|
| all named defects caught | `strongly_supported` |
| some (≥1) but not all | `partially_supported` |
| a mapped test, none caught | `nominally_supported` |
| no mapped test at all | `unsupported` |
| mapped test, no defect judged | `indeterminate` |

`requires_other_evidence` is deliberately **not** produced here — the discrimination verdicts carry no signal that a criterion needs non-code evidence, so inventing it would be dishonest; that routing is left to coverage's `requires_non_code_evidence` downstream (M5.5/M7).

Each classification links to the exact mapped tests (pytest nodeids) and explains itself; a nominal test that bypasses the behavior **via a mock cites the mock** (from M5.1's extracted `TestEvidence.mocks`), per §9.4.

**Small refactor:** moved the `EvidenceClassification` §9.3 `Literal` from `benchmark/case.py` to `review_state.py`, so the checker (`evidence/strength.py`) and the benchmark both use it without the checker depending on the benchmark module (wrong layer direction). Behavior-preserving — `case.py` imports it; 19 case tests pass unchanged.

## Test plan (deterministic — no live run needed; no prompt to verify)
- [x] **Acceptance:** archetype #3 → `one-per-month` **strongly** (`len==12` catches wrong count), `equal-payments`/`fully-amortizing` **nominally** (never asserted); archetype #6 → `select-rate` **nominally with the `Mock` cited**, `compute-coupon` **partially** (catches the multiply, misses rounding). Each linked to the exact test.
- [x] Each class-mapping branch + `unsupported`/`indeterminate` + round-trip.
- [x] Full suite: 354 passed (was 346); ruff clean.
- [x] Dogfooded (`decompose`/`classify`) — all 9 obligations `[addressed]`; all 4 unrequested flags self-`[in_service]`.

## Scope
Classifier only. Wiring into `classify_case` and making `evidence_agreement` score (now measurable thanks to #118) is **M5.5**.

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)