### PR TITLE
M5.5: semantic scoring hook (§11.1 evidence-classification agreement)

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,12 +1,12 @@
 # Task
-Classify each criterion's test-evidence strength into the §9.3 classes — strongly / partially / nominally / unsupported / indeterminate — at the static tier, with a linked, self-justifying explanation.
+Feed the M5.1-M5.3 test-evidence classifications into the evidence-classification-agreement metric, so the archetype set reports a real figure.
 
 ## Constraints
-- Consume M5.2's per-criterion discrimination verdicts; this is a deterministic reduce, not a fresh model judgment.
-- Map on the single bright line: all named plausible defects caught is strongly supported; at least one but not all is partially supported; a mapped test that catches none is nominally supported; no mapped test at all is unsupported; a mapped test with no defect judged is indeterminate.
-- Do not invent requires_other_evidence from discrimination alone — there is no such signal in the verdicts.
-- Each classification links to the exact mapped tests, and a nominal test that bypasses the behavior via a mock cites the mock (from M5.1's extracted mocks).
+- Wire test discovery, mapping, extraction, discrimination, and strength classification into the benchmark's static pipeline (classify_case), ahead of coverage classification.
+- Add a field on the reviewer's Obligation for the §9.3 evidence class, populated by the strength classifier's output.
+- Update the evidence-classification-agreement metric to score real matched/reported counts instead of always reporting zero reported.
+- The metric must use the same semantic-alignment mechanism as the other obligation-keyed metrics, so it isn't defeated by reworded reviewer criteria.
 
 ## Completion expectations
 - Implementation
-- Unit tests: archetype #3's superficial test yields nominal for the rules it never checks; archetype #6's mocked-out core behavior is nominal with the mock cited; each classification links to the exact mapped tests.
+- Unit tests: on an archetype, the checker's own classification of its real candidate tests agrees with ground truth and evidence_agreement reports a real, non-trivial number.

--- a/src/acceptance/benchmark/coverage.py
+++ b/src/acceptance/benchmark/coverage.py
@@ -1,8 +1,7 @@
-"""Coverage scoring hook (M3.3).
+"""Coverage & evidence scoring hook (M3.3, extended M5.5).
 
-Wires M3.1's implementation-coverage classification and M3.2's
-unrequested-change detection into the M-B0.3 gap-detection/false-alarm
-metric. Like M1.4's decompose_case (decomposition.py), this stays lighter
+Wires the checker's static-analysis capabilities into the M-B0.3 §11.1
+metrics. Like M1.4's decompose_case (decomposition.py), this stays lighter
 than the full checker pipeline (M-B0.2's run_case) — it only needs a case's
 task text and its materialized repo's diff, no test execution.
 
@@ -15,6 +14,11 @@ covered, so it becomes a Finding linked to that obligation. An
 about code that shouldn't have changed, not about an obligation going
 unmet — so it becomes an unlinked Finding: reported for a human to read, but
 not yet counted by a metric that only scores obligation-linked gaps.
+
+M5.5 adds the test-evidence chain (discover -> map -> extract -> discriminate
+-> classify strength) ahead of coverage classification, so `Obligation.
+evidence_class` is set from real analysis of the case's own tests before
+`scoring.py`'s evidence-classification-agreement metric reads it.
 """
 
 from __future__ import annotations
@@ -29,7 +33,10 @@ from acceptance.coverage.classify import CoverageStatus, ImplementationCoverage,
 from acceptance.coverage.disposition import DispositionedChange, classify_dispositions
 from acceptance.coverage.unrequested import detect_unrequested_changes
 from acceptance.evidence.discovery import discover_tests
+from acceptance.evidence.discrimination import judge_discrimination
+from acceptance.evidence.extraction import extract_test_evidence
 from acceptance.evidence.mapping import apply_test_mapping, map_tests_to_obligations
+from acceptance.evidence.strength import apply_evidence_strength, classify_strength
 from acceptance.evidence_tier import Component, EvidenceTier
 from acceptance.llm import ModelClient
 from acceptance.requirement.obligations import decompose
@@ -105,10 +112,11 @@ def classify_case(
     client: ModelClient,
     policy: ScopeExpansionPolicy = ScopeExpansionPolicy.STRICT,
 ) -> BenchmarkCase:
-    """Decompose; discover and map candidate tests; classify coverage, detect
-    unrequested changes and their dispositions for a case's diff; return a
-    scored copy of `case`. The benchmark's assembled static pipeline — each
-    capability lands here as it ships so its §11.1 metric is scored (M3-M5)."""
+    """Decompose; discover and map candidate tests; extract, discriminate, and
+    classify their evidence strength; classify coverage, detect unrequested
+    changes and their dispositions for a case's diff; return a scored copy of
+    `case`. The benchmark's assembled static pipeline — each capability lands
+    here as it ships so its §11.1 metric is scored (M3-M5)."""
     parsed = parse_task_file(case.inputs.task_text)
     obligations = decompose(parsed, client).obligations
     repo = Path(case.inputs.repo)
@@ -119,6 +127,11 @@ def classify_case(
     discovered = discover_tests(repo, change_set)
     mapping = map_tests_to_obligations(obligations, discovered.tests, client)
     obligations = apply_test_mapping(obligations, mapping)
+
+    test_evidence = extract_test_evidence(repo, discovered.tests, change_set, mapping)
+    discriminations = judge_discrimination(obligations, test_evidence, change_set, client)
+    strengths = classify_strength(obligations, test_evidence, discriminations)
+    obligations = apply_evidence_strength(obligations, strengths)
 
     coverages = classify_coverage(obligations, change_set, client)
     unrequested = detect_unrequested_changes(obligations, change_set, client)

--- a/src/acceptance/benchmark/scoring.py
+++ b/src/acceptance/benchmark/scoring.py
@@ -16,12 +16,12 @@ carries no obligation link at all.
 
 Ground truth identifies obligations by a stable id; the reviewer's Review
 (review_state.py) does not yet — its obligations are identified only by
-description, and its Findings carry no §9.3 classification (that is the M1
-obligation-schema and M5.3 strength-classification work). So the cross-join
-to reviewer output is by description for now, and evidence agreement scores
-with reported_total=0 until a reviewer can express a classification. When M1
-gives reviewer obligations ids, these joins move to ids; the ground-truth
-tree is already the anchor for that.
+description. So the cross-join to reviewer output is by description for now
+(sharpened to semantic matching by #118's alignment, below); when M1 gives
+reviewer obligations ids, these joins move to ids; the ground-truth tree is
+already the anchor for that. Evidence agreement reads `Obligation.evidence_class`,
+set by M5.3's strength classifier via `apply_evidence_strength` (M5.5); an
+obligation the reviewer hasn't classified yet contributes no reported ref.
 
 Aggregation pools raw match counts across cases before dividing
 (micro-averaging), so small or no-op-heavy cases can't dilute the headline
@@ -155,15 +155,22 @@ def _mapping_counts(case: BenchmarkCase, alignment: dict[str, str]) -> _MatchCou
     return _counts(ground_truth_refs, reported_refs)
 
 
-def _evidence_counts(case: BenchmarkCase) -> _MatchCounts:
+def _evidence_counts(case: BenchmarkCase, alignment: dict[str, str]) -> _MatchCounts:
     # Every obligation carries an evidence class, so the denominator is the full
-    # decomposition. reported_total is 0 until a reviewer Obligation can express
-    # a §9.3 classification (M5.3); matched is therefore 0 for now.
+    # decomposition. A reviewer Obligation expresses its §9.3 classification via
+    # `evidence_class` (M5.3/M5.5); one with none set (not yet classified)
+    # contributes no reported ref, same as any other unreported obligation.
+    review = case.reviewer_output
     ground_truth_refs = {
         (obligation.description, obligation.evidence_class)
         for obligation in case.ground_truth.obligations
     }
-    return _MatchCounts(matched=0, ground_truth_total=len(ground_truth_refs), reported_total=0)
+    reported_refs = {
+        (_remap(obligation.description, alignment), obligation.evidence_class)
+        for obligation in review.obligation_map
+        if obligation.evidence_class is not None
+    }
+    return _counts(ground_truth_refs, reported_refs)
 
 
 def _alignment(case: BenchmarkCase, client: ModelClient | None) -> dict[str, str]:
@@ -188,7 +195,7 @@ def _all_counts(
         _gap_counts(case, alignment),
         _decomposition_counts(case, alignment),
         _mapping_counts(case, alignment),
-        _evidence_counts(case),
+        _evidence_counts(case, alignment),
         _unrequested_counts(case),
     )
 

--- a/src/acceptance/evidence/strength.py
+++ b/src/acceptance/evidence/strength.py
@@ -22,12 +22,15 @@ explains itself — for a nominal test that bypasses the behavior via a mock, th
 mock is cited (from M5.1's extracted `TestEvidence.mocks`), per §9.4.
 
 Classification is at the `static` evidence tier: these are static predictions;
-M8 execution can later confirm them and raise the tier.
+M8 execution can later confirm them and raise the tier. `apply_evidence_strength`
+(M5.5) writes each obligation's class into `Obligation.evidence_class` — the
+field the §11.1 evidence-classification-agreement metric (scoring.py) reads.
 """
 
 from __future__ import annotations
 
 from acceptance.evidence.discrimination import ObligationDiscrimination
+from acceptance.evidence_tier import EvidenceTier
 from acceptance.model_base import PersistableModel
 from acceptance.review_state import EvidenceClassification, Obligation, TestEvidence
 
@@ -144,3 +147,27 @@ def classify_strength(
             )
         )
     return results
+
+
+def apply_evidence_strength(
+    obligations: list[Obligation], results: list[EvidenceStrength]
+) -> list[Obligation]:
+    """Return copies of `obligations` with `evidence_class` (and the `static`
+    achieved tier) set from the classification — the join the §11.1
+    evidence-classification-agreement metric scores (M5.5)."""
+    by_id = {r.obligation_id: r for r in results}
+    updated = []
+    for obligation in obligations:
+        result = by_id.get(obligation.id)
+        if result is None:
+            updated.append(obligation)
+            continue
+        updated.append(
+            obligation.model_copy(
+                update={
+                    "evidence_class": result.evidence_class,
+                    "achieved_evidence_tier": EvidenceTier.STATIC,
+                }
+            )
+        )
+    return updated

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -161,38 +161,6 @@ class ChangeSet(_Model):
     ignored_paths: list[str] = Field(default_factory=list)
 
 
-class Obligation(_Model):
-    """A discrete, typed obligation derived from the task (§7.3, §9.1; M1.2).
-
-    `id` is a stable slug so a reviewer obligation joins to the benchmark's
-    ground-truth obligation by id. `source_spans` link it to the exact task
-    text it derives from (M1.1). `explicit` is refined into explicit /
-    reasonable-inferred / open-question by M1.3."""
-
-    id: str
-    description: str
-    type: ObligationType
-    importance: Literal["critical", "normal"]
-    explicit: bool
-    observable_behavior: str
-    source_spans: list[TextSpan] = Field(default_factory=list)
-    achieved_evidence_tier: EvidenceTier | None = None
-    test_evidence: list[str] = Field(default_factory=list)
-
-
-class OpenQuestion(_Model):
-    """A material ambiguity in the task that needs user judgment (§7.3, §9.3).
-
-    Surfaced instead of silently inventing an obligation — uncertainty is a
-    first-class, expected output. `source_spans` link to the underspecified
-    task text."""
-
-    id: str
-    question: str
-    importance: Literal["critical", "normal"] = "normal"
-    source_spans: list[TextSpan] = Field(default_factory=list)
-
-
 # §9.3 test-evidence strength classifications. Distinct from EvidenceTier
 # (evidence_tier.py), which grades *how* evidence was produced, not how strong
 # it is. Defined over the plausible-violation space — the §8.2 mapped mutants —
@@ -216,6 +184,42 @@ EvidenceClassification = Literal[
     "requires_other_evidence",
     "indeterminate",
 ]
+
+
+class Obligation(_Model):
+    """A discrete, typed obligation derived from the task (§7.3, §9.1; M1.2).
+
+    `id` is a stable slug so a reviewer obligation joins to the benchmark's
+    ground-truth obligation by id. `source_spans` link it to the exact task
+    text it derives from (M1.1). `explicit` is refined into explicit /
+    reasonable-inferred / open-question by M1.3. `evidence_class` is the §9.3
+    strength classification (M5.3); `achieved_evidence_tier` is separate — how
+    that classification was produced (static prediction vs. executed), not how
+    strong it is."""
+
+    id: str
+    description: str
+    type: ObligationType
+    importance: Literal["critical", "normal"]
+    explicit: bool
+    observable_behavior: str
+    source_spans: list[TextSpan] = Field(default_factory=list)
+    achieved_evidence_tier: EvidenceTier | None = None
+    test_evidence: list[str] = Field(default_factory=list)
+    evidence_class: EvidenceClassification | None = None
+
+
+class OpenQuestion(_Model):
+    """A material ambiguity in the task that needs user judgment (§7.3, §9.3).
+
+    Surfaced instead of silently inventing an obligation — uncertainty is a
+    first-class, expected output. `source_spans` link to the underspecified
+    task text."""
+
+    id: str
+    question: str
+    importance: Literal["critical", "normal"] = "normal"
+    source_spans: list[TextSpan] = Field(default_factory=list)
 
 
 class TestEvidence(_Model):

--- a/tests/benchmark/test_coverage.py
+++ b/tests/benchmark/test_coverage.py
@@ -10,8 +10,14 @@ file against `unrequested_changes` ground truth — never via any obligation's
 coverage classification, since an unrequested-change finding carries no
 `related_obligation` at all.
 
-classify_case makes three schema-constrained calls per case (decompose,
-classify_coverage, detect_unrequested_changes); per the replay-first
+M5.5 adds the test-evidence chain (discover -> map -> extract -> discriminate
+-> classify strength) ahead of coverage: archetype #1 also contributes a real
+evidence_agreement figure, backed by the checker's own classification of its
+real candidate tests.
+
+classify_case makes several schema-constrained calls per case (decompose,
+test mapping, discrimination when a criterion has a mapped test, coverage
+classification, unrequested-change detection); per the replay-first
 invariant the test client dispatches a fixed, hand-authored response per
 call by its response schema name — no live calls.
 """
@@ -112,6 +118,73 @@ def test_archetype_1_missed_obligation_yields_full_recall_and_precision(tmp_path
     )
     assert scored.score.gap_recall == 1.0
     assert scored.score.gap_precision == 1.0
+
+
+def test_archetype_1_evidence_agreement_reports_a_real_number(tmp_path):
+    """M5.5 acceptance: the checker's own evidence-strength classification —
+    fed by real M4.1 discovery + M4.2 mapping + M5.1 extraction + M5.2
+    discrimination — agrees with archetype #1's ground truth."""
+    case = build_benchmark_case(ARCHETYPES_DIR / "01-missed-obligation", tmp_path / "repo")
+
+    obligations = [
+        {"id": "show-fields", "description": "Show the item name, quantity, and unit price",
+         "type": "functional", "source_quote": "Show the item name, the quantity, and the unit price."},
+        {"id": "line-total", "description": "Include the line total (quantity times unit price)",
+         "type": "functional", "source_quote": "Include the line total (quantity × unit price)."},
+        {"id": "money-format", "description": "Format money as USD with two decimals and a leading $",
+         "type": "functional", "source_quote": "Format every money value as USD with exactly two decimals"},
+        {"id": "returns-in-parens",
+         "description": "Show negative-quantity returns with the quantity and total in parentheses",
+         "type": "boundary", "source_quote": "For returns (a negative quantity)"},
+    ]
+    pos = "test_receipt.py::test_positive_line"
+    two = "test_receipt.py::test_two_decimal_formatting"
+    client = _client_dispatching(
+        {
+            "_Decomposition": _decomposition_response(obligations),
+            "_Mappings": {
+                "mappings": [
+                    {"test_id": pos, "obligation_ids": ["show-fields", "line-total", "money-format"], "rationale": "."},
+                    {"test_id": two, "obligation_ids": ["show-fields", "line-total", "money-format"], "rationale": "."},
+                ]
+            },
+            "_Discrimination": {
+                "obligations": [
+                    {"obligation_id": "show-fields", "defects": [
+                        {"description": "wrong/omitted field", "would_be_caught": True, "reason": "exact line string asserted"},
+                    ]},
+                    {"obligation_id": "line-total", "defects": [
+                        {"description": "wrong total formula", "would_be_caught": True, "reason": "exact total asserted"},
+                    ]},
+                    {"obligation_id": "money-format", "defects": [
+                        {"description": "wrong currency formatting", "would_be_caught": True, "reason": "exact $ format asserted"},
+                    ]},
+                    # returns-in-parens has no mapped test, so it's never sent here.
+                ]
+            },
+            "_Coverage": _classification_response(
+                [
+                    {"obligation_id": "show-fields", "status": "addressed"},
+                    {"obligation_id": "line-total", "status": "addressed"},
+                    {"obligation_id": "money-format", "status": "addressed"},
+                    {"obligation_id": "returns-in-parens", "status": "not_addressed"},
+                ]
+            ),
+            "_Detections": {"unrequested_changes": []},
+        }
+    )
+
+    scored = classify_case(case, client)
+
+    by_id = {o.id: o for o in scored.reviewer_output.obligation_map}
+    assert by_id["show-fields"].evidence_class == "strongly_supported"
+    assert by_id["line-total"].evidence_class == "strongly_supported"
+    assert by_id["money-format"].evidence_class == "strongly_supported"
+    assert by_id["returns-in-parens"].evidence_class == "unsupported"  # no mapped test
+
+    # Reviewer descriptions match ground truth exactly by construction here, so
+    # exact-string scoring (no alignment client) already agrees fully: 4/4.
+    assert scored.score.evidence_agreement == 1.0
 
 
 def test_archetype_2_missed_qualifier_yields_full_recall_and_precision(tmp_path):


### PR DESCRIPTION
## Summary
Wires M5.1–M5.3's test-evidence chain into the benchmark's static pipeline (`classify_case`), ahead of coverage classification: `discover_tests` → `map_tests_to_obligations` → `extract_test_evidence` → `judge_discrimination` → `classify_strength` → `apply_evidence_strength`.

- `Obligation` gains `evidence_class` (§9.3 `EvidenceClassification`), moved from `benchmark/case.py` to `review_state.py` so the checker doesn't depend on the benchmark module (wrong layer direction) — behavior-preserving, `case.py` now imports it, 19 case tests pass unchanged.
- `scoring.py`'s `_evidence_counts` finally computes **real** matched/reported counts — previously hardcoded `reported_total=0`, so `evidence_agreement` always scored `0.0` regardless of reviewer output.
- Threaded through the same semantic alignment **#118** built for decomposition/mapping/gap, so a reworded reviewer criterion still agrees with ground truth instead of silently failing the join.

## Acceptance
Archetype #1, real discovery + mapping + extraction + discrimination (not hand-faked classes): `show-fields`/`line-total`/`money-format` classify `strongly_supported` (their real test asserts exact strings); `returns-in-parens` classifies `unsupported` (genuinely no mapped test — the head fixture never implements it). All four agree with ground truth → `evidence_agreement` reports **1.0**, not the `0.0` it always reported before this PR.

## Test plan
- [x] New acceptance test (`test_coverage.py`): full pipeline on archetype #1, asserts each obligation's real classified `evidence_class` and the resulting `evidence_agreement == 1.0`.
- [x] All 5 pre-existing `classify_case` tests pass unchanged (their mocked `_Mappings: []` means discrimination never fires — no model call needed, confirming backward compatibility).
- [x] Full suite: 355 passed (was 354); ruff clean.
- [x] Dogfooded (`decompose`/`classify`) — all 5 obligations `[addressed]`; all 4 unrequested flags self-`[in_service]`.

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)