### PR TITLE
M5.4: weak-evidence pattern detectors (§9.4)

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,12 +1,12 @@
 # Task
-Feed the M5.1-M5.3 test-evidence classifications into the evidence-classification-agreement metric, so the archetype set reports a real figure.
+Detect the §9.4 weak-evidence anti-patterns and flag each with its matching pattern name: assert-not-none/result-exists, circular expected value, incomplete error assertion, requirement-not-exercised, critical-behavior-mocked, unvalidated snapshot.
 
 ## Constraints
-- Wire test discovery, mapping, extraction, discrimination, and strength classification into the benchmark's static pipeline (classify_case), ahead of coverage classification.
-- Add a field on the reviewer's Obligation for the §9.3 evidence class, populated by the strength classifier's output.
-- Update the evidence-classification-agreement metric to score real matched/reported counts instead of always reporting zero reported.
-- The metric must use the same semantic-alignment mechanism as the other obligation-keyed metrics, so it isn't defeated by reworded reviewer criteria.
+- Structural detection, no model call.
+- Reuse what M5.1-M5.3 already compute rather than recomputing: circular expected value from M5.1's expected-value provenance; requirement-not-exercised and critical-behavior-mocked from M5.3's nominal classification, distinguished by whether mocks are involved.
+- The remaining three patterns (non-discriminating assertion, incomplete error assertion, unvalidated snapshot) need new structural detection over a test's raw source.
+- An incomplete error assertion may be checked either inside the raises block or in the statements immediately following it — both are valid pytest style.
 
 ## Completion expectations
 - Implementation
-- Unit tests: on an archetype, the checker's own classification of its real candidate tests agrees with ground truth and evidence_agreement reports a real, non-trivial number.
+- Unit tests: each §9.4 code example is correctly flagged with the matching pattern name; a genuinely strong test is not flagged.

--- a/src/acceptance/evidence/extraction.py
+++ b/src/acceptance/evidence/extraction.py
@@ -66,7 +66,7 @@ def extract_test_evidence(
             production_by_file[test.file] = _production_import_names(
                 repo / test.file, changed_modules
             )
-        func = _parse_test_function(test.source)
+        func = parse_test_function(test.source)
         if func is None:
             continue
         evidence.append(
@@ -97,7 +97,9 @@ def _production_import_names(file_path: Path, changed_modules: set[str]) -> set[
     return names
 
 
-def _parse_test_function(source: str) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+def parse_test_function(source: str) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+    """Parse a `DiscoveredTest.source` snippet back into its function AST node —
+    shared with weak_patterns.py (M5.4), which needs the raw body too."""
     try:
         module = ast.parse(textwrap.dedent(source))  # dedent: class methods are indented
     except SyntaxError:

--- a/src/acceptance/evidence/weak_patterns.py
+++ b/src/acceptance/evidence/weak_patterns.py
@@ -1,0 +1,274 @@
+"""Weak-evidence pattern detectors (M5.4, §9.4).
+
+Names the six §9.4 anti-patterns wherever a test exhibits them. Structural,
+no model call — three patterns are new AST shape-matching over a test's raw
+source (`DiscoveredTest.source`); the other three are already computed by
+M5.1-M5.3 and just need relabeling:
+
+- CIRCULAR_EXPECTED_VALUE      <- M5.1's expected_value_provenance ("Circular...")
+- REQUIREMENT_NOT_EXERCISED    <- M5.3 nominal (no defect caught), no mocks
+                                   involved: the INPUT itself fails to
+                                   discriminate (§9.4's calendar-aligned-dates
+                                   example, archetype #4's shape)
+- CRITICAL_BEHAVIOR_MOCKED     <- M5.3 nominal, WITH mocks involved: the
+                                   behavior under review was bypassed
+                                   (§9.4's rate-selection example, archetype
+                                   #6's shape)
+
+Mocks-present is the mechanical signal that distinguishes the latter two — a
+nominal test that mocked nothing failed to discriminate because its INPUT
+happened to coincide with a plausible defect; a nominal test that mocked the
+behavior under review never exercised it at all. Both still nominally_supported
+in M5.3; §9.4 wants the reader to know *why*.
+
+New structural detection (over `DiscoveredTest.source`):
+- NON_DISCRIMINATING_ASSERTION: `assert x is not None` / a bare truthy check —
+  establishes only that *something* was returned, not that it was CORRECT.
+- INCOMPLETE_ERROR_ASSERTION: `pytest.raises(Exception)` (too broad — matches
+  almost any failure) or a raises-block with no assertion on the exception
+  itself (type, message, or attributes).
+- UNVALIDATED_SNAPSHOT: an assertion compares against something *named* like a
+  stored/golden artifact (snapshot/golden/approved/expected-file) rather than
+  an independently-derived value — a name heuristic, the same spirit as
+  extraction.py's `_MOCK_NAMES`.
+
+This is a reporting/advisory layer (feeds §9.5 recommendations, M7 territory)
+— not wired into classify_case/scoring, same scope boundary as M5.1.
+"""
+
+from __future__ import annotations
+
+import ast
+from enum import Enum
+
+from acceptance.evidence.discovery import DiscoveredTest
+from acceptance.evidence.discrimination import ObligationDiscrimination
+from acceptance.evidence.extraction import parse_test_function
+from acceptance.model_base import PersistableModel
+from acceptance.review_state import TestEvidence
+
+_SNAPSHOT_NAME_MARKERS = ("snapshot", "golden", "approved")
+
+
+class WeakEvidencePattern(str, Enum):
+    NON_DISCRIMINATING_ASSERTION = "non_discriminating_assertion"
+    CIRCULAR_EXPECTED_VALUE = "circular_expected_value"
+    INCOMPLETE_ERROR_ASSERTION = "incomplete_error_assertion"
+    REQUIREMENT_NOT_EXERCISED = "requirement_not_exercised"
+    CRITICAL_BEHAVIOR_MOCKED = "critical_behavior_mocked"
+    UNVALIDATED_SNAPSHOT = "unvalidated_snapshot"
+
+
+class WeakEvidenceFinding(PersistableModel):
+    test_id: str
+    pattern: WeakEvidencePattern
+    description: str
+
+
+def _non_discriminating_assertion(func: ast.AST) -> str | None:
+    for node in ast.walk(func):
+        if not isinstance(node, ast.Assert):
+            continue
+        test = node.test
+        # `assert x is not None` / `assert x is not False` etc.
+        if (
+            isinstance(test, ast.Compare)
+            and len(test.ops) == 1
+            and isinstance(test.ops[0], ast.IsNot)
+        ):
+            return ast.unparse(node)
+        # `assert x` / `assert isinstance(x, T)` — no comparison to a specific
+        # expected value, only a truthy/type check.
+        if isinstance(test, ast.Call) and _call_name(test) == "isinstance":
+            return ast.unparse(node)
+        if isinstance(test, (ast.Name, ast.Attribute, ast.Call)):
+            return ast.unparse(node)
+    return None
+
+
+def _call_name(call: ast.Call) -> str | None:
+    if isinstance(call.func, ast.Name):
+        return call.func.id
+    if isinstance(call.func, ast.Attribute):
+        return call.func.attr
+    return None
+
+
+def _incomplete_error_assertion(func: ast.AST) -> str | None:
+    """A `pytest.raises` block whose exception type is too broad to mean
+    anything, or whose exception is never inspected afterward. The exception
+    is commonly checked in the statements AFTER the `with` block exits (not
+    inside it) — a valid, common pytest style — so both are searched."""
+    for body in _statement_lists(func):
+        for i, node in enumerate(body):
+            if not isinstance(node, ast.With):
+                continue
+            for item in node.items:
+                call = item.context_expr
+                if not (isinstance(call, ast.Call) and _call_name(call) == "raises"):
+                    continue
+                exc_type = ast.unparse(call.args[0]) if call.args else ""
+                too_broad = exc_type in ("Exception", "BaseException")
+                checks_exception = item.optional_vars is not None and (
+                    _references(node.body, item.optional_vars)
+                    or _references(body[i + 1 :], item.optional_vars)
+                )
+                if too_broad or not checks_exception:
+                    return ast.unparse(node).splitlines()[0]
+    return None
+
+
+def _statement_lists(func: ast.AST) -> list[list[ast.stmt]]:
+    """Every statement-list (function/if/for/while/with body, ...) in `func`,
+    so callers can inspect a node's SIBLINGS, not just its descendants —
+    `ast.walk` alone loses that structural context."""
+    lists: list[list[ast.stmt]] = []
+
+    def visit(node: ast.AST) -> None:
+        for field in ("body", "orelse", "finalbody"):
+            block = getattr(node, field, None)
+            if isinstance(block, list) and block and isinstance(block[0], ast.stmt):
+                lists.append(block)
+                for stmt in block:
+                    visit(stmt)
+
+    visit(func)
+    return lists
+
+
+def _references(stmts: list[ast.stmt], target: ast.expr) -> bool:
+    if not isinstance(target, ast.Name):
+        return False
+    for stmt in stmts:
+        for node in ast.walk(stmt):
+            if isinstance(node, ast.Name) and node.id == target.id:
+                return True
+    return False
+
+
+def _unvalidated_snapshot(func: ast.AST) -> str | None:
+    for node in ast.walk(func):
+        if not isinstance(node, ast.Assert) or not isinstance(node.test, ast.Compare):
+            continue
+        operands = [node.test.left, *node.test.comparators]
+        for operand in operands:
+            name = _operand_name(operand)
+            if name and any(marker in name.lower() for marker in _SNAPSHOT_NAME_MARKERS):
+                return ast.unparse(node)
+    return None
+
+
+def _operand_name(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    if isinstance(node, ast.Call):
+        return _call_name(node)
+    return None
+
+
+def _from_test_evidence(evidence: TestEvidence) -> list[WeakEvidenceFinding]:
+    findings = []
+    if evidence.expected_value_provenance and evidence.expected_value_provenance.startswith(
+        "Circular"
+    ):
+        findings.append(
+            WeakEvidenceFinding(
+                test_id=evidence.identifier,
+                pattern=WeakEvidencePattern.CIRCULAR_EXPECTED_VALUE,
+                description=evidence.expected_value_provenance,
+            )
+        )
+    return findings
+
+
+def _from_discrimination(
+    evidence: TestEvidence, discriminations_by_obligation: dict[str, ObligationDiscrimination]
+) -> list[WeakEvidenceFinding]:
+    findings = []
+    for obligation_id in evidence.mapped_obligations:
+        discrimination = discriminations_by_obligation.get(obligation_id)
+        if discrimination is None or not discrimination.defects:
+            continue
+        if any(d.would_be_caught for d in discrimination.defects):
+            continue  # not nominal — some defect is caught
+        if evidence.mocks:
+            findings.append(
+                WeakEvidenceFinding(
+                    test_id=evidence.identifier,
+                    pattern=WeakEvidencePattern.CRITICAL_BEHAVIOR_MOCKED,
+                    description=(
+                        f"Mocks {', '.join(sorted(evidence.mocks))} while claiming to "
+                        f"establish {obligation_id}; every plausible defect survives."
+                    ),
+                )
+            )
+        else:
+            findings.append(
+                WeakEvidenceFinding(
+                    test_id=evidence.identifier,
+                    pattern=WeakEvidencePattern.REQUIREMENT_NOT_EXERCISED,
+                    description=(
+                        f"The test's inputs do not distinguish {obligation_id} from a "
+                        f"plausible defect; every mapped defect survives."
+                    ),
+                )
+            )
+    return findings
+
+
+def _from_source(test: DiscoveredTest) -> list[WeakEvidenceFinding]:
+    func = parse_test_function(test.source)
+    if func is None:
+        return []
+    findings = []
+    if match := _non_discriminating_assertion(func):
+        findings.append(
+            WeakEvidenceFinding(
+                test_id=test.test_id,
+                pattern=WeakEvidencePattern.NON_DISCRIMINATING_ASSERTION,
+                description=f"Establishes only that a value was returned, not that it was correct: `{match}`.",
+            )
+        )
+    if match := _incomplete_error_assertion(func):
+        findings.append(
+            WeakEvidenceFinding(
+                test_id=test.test_id,
+                pattern=WeakEvidencePattern.INCOMPLETE_ERROR_ASSERTION,
+                description=(
+                    f"Does not establish the error type, message, or content: `{match}`."
+                ),
+            )
+        )
+    if match := _unvalidated_snapshot(func):
+        findings.append(
+            WeakEvidenceFinding(
+                test_id=test.test_id,
+                pattern=WeakEvidencePattern.UNVALIDATED_SNAPSHOT,
+                description=(
+                    f"Confirms output is unchanged with no evidence the stored value "
+                    f"was correct: `{match}`."
+                ),
+            )
+        )
+    return findings
+
+
+def detect_weak_patterns(
+    discovered_tests: list[DiscoveredTest],
+    test_evidence: list[TestEvidence],
+    discriminations: list[ObligationDiscrimination],
+) -> list[WeakEvidenceFinding]:
+    """Flag each §9.4 weak-evidence pattern a test exhibits."""
+    discriminations_by_obligation = {d.obligation_id: d for d in discriminations}
+    findings: list[WeakEvidenceFinding] = []
+
+    for evidence in test_evidence:
+        findings.extend(_from_test_evidence(evidence))
+        findings.extend(_from_discrimination(evidence, discriminations_by_obligation))
+
+    for test in discovered_tests:
+        findings.extend(_from_source(test))
+
+    return findings

--- a/tests/evidence/test_weak_patterns.py
+++ b/tests/evidence/test_weak_patterns.py
@@ -1,0 +1,161 @@
+"""M5.4 acceptance: each §9.4 weak-evidence pattern is correctly flagged with
+its matching pattern name — the three code examples from the spec verbatim,
+plus neutral fixtures for the three prose-described patterns.
+
+Structural (no model call), so these assert real detections directly."""
+
+from acceptance.evidence.discovery import DiscoveredTest, DiscoveryReason
+from acceptance.evidence.discrimination import ObligationDiscrimination, PlausibleDefect
+from acceptance.evidence.weak_patterns import WeakEvidencePattern, detect_weak_patterns
+from acceptance.review_state import TestEvidence
+
+
+def _test(test_id: str, source: str) -> DiscoveredTest:
+    return DiscoveredTest(
+        test_id=test_id, file=test_id.split("::", 1)[0],
+        reasons=[DiscoveryReason.CALLS_CHANGED_SYMBOL], source=source,
+    )
+
+
+def _evidence(identifier: str, **kwargs) -> TestEvidence:
+    return TestEvidence(identifier=identifier, location=identifier.split("::", 1)[0], **kwargs)
+
+
+def _disc(obligation_id: str, *caught: bool) -> ObligationDiscrimination:
+    defects = [
+        PlausibleDefect(description=f"defect {i}", would_be_caught=c, reason=".")
+        for i, c in enumerate(caught)
+    ]
+    return ObligationDiscrimination(obligation_id=obligation_id, defects=defects, discriminating=any(caught))
+
+
+def _patterns(findings, test_id):
+    return {f.pattern for f in findings if f.test_id == test_id}
+
+
+# --- §9.4's own code examples, verbatim ---
+
+
+def test_non_discriminating_assert_not_none():
+    test_id = "t.py::test_result"
+    source = (
+        "def test_result():\n"
+        "    result = calculate_coupon(input)\n"
+        "    assert result is not None\n"
+    )
+    tests = [_test(test_id, source)]
+
+    findings = detect_weak_patterns(tests, [], [])
+
+    assert WeakEvidencePattern.NON_DISCRIMINATING_ASSERTION in _patterns(findings, test_id)
+
+
+def test_circular_expected_value():
+    test_id = "t.py::test_coupon"
+    evidence = [_evidence(
+        test_id,
+        expected_value_provenance="Circular: both sides derive from calculate_coupon.",
+    )]
+
+    findings = detect_weak_patterns([], evidence, [])
+
+    assert WeakEvidencePattern.CIRCULAR_EXPECTED_VALUE in _patterns(findings, test_id)
+
+
+def test_incomplete_error_assertion():
+    test_id = "t.py::test_error"
+    source = (
+        "def test_error():\n"
+        "    with pytest.raises(Exception):\n"
+        "        calculate_coupon(input_with_missing_rate)\n"
+    )
+    tests = [_test(test_id, source)]
+
+    findings = detect_weak_patterns(tests, [], [])
+
+    assert WeakEvidencePattern.INCOMPLETE_ERROR_ASSERTION in _patterns(findings, test_id)
+
+
+def test_specific_exception_type_with_message_check_is_not_flagged():
+    test_id = "t.py::test_error_specific"
+    source = (
+        "def test_error_specific():\n"
+        "    with pytest.raises(MissingRateError) as exc:\n"
+        "        calculate_coupon(input_with_missing_rate)\n"
+        "    assert 'missing rate' in str(exc.value)\n"
+    )
+    tests = [_test(test_id, source)]
+
+    findings = detect_weak_patterns(tests, [], [])
+
+    assert WeakEvidencePattern.INCOMPLETE_ERROR_ASSERTION not in _patterns(findings, test_id)
+
+
+# --- prose-described patterns, neutral fixtures ---
+
+
+def test_requirement_not_exercised_no_mocks_nominal():
+    # Archetype #4's shape: a nominal test whose INPUT coincides with the defect.
+    test_id = "t.py::test_partial_month"
+    evidence = [_evidence(test_id, mapped_obligations=["daily-rate"], mocks=[])]
+    discriminations = [_disc("daily-rate", False, False)]
+
+    findings = detect_weak_patterns([], evidence, discriminations)
+
+    assert WeakEvidencePattern.REQUIREMENT_NOT_EXERCISED in _patterns(findings, test_id)
+    assert WeakEvidencePattern.CRITICAL_BEHAVIOR_MOCKED not in _patterns(findings, test_id)
+
+
+def test_critical_behavior_mocked_out_nominal_with_mocks():
+    # Archetype #6's shape: mocking the component the obligation claims to test.
+    test_id = "t.py::test_rate_selection"
+    evidence = [_evidence(test_id, mapped_obligations=["select-rate"], mocks=["Mock"])]
+    discriminations = [_disc("select-rate", False)]
+
+    findings = detect_weak_patterns([], evidence, discriminations)
+
+    assert WeakEvidencePattern.CRITICAL_BEHAVIOR_MOCKED in _patterns(findings, test_id)
+    assert WeakEvidencePattern.REQUIREMENT_NOT_EXERCISED not in _patterns(findings, test_id)
+
+
+def test_discriminating_test_is_not_flagged_nominal():
+    test_id = "t.py::test_strong"
+    evidence = [_evidence(test_id, mapped_obligations=["ob"], mocks=[])]
+    discriminations = [_disc("ob", True, True)]  # all caught -> strongly supported
+
+    findings = detect_weak_patterns([], evidence, discriminations)
+
+    assert _patterns(findings, test_id) == set()
+
+
+def test_unvalidated_snapshot():
+    test_id = "t.py::test_output_unchanged"
+    source = (
+        "def test_output_unchanged(snapshot):\n"
+        "    result = render(report)\n"
+        "    assert result == snapshot\n"
+    )
+    tests = [_test(test_id, source)]
+
+    findings = detect_weak_patterns(tests, [], [])
+
+    assert WeakEvidencePattern.UNVALIDATED_SNAPSHOT in _patterns(findings, test_id)
+
+
+def test_comparison_to_independently_derived_value_is_not_a_snapshot():
+    test_id = "t.py::test_normal"
+    source = "def test_normal():\n    assert calculate_total(10, 2) == 20\n"
+    tests = [_test(test_id, source)]
+
+    findings = detect_weak_patterns(tests, [], [])
+
+    assert WeakEvidencePattern.UNVALIDATED_SNAPSHOT not in _patterns(findings, test_id)
+
+
+def test_finding_round_trips():
+    test_id = "t.py::test_result"
+    source = "def test_result():\n    assert calc(1) is not None\n"
+    finding = detect_weak_patterns([_test(test_id, source)], [], [])[0]
+    from acceptance.evidence.weak_patterns import WeakEvidenceFinding
+
+    assert WeakEvidenceFinding.from_dict(finding.to_dict()) == finding


### PR DESCRIPTION
## Summary
`evidence/weak_patterns.py` — `detect_weak_patterns()` flags each §9.4 anti-pattern a test exhibits. Structural, **no model call**.

**Three patterns reuse what M5.1–M5.3 already compute**, rather than recomputing:
- `circular_expected_value` ← M5.1's `expected_value_provenance`
- `requirement_not_exercised` ← M5.3 nominal (no defect caught), **no mocks**: the *input itself* fails to discriminate (archetype #4's shape)
- `critical_behavior_mocked` ← M5.3 nominal, **with mocks**: the behavior under review was bypassed (archetype #6's shape)

Mocks-present is the mechanical signal distinguishing the latter two — both are "nominal" in M5.3, but §9.4 wants the reader to know *why*.

**Three patterns are new AST shape-matching** over `DiscoveredTest.source`: `non_discriminating_assertion` (`assert x is not None` / bare truthy / isinstance-only), `incomplete_error_assertion` (`pytest.raises(Exception)` — too broad — or no assertion on the exception itself), `unvalidated_snapshot` (comparison to something named like a stored/golden artifact — a name heuristic, same spirit as `extraction.py`'s existing `_MOCK_NAMES`).

**Real bug caught by a negative test before shipping:** the exception in a `pytest.raises` block is commonly checked in the statements *after* the `with` exits, not inside it (valid, common pytest style) — my first cut only scanned inside the with-block and false-flagged that pattern. Fixed by walking every statement-list in the function so a with-node's *siblings* (not just descendants) are inspectable.

**Small refactor:** promoted `extraction.py`'s `_parse_test_function` to public (`parse_test_function`) since `weak_patterns.py` needs it too — avoiding the private-cross-module-reach anti-pattern from M3.2.

## Test plan
- [x] **Acceptance:** the three §9.4 code examples (assert-not-none, circular, `pytest.raises(Exception)`) each flagged with the matching pattern name.
- [x] Negative: a specific exception type with a message check is **not** flagged (the real bug this caught); a genuinely strong (all-caught) test is not flagged.
- [x] The two prose-described patterns (requirement-not-exercised, critical-behavior-mocked) on neutral archetype-#4/#6-shaped fixtures; unvalidated-snapshot positive/negative.
- [x] Full suite: 365 passed (was 355); ruff clean.
- [x] Dogfooded (`decompose`/`classify`) — all 8 obligations `[addressed]`.

**Note on dogfood output:** it flagged the `parse_test_function` promotion `[separable]`, but it's actually in-service — the tool had no way to infer that reasoning (avoiding the M3.2 private-import anti-pattern) from `current-task.md` alone, since that context lives in this session's history, not the task text. Not a repeatable tool defect, just missing context — noting rather than filing.

## Scope
Advisory/reporting layer (feeds §9.5 recommendations, M7 territory) — not wired into `classify_case`/scoring, same scope boundary as M5.1.

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)