### PR TITLE
Fix self-contradictory and location-less unrequested-change findings

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,29 +1,12 @@
 # Task
-Unrequested-change detection emits spurious, location-less findings (diff_ref "?") whose rationale concludes the change IS requested.
+Fix unrequested-change detection (`detect_unrequested_changes`, M3.2) so it no longer emits spurious, location-less findings (diff_ref "?") whose rationale concludes the change IS requested. Surfaced dogfooding #118: `acceptance classify` on that PR's own diff emitted an unrequested-change finding whose rationale ended "...so this is not unrequested" — yet it was still reported as unrequested — with empty `diff_refs`, rendered by the CLI as a bare `?`.
 
-## Context
-Surfaced dogfooding #118. `acceptance classify` on that PR's own diff emitted this unrequested-change finding:
+## Constraints
+- The benchmark path already drops empty-`diff_refs` unrequested changes (`benchmark/coverage.py::_unrequested_finding` returns `None`); the CLI path (`run_classify` -> `render_classify`) must behave consistently — a finding with no location a human can act on is noise.
+- The M3.2 prompt already says "Do not report changes that a listed obligation requires" — the fix must address why the detector still emitted a change whose own rationale concludes it is requested, not just paper over the symptom.
+- Prefer fixing this once at the source (`detect_unrequested_changes`) over duplicating a drop-check in every consumer.
 
-```
-[separable] (adjacent_behavior) The new alignment logic is applied to gap, decomposition, and
-mapping scoring joins, but the obligations only require those joins to be updated through the
-alignment path; the exact implementation choice of remapping reviewer descriptions before
-intersection is requested, so this is not unrequested.
-   -> ?
-```
-
-Two defects in one finding:
-
-1. **Self-contradictory:** the rationale literally ends *"so this is not unrequested"* — yet it was emitted AS an unrequested change. The detector (`detect_unrequested_changes`, M3.2) produced a finding it simultaneously argues is requested.
-2. **No resolvable location (`-> ?`):** the finding has empty `diff_refs`. The model returned hunk labels that `resolve_refs` couldn't map to real hunks (dropped them), leaving no diff region. The CLI renders it anyway as `?`.
-
-## Inconsistency worth noting
-The benchmark path already handles case 2: `benchmark/coverage.py::_unrequested_finding` returns `None` when `change.diff_refs` is empty ("no diff location to point to means nothing a human can act on"). But the CLI path (`run_classify` -> `render_classify`) does **not** drop empty-`diff_refs` unrequested changes — it shows them with `?`. So the two consumers disagree, and the CLI surfaces location-less phantom findings the benchmark correctly suppresses.
-
-## Deliverable / directions
-- Drop (or clearly de-rank) unrequested changes with no resolvable `diff_refs` in the CLI path too — consistency with the benchmark path; a finding with no location a human can act on is noise.
-- Investigate why the detector emits a change whose own rationale concludes it is requested — the M3.2 prompt says "Do not report changes that a listed obligation requires"; this is a prompt/detection soundness miss.
-
-## Acceptance
+## Completion expectations
+- Implementation
 - An unrequested change whose model-returned hunk labels don't resolve does not appear as a bare `?` finding in CLI output.
 - A synthetic check that a change the model itself judges "requested" is not emitted as unrequested.

--- a/current-task.md
+++ b/current-task.md
@@ -1,12 +1,29 @@
 # Task
-Detect the §9.4 weak-evidence anti-patterns and flag each with its matching pattern name: assert-not-none/result-exists, circular expected value, incomplete error assertion, requirement-not-exercised, critical-behavior-mocked, unvalidated snapshot.
+Unrequested-change detection emits spurious, location-less findings (diff_ref "?") whose rationale concludes the change IS requested.
 
-## Constraints
-- Structural detection, no model call.
-- Reuse what M5.1-M5.3 already compute rather than recomputing: circular expected value from M5.1's expected-value provenance; requirement-not-exercised and critical-behavior-mocked from M5.3's nominal classification, distinguished by whether mocks are involved.
-- The remaining three patterns (non-discriminating assertion, incomplete error assertion, unvalidated snapshot) need new structural detection over a test's raw source.
-- An incomplete error assertion may be checked either inside the raises block or in the statements immediately following it — both are valid pytest style.
+## Context
+Surfaced dogfooding #118. `acceptance classify` on that PR's own diff emitted this unrequested-change finding:
 
-## Completion expectations
-- Implementation
-- Unit tests: each §9.4 code example is correctly flagged with the matching pattern name; a genuinely strong test is not flagged.
+```
+[separable] (adjacent_behavior) The new alignment logic is applied to gap, decomposition, and
+mapping scoring joins, but the obligations only require those joins to be updated through the
+alignment path; the exact implementation choice of remapping reviewer descriptions before
+intersection is requested, so this is not unrequested.
+   -> ?
+```
+
+Two defects in one finding:
+
+1. **Self-contradictory:** the rationale literally ends *"so this is not unrequested"* — yet it was emitted AS an unrequested change. The detector (`detect_unrequested_changes`, M3.2) produced a finding it simultaneously argues is requested.
+2. **No resolvable location (`-> ?`):** the finding has empty `diff_refs`. The model returned hunk labels that `resolve_refs` couldn't map to real hunks (dropped them), leaving no diff region. The CLI renders it anyway as `?`.
+
+## Inconsistency worth noting
+The benchmark path already handles case 2: `benchmark/coverage.py::_unrequested_finding` returns `None` when `change.diff_refs` is empty ("no diff location to point to means nothing a human can act on"). But the CLI path (`run_classify` -> `render_classify`) does **not** drop empty-`diff_refs` unrequested changes — it shows them with `?`. So the two consumers disagree, and the CLI surfaces location-less phantom findings the benchmark correctly suppresses.
+
+## Deliverable / directions
+- Drop (or clearly de-rank) unrequested changes with no resolvable `diff_refs` in the CLI path too — consistency with the benchmark path; a finding with no location a human can act on is noise.
+- Investigate why the detector emits a change whose own rationale concludes it is requested — the M3.2 prompt says "Do not report changes that a listed obligation requires"; this is a prompt/detection soundness miss.
+
+## Acceptance
+- An unrequested change whose model-returned hunk labels don't resolve does not appear as a bare `?` finding in CLI output.
+- A synthetic check that a change the model itself judges "requested" is not emitted as unrequested.

--- a/src/acceptance/coverage/unrequested.py
+++ b/src/acceptance/coverage/unrequested.py
@@ -10,6 +10,14 @@ adjacent-behavior changes, which are the ones most worth a human's attention
 A semantic judgment, so a schema-constrained model call through the M0.4
 harness — recorded for replay, never a live call in tests. Each flagged change
 links to the exact diff hunks it concerns.
+
+Two structural guards on the model's output (#121): a detection whose own
+`requested_by_obligation` re-check comes back true is dropped rather than
+emitted as a self-contradictory finding, and a detection whose hunk labels
+don't resolve to a real diff region is dropped rather than surfaced with no
+location a human can act on. Filtering here — once, at the source — means
+every downstream consumer (CLI, benchmark) sees only actionable, non-
+contradictory findings without each having to re-implement the same checks.
 """
 
 from __future__ import annotations
@@ -63,16 +71,20 @@ creep — do NOT report it. Only report a change when NO obligation, read in ful
 calls for it. (When you are genuinely unsure whether any obligation covers a
 change, still report it — bias toward surfacing the unexplained.)
 
-For each unrequested change return its `kind`, a short `rationale`, and
-`diff_refs`: the labels (like `path#0`) of the hunks it concerns. Do not report
-changes that a listed obligation requires. If every change is requested, return
-an empty list."""
+For each unrequested change return its `kind`, a short `rationale`,
+`diff_refs` (the labels, like `path#0`, of the hunks it concerns), and
+`requested_by_obligation`: re-check the change one more time against every
+obligation and set this true if, on that re-check, some obligation actually
+requires it after all — such a change must NOT be reported as unrequested. Do
+not report changes that a listed obligation requires. If every change is
+requested, return an empty list."""
 
 
 class _Detected(StrictResponseModel):
     kind: UnrequestedChangeKind
     rationale: str
     diff_refs: list[str]
+    requested_by_obligation: bool
 
 
 class _Detections(StrictResponseModel):
@@ -92,7 +104,11 @@ def detect_unrequested_changes(
 
     changes = []
     for detected in result.unrequested_changes:
+        if detected.requested_by_obligation:
+            continue  # model's own re-check found this requested after all
         refs = resolve_refs(detected.diff_refs, label_to_ref)
+        if not refs:
+            continue  # no resolvable diff location for a human to act on
         changes.append(
             UnrequestedChange(kind=detected.kind, rationale=detected.rationale, diff_refs=refs)
         )

--- a/tests/benchmark/test_coverage.py
+++ b/tests/benchmark/test_coverage.py
@@ -281,6 +281,7 @@ def test_archetype_8_unrequested_change_gap_matches_via_its_obligation(tmp_path)
                         "kind": "public_interface",
                         "rationale": "checkout gained a tax_rate parameter and rounding; not requested.",
                         "diff_refs": [cart_ref],
+                        "requested_by_obligation": False,
                     }
                 ]
             },
@@ -354,6 +355,7 @@ def test_archetype_8_unrequested_change_metric_does_not_route_through_coverage(t
                         "kind": "public_interface",
                         "rationale": "checkout gained a tax_rate parameter and rounding; not requested.",
                         "diff_refs": [cart_ref],
+                        "requested_by_obligation": False,
                     }
                 ]
             },

--- a/tests/coverage/test_unrequested.py
+++ b/tests/coverage/test_unrequested.py
@@ -46,6 +46,7 @@ def test_archetype_8_public_interface_change_is_flagged(tmp_path):
                 "kind": "public_interface",
                 "rationale": "checkout gained a tax_rate parameter and rounding; not requested.",
                 "diff_refs": [f"{cart}#0"],
+                "requested_by_obligation": False,
             }
         ]
     }
@@ -70,15 +71,44 @@ def test_nothing_flagged_when_all_changes_are_requested(tmp_path):
 
 
 def test_unknown_hunk_labels_are_dropped(tmp_path):
+    # A finding with no resolvable location is noise a human can't act on
+    # (#121) -- dropped entirely, not surfaced with an empty diff_refs.
     change_set = _archetype_change_set("08-unrequested-change", tmp_path)
     obligations = [_obligation("x", "obligation", ObligationType.FUNCTIONAL)]
     response = {
         "unrequested_changes": [
-            {"kind": "dependency", "rationale": "...", "diff_refs": ["ghost.py#9"]}
+            {
+                "kind": "dependency",
+                "rationale": "...",
+                "diff_refs": ["ghost.py#9"],
+                "requested_by_obligation": False,
+            }
         ]
     }
     changes = detect_unrequested_changes(obligations, change_set, _client_returning(response))
-    assert changes[0].diff_refs == []  # unknown label dropped, not crashed
+    assert changes == []
+
+
+def test_change_the_model_judges_requested_is_not_emitted(tmp_path):
+    # #121: a detection whose own requested_by_obligation re-check comes back
+    # true must not be emitted, even though the model also included it in the
+    # list -- guards against exactly the self-contradictory finding seen in
+    # dogfooding (rationale concluding "not unrequested" but still reported).
+    change_set = _archetype_change_set("08-unrequested-change", tmp_path)
+    cart = _source_file(change_set, "cart.py")
+    obligations = [_obligation("x", "obligation", ObligationType.FUNCTIONAL)]
+    response = {
+        "unrequested_changes": [
+            {
+                "kind": "adjacent_behavior",
+                "rationale": "...the exact implementation choice is requested, so this is not unrequested.",
+                "diff_refs": [f"{cart}#0"],
+                "requested_by_obligation": True,
+            }
+        ]
+    }
+    changes = detect_unrequested_changes(obligations, change_set, _client_returning(response))
+    assert changes == []
 
 
 def test_unrequested_change_round_trips_through_persistence(tmp_path):
@@ -87,7 +117,12 @@ def test_unrequested_change_round_trips_through_persistence(tmp_path):
     obligations = [_obligation("apply-discount", "Add apply_discount", ObligationType.FUNCTIONAL)]
     response = {
         "unrequested_changes": [
-            {"kind": "public_interface", "rationale": "checkout signature changed", "diff_refs": [f"{cart}#0"]}
+            {
+                "kind": "public_interface",
+                "rationale": "checkout signature changed",
+                "diff_refs": [f"{cart}#0"],
+                "requested_by_obligation": False,
+            }
         ]
     }
     change = detect_unrequested_changes(obligations, change_set, _client_returning(response))[0]


### PR DESCRIPTION
## Summary
- `detect_unrequested_changes` (M3.2) now drops a detection when its own `requested_by_obligation` re-check comes back true — guards against the model emitting a finding whose rationale concludes it's actually requested, which is exactly the self-contradictory finding dogfooding caught in #118.
- It also now drops detections whose hunk labels don't resolve to a real diff region, at the source, so the CLI path stops rendering bare `?` findings without needing its own copy of the check — brings it in line with the benchmark path's existing (`_unrequested_finding`) behavior.

## Dogfood
Ran `acceptance decompose` + `acceptance classify` against this PR's own diff (task text = issue #121's body, via `current-task.md`):
- All 5 derived obligations mapped `[addressed]` to `src/acceptance/coverage/unrequested.py`.
- One unrequested-change finding: the added docstring prose flagged `separable` — the known doc/comment-misclassification pattern already tracked in #122, not a new defect.

## Test plan
- [x] `pytest -q` — 366 passed
- [x] `ruff check src tests` — clean
- [x] New/updated unit tests: model's own `requested_by_obligation=true` self-check is dropped; unresolved hunk labels are dropped entirely (not surfaced with empty `diff_refs`)

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)
