### PR TITLE
Classify co-located doc/comment updates as in_service, not separable

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,12 +1,11 @@
 # Task
-Fix unrequested-change detection (`detect_unrequested_changes`, M3.2) so it no longer emits spurious, location-less findings (diff_ref "?") whose rationale concludes the change IS requested. Surfaced dogfooding #118: `acceptance classify` on that PR's own diff emitted an unrequested-change finding whose rationale ended "...so this is not unrequested" — yet it was still reported as unrequested — with empty `diff_refs`, rendered by the CLI as a bare `?`.
+Fix the disposition classifier (`classify_dispositions`, `coverage/disposition.py`, M3.5.3) so it stops labeling a change's own doc/comment updates as `separable`. Surfaced dogfooding #118: `acceptance classify` flagged a docstring update that accompanies an in-service code change as `separable`, with a recommendation to "split into its own PR" — actively bad advice, since updating documentation to describe the change you are making is in service of that change, not a distinct unit of work.
 
 ## Constraints
-- The benchmark path already drops empty-`diff_refs` unrequested changes (`benchmark/coverage.py::_unrequested_finding` returns `None`); the CLI path (`run_classify` -> `render_classify`) must behave consistently — a finding with no location a human can act on is noise.
-- The M3.2 prompt already says "Do not report changes that a listed obligation requires" — the fix must address why the detector still emitted a change whose own rationale concludes it is requested, not just paper over the symptom.
-- Prefer fixing this once at the source (`detect_unrequested_changes`) over duplicating a drop-check in every consumer.
+- `classify_dispositions` treats a change as `separable` when it isn't load-bearing for an obligation's coverage and looks self-contained; a docstring/comment change co-located with and describing a code change that IS load-bearing should inherit `in_service` instead.
+- `separable` should mean "a coherent DISTINCT unit of work" — a docstring for the very change under review is not distinct work.
+- Prefer a deterministic structural fast-path over a new model call where the signal is checkable without semantic judgment, consistent with the classifier's existing hybrid design (structural fast-paths for the unambiguous cases, model judgment for the genuinely ambiguous rest).
 
 ## Completion expectations
 - Implementation
-- An unrequested change whose model-returned hunk labels don't resolve does not appear as a bare `?` finding in CLI output.
-- A synthetic check that a change the model itself judges "requested" is not emitted as unrequested.
+- A synthetic case where a PR edits a function AND updates its docstring/comments to match classifies the doc change as `in_service`, not `separable` with a "split into its own PR" recommendation.

--- a/src/acceptance/coverage/disposition.py
+++ b/src/acceptance/coverage/disposition.py
@@ -21,6 +21,11 @@ The classifier is a **hybrid** (chosen deliberately, not for cheapness):
      coverage-mapped region is never a bare unrequested flag.) Only `addressed`
      counts — a `partially_addressed` region can be the one that *violates* a
      leave-as-is obligation, which is ambiguous and escalates.
+   - a comment/docstring-only hunk in a file that also has an `addressed`
+     hunk elsewhere → documentation OF that in-service change → **in_service**
+     (#122). `separable` means "a coherent DISTINCT unit of work"; a docstring
+     update describing the very change under review is not distinct work, and
+     recommending it split into its own PR is actively bad advice.
    - a pure new-file addition that no obligation's coverage claims → new,
      self-contained work → **separable**.
 2. Everything else — edits to existing code with no clean coverage attribution —
@@ -86,7 +91,10 @@ for — into exactly one disposition, using the removability litmus:
 
 - in_service: NO — some obligation depends on this change (e.g. a refactor or
   helper the requested feature needs), even though nothing requested it
-  directly. Removing it would leave an obligation incomplete.
+  directly. Removing it would leave an obligation incomplete. A comment or
+  docstring update that describes an in-service code edit in the SAME file is
+  itself in_service — it is not distinct work, and it should never be
+  recommended for splitting into its own PR.
 - separable: YES, and it is coherent, self-contained work — valuable but a
   DISTINCT unit that belongs in its own PR / backlog item.
 - risky: YES, but it edits existing public interface, dependencies, or adjacent
@@ -120,6 +128,73 @@ def _addressed_regions(coverages: list[ImplementationCoverage]) -> set[tuple[str
 
 def _is_load_bearing(change: UnrequestedChange, addressed: set[tuple[str, str]]) -> bool:
     return any(_region_key(ref) in addressed for ref in change.diff_refs)
+
+
+def _addressed_files(coverages: list[ImplementationCoverage]) -> set[str]:
+    return {
+        ref.file
+        for coverage in coverages
+        if coverage.status == CoverageStatus.ADDRESSED
+        for ref in coverage.diff_refs
+    }
+
+
+def _hunk_content(ref: DiffRef, change_set: ChangeSet) -> str | None:
+    for file_change in change_set.files:
+        if file_change.path != ref.file:
+            continue
+        for hunk in file_change.hunks:
+            if hunk.header == ref.hunk_header:
+                return hunk.content
+    return None
+
+
+def _is_documentation_only_hunk(content: str) -> bool:
+    """True if every changed (+/-) line is blank, a `#` comment, or inside a
+    triple-quoted string — the hunk touches no executable code. Triple-quote
+    state is tracked from the hunk's own start: a hunk that opens partway
+    through an existing docstring (its opening `\"\"\"` outside the hunk's
+    context window) is a known heuristic limitation, not a silent gap."""
+    in_double = False
+    in_single = False
+    for line in content.splitlines():
+        if not line:
+            continue
+        prefix, text = line[0], line[1:]
+        stripped = text.strip()
+        was_in_string = in_double or in_single
+        if stripped.count('"""') % 2:
+            in_double = not in_double
+        if stripped.count("'''") % 2:
+            in_single = not in_single
+        if prefix not in "+-":
+            continue
+        is_doc_line = (
+            not stripped
+            or stripped.startswith("#")
+            or was_in_string
+            or '"""' in stripped
+            or "'''" in stripped
+        )
+        if not is_doc_line:
+            return False
+    return True
+
+
+def _is_documentation_of_in_service_change(
+    change: UnrequestedChange, addressed_files: set[str], change_set: ChangeSet
+) -> bool:
+    """A comment/docstring-only change, co-located in a file that also has an
+    `addressed` (in-service) hunk, is documentation OF that change (#122)."""
+    if not change.diff_refs:
+        return False
+    for ref in change.diff_refs:
+        if ref.file not in addressed_files:
+            return False
+        content = _hunk_content(ref, change_set)
+        if content is None or not _is_documentation_only_hunk(content):
+            return False
+    return True
 
 
 def _is_pure_addition(change: UnrequestedChange, change_set: ChangeSet) -> bool:
@@ -203,6 +278,7 @@ def classify_dispositions(
     """Classify each unrequested change's disposition (hybrid: deterministic
     fast-paths, model judgment for the ambiguous rest)."""
     addressed = _addressed_regions(coverages)
+    addressed_files = _addressed_files(coverages)
     results: list[DispositionedChange] = []
     for change in changes:
         if _is_load_bearing(change, addressed):
@@ -212,6 +288,17 @@ def classify_dispositions(
                     UnrequestedChangeDisposition.IN_SERVICE,
                     "The change's region is where an obligation is addressed; it is "
                     "load-bearing for that obligation.",
+                    decided_by="structural",
+                )
+            )
+        elif _is_documentation_of_in_service_change(change, addressed_files, change_set):
+            results.append(
+                _dispositioned(
+                    change,
+                    UnrequestedChangeDisposition.IN_SERVICE,
+                    "A comment/docstring-only change describing an in-service change "
+                    "in the same file; documentation of in-service work is itself "
+                    "in-service, not distinct work.",
                     decided_by="structural",
                 )
             )

--- a/tests/coverage/test_disposition.py
+++ b/tests/coverage/test_disposition.py
@@ -95,6 +95,87 @@ def test_pure_new_file_addition_is_separable_without_a_model_call():
     assert "splitting" in result[0].recommendation
 
 
+def test_docstring_update_of_in_service_change_is_in_service_without_a_model_call():
+    # #122: a PR edits a function (in-service, addressed) AND updates a
+    # module docstring describing it, in a separate hunk. The docstring hunk
+    # must classify in_service, not separable-with-a-split-recommendation.
+    code_hunk = _hunk(header="@@ -10,3 +10,3 @@")
+    doc_hunk = DiffHunk(
+        header="@@ -1,2 +1,4 @@", old_start=1, old_lines=2, new_start=1, new_lines=4,
+        content='+"""Module docstring.\n+\n+Now also describes the new behavior.\n+"""',
+    )
+    change_set = ChangeSet(base_revision="a", head_revision="b", files=[
+        FileChange(path="pkg.py", status="modified", category="source", hunks=[code_hunk, doc_hunk]),
+    ])
+    coverages = [ImplementationCoverage(
+        obligation_id="ob-1", status=CoverageStatus.ADDRESSED, rationale="here",
+        diff_refs=[DiffRef(file="pkg.py", hunk_header=code_hunk.header)],
+    )]
+    changes = [_change("pkg.py", header=doc_hunk.header, kind=UnrequestedChangeKind.OTHER)]
+
+    result = classify_dispositions(
+        changes, [_obligation("ob-1")], coverages, change_set,
+        ScopeExpansionPolicy.STRICT, _exploding_client(),
+    )
+
+    assert result[0].disposition is UnrequestedChangeDisposition.IN_SERVICE
+    assert result[0].decided_by == "structural"
+    assert result[0].recommendation is None
+
+
+def test_comment_only_hunk_in_unaddressed_file_still_escalates_to_the_model():
+    # The docstring heuristic only fires when the SAME file also has an
+    # addressed hunk (#122's "documentation OF an in-service change"); a
+    # comment-only change with no in-service sibling in that file is still
+    # genuinely ambiguous and escalates.
+    doc_hunk = DiffHunk(
+        header="@@ -1 +1 @@", old_start=1, old_lines=1, new_start=1, new_lines=1,
+        content="+# just a comment, no addressed code in this file",
+    )
+    change_set = ChangeSet(base_revision="a", head_revision="b", files=[
+        FileChange(path="notes.py", status="modified", category="source", hunks=[doc_hunk]),
+    ])
+    changes = [_change("notes.py", header=doc_hunk.header, kind=UnrequestedChangeKind.OTHER)]
+    client = client_dispatching({"_DispositionJudgment": {
+        "disposition": "separable", "rationale": "unrelated comment",
+    }})
+
+    result = classify_dispositions(
+        changes, [_obligation("ob-1")], [], change_set,
+        ScopeExpansionPolicy.STRICT, client,
+    )
+
+    assert result[0].decided_by == "model"
+
+
+def test_hunk_mixing_code_and_comments_does_not_shortcut_to_in_service():
+    # A hunk that changes real code (not just comments/docstring) must not be
+    # mistaken for documentation, even if co-located with an addressed hunk.
+    code_hunk = _hunk(header="@@ -10,3 +10,3 @@")
+    mixed_hunk = DiffHunk(
+        header="@@ -20,2 +20,3 @@", old_start=20, old_lines=2, new_start=20, new_lines=3,
+        content="+# a helpful comment\n+result = compute(x) + 1",
+    )
+    change_set = ChangeSet(base_revision="a", head_revision="b", files=[
+        FileChange(path="pkg.py", status="modified", category="source", hunks=[code_hunk, mixed_hunk]),
+    ])
+    coverages = [ImplementationCoverage(
+        obligation_id="ob-1", status=CoverageStatus.ADDRESSED, rationale="here",
+        diff_refs=[DiffRef(file="pkg.py", hunk_header=code_hunk.header)],
+    )]
+    changes = [_change("pkg.py", header=mixed_hunk.header, kind=UnrequestedChangeKind.OTHER)]
+    client = client_dispatching({"_DispositionJudgment": {
+        "disposition": "separable", "rationale": "extra computation",
+    }})
+
+    result = classify_dispositions(
+        changes, [_obligation("ob-1")], coverages, change_set,
+        ScopeExpansionPolicy.STRICT, client,
+    )
+
+    assert result[0].decided_by == "model"
+
+
 def test_partially_addressed_overlap_does_not_shortcut_to_in_service():
     # A partially_addressed region can be the one that *violates* a leave-as-is
     # obligation (archetype #8), so it must NOT deterministically become


### PR DESCRIPTION
## Summary
- `classify_dispositions` (M3.5.3) gains a deterministic structural fast-path: a comment/docstring-only hunk in a file that also has an `addressed` (in-service) hunk elsewhere is documentation OF that change — itself `in_service`, not distinct work. Fixes the dogfooding-caught bug where a docstring update accompanying a code change was labeled `separable` with a "split into its own PR" recommendation.
- The `_is_documentation_only_hunk` heuristic scans a hunk's changed lines for blank/`#`-comment/triple-quoted-string content only — no repo access or full-file AST needed, consistent with the classifier's existing structural/model hybrid design.
- The model prompt (for the genuinely ambiguous rest — e.g. a doc-only hunk in a file with no addressed code) gets a matching clarifying line as defense-in-depth.

## Dogfood
Ran `acceptance decompose` + `acceptance classify` against this PR's own diff (task text = issue #122's body, via `current-task.md`):
- All 6 derived obligations mapped `[addressed]` to `src/acceptance/coverage/disposition.py` (or the test file for the synthetic-test obligation).
- Zero unrequested changes flagged.

## Test plan
- [x] `pytest -q` — 369 passed
- [x] `ruff check src tests` — clean
- [x] New tests: synthetic function-edit + docstring-update case classifies `in_service` (matches the issue's acceptance criterion); comment-only hunk in a file with no addressed code still escalates to the model; a hunk mixing real code with comments doesn't false-positive into the structural path

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)
