### PR TITLE
Classify same-diff cross-file import linkage as in_service

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,11 +1,12 @@
 # Task
-Fix the disposition classifier (`classify_dispositions`, `coverage/disposition.py`, M3.5.3) so it stops labeling a change's own doc/comment updates as `separable`. Surfaced dogfooding #118: `acceptance classify` flagged a docstring update that accompanies an in-service code change as `separable`, with a recommendation to "split into its own PR" — actively bad advice, since updating documentation to describe the change you are making is in service of that change, not a distinct unit of work.
+Fix the disposition classifier (`classify_dispositions`, `coverage/disposition.py`, M3.5.3) so it stops calling a load-bearing cross-file rename `separable`. Surfaced dogfooding M5.4 (#28): `parse_test_function` was promoted from a private helper in `extraction.py` to public, in the same diff as `weak_patterns.py` adding `from acceptance.evidence.extraction import parse_test_function`. `acceptance classify` flagged the rename as an unrequested change and called it `separable`, recommending it be split into its own PR — wrong, since reverting the rename would break the import the same diff depends on.
 
 ## Constraints
-- `classify_dispositions` treats a change as `separable` when it isn't load-bearing for an obligation's coverage and looks self-contained; a docstring/comment change co-located with and describing a code change that IS load-bearing should inherit `in_service` instead.
-- `separable` should mean "a coherent DISTINCT unit of work" — a docstring for the very change under review is not distinct work.
-- Prefer a deterministic structural fast-path over a new model call where the signal is checkable without semantic judgment, consistent with the classifier's existing hybrid design (structural fast-paths for the unambiguous cases, model judgment for the genuinely ambiguous rest).
+- The removability litmus's deterministic fast-path already checks coverage-region overlap and pure-new-file-addition; it does not check whether a changed/renamed symbol is imported and used by another file changed in the SAME diff — direct structural evidence sitting in the diff, not something requiring semantic judgment.
+- The model-judgment fallback also missed this case; the fix should not rely solely on sharpening the model prompt.
+- This is a general, structural signal — not specific to this repo or this instance.
 
 ## Completion expectations
 - Implementation
-- A synthetic case where a PR edits a function AND updates its docstring/comments to match classifies the doc change as `in_service`, not `separable` with a "split into its own PR" recommendation.
+- A synthetic case: file A renames/exports a symbol; file B (changed in the same diff) imports and uses it. The rename in file A classifies `in_service`, not `separable`, without a model call (the new fast-path).
+- Existing disposition tests (fast-path and model-judgment paths) are unaffected.

--- a/src/acceptance/coverage/disposition.py
+++ b/src/acceptance/coverage/disposition.py
@@ -26,6 +26,11 @@ The classifier is a **hybrid** (chosen deliberately, not for cheapness):
      (#122). `separable` means "a coherent DISTINCT unit of work"; a docstring
      update describing the very change under review is not distinct work, and
      recommending it split into its own PR is actively bad advice.
+   - a symbol a change defines/renames/exports in one file is imported by
+     ANOTHER file changed in the same diff → **in_service** for that other
+     file's changes (#126). This is direct structural evidence sitting in the
+     diff itself (the import statement), not something requiring semantic
+     judgment — reverting the change would break the file that imports it.
    - a pure new-file addition that no obligation's coverage claims → new,
      self-contained work → **separable**.
 2. Everything else — edits to existing code with no clean coverage attribution —
@@ -47,6 +52,7 @@ governs how it is *treated*, not whether it was found.
 
 from __future__ import annotations
 
+import re
 from typing import Literal
 
 from acceptance.config import ScopeExpansionPolicy
@@ -94,7 +100,10 @@ for — into exactly one disposition, using the removability litmus:
   directly. Removing it would leave an obligation incomplete. A comment or
   docstring update that describes an in-service code edit in the SAME file is
   itself in_service — it is not distinct work, and it should never be
-  recommended for splitting into its own PR.
+  recommended for splitting into its own PR. A symbol this change defines or
+  renames that is imported and used by ANOTHER file changed in this SAME diff
+  is also in_service for that usage — removing it would break the file that
+  imports it.
 - separable: YES, and it is coherent, self-contained work — valuable but a
   DISTINCT unit that belongs in its own PR / backlog item.
 - risky: YES, but it edits existing public interface, dependencies, or adjacent
@@ -195,6 +204,85 @@ def _is_documentation_of_in_service_change(
         if content is None or not _is_documentation_only_hunk(content):
             return False
     return True
+
+
+def _module_name(path: str) -> str:
+    return path.rsplit("/", 1)[-1].removesuffix(".py")
+
+
+_DEF_RE = re.compile(r"^(?:async\s+)?def\s+(\w+)\s*\(")
+_CLASS_RE = re.compile(r"^class\s+(\w+)\s*[:(]")
+_ASSIGN_RE = re.compile(r"^(\w+)\s*(?::[^=]+)?=(?!=)")
+_IMPORT_RE = re.compile(r"^from\s+([\w.]+)\s+import\s+(.+)$")
+
+
+def _defined_symbols(content: str) -> set[str]:
+    """Top-level names a hunk's added lines define, rename, or (re-)export —
+    a `def`/`class`/simple assignment at column 0. A structural heuristic over
+    the diff text itself, no full-file parse needed."""
+    names: set[str] = set()
+    for line in content.splitlines():
+        if not line or line[0] != "+":
+            continue
+        rest = line[1:]
+        if rest[:1] in (" ", "\t"):
+            continue  # indented -- not top-level (e.g. a nested def/assignment)
+        stripped = rest.strip()
+        for pattern in (_DEF_RE, _CLASS_RE, _ASSIGN_RE):
+            if match := pattern.match(stripped):
+                names.add(match.group(1))
+                break
+    return names
+
+
+def _imported_names(content: str, module: str) -> set[str]:
+    """Names a hunk's added lines import via `from <module> import ...`,
+    matched against the LEAF module component (`acceptance.evidence.extraction`
+    matches module="extraction"). Known limitation, shared with extraction.py's
+    `_production_import_names`: a plain `import module; module.f()` isn't
+    traced, only from-imports."""
+    names: set[str] = set()
+    for line in content.splitlines():
+        if not line or line[0] != "+":
+            continue
+        match = _IMPORT_RE.match(line[1:].strip())
+        if not match or match.group(1).rsplit(".", 1)[-1] != module:
+            continue
+        for name in match.group(2).split(","):
+            name = name.strip().strip("()").split(" as ")[0].strip()
+            if name:
+                names.add(name)
+    return names
+
+
+def _is_load_bearing_via_cross_file_import(
+    change: UnrequestedChange, change_set: ChangeSet
+) -> bool:
+    """A symbol this change defines/renames/exports in one file, imported by
+    ANOTHER file changed in the same diff, is load-bearing for that other
+    file's changes (#126) -- direct structural evidence sitting in the diff,
+    no semantic judgment required."""
+    changed_files = {ref.file for ref in change.diff_refs}
+    if len(changed_files) != 1:
+        return False  # scope to the common case: a rename/export in one file
+    (file_path,) = changed_files
+    module = _module_name(file_path)
+
+    defined: set[str] = set()
+    for ref in change.diff_refs:
+        content = _hunk_content(ref, change_set)
+        if content:
+            defined |= _defined_symbols(content)
+    if not defined:
+        return False
+
+    for file_change in change_set.files:
+        if file_change.path == file_path:
+            continue
+        for hunk in file_change.hunks:
+            if _imported_names(hunk.content, module) & defined:
+                return True
+    return False
 
 
 def _is_pure_addition(change: UnrequestedChange, change_set: ChangeSet) -> bool:
@@ -299,6 +387,17 @@ def classify_dispositions(
                     "A comment/docstring-only change describing an in-service change "
                     "in the same file; documentation of in-service work is itself "
                     "in-service, not distinct work.",
+                    decided_by="structural",
+                )
+            )
+        elif _is_load_bearing_via_cross_file_import(change, change_set):
+            results.append(
+                _dispositioned(
+                    change,
+                    UnrequestedChangeDisposition.IN_SERVICE,
+                    "A symbol this change defines or renames is imported by another "
+                    "file changed in the same diff; reverting it would break that "
+                    "file's changes.",
                     decided_by="structural",
                 )
             )

--- a/tests/coverage/test_disposition.py
+++ b/tests/coverage/test_disposition.py
@@ -176,6 +176,72 @@ def test_hunk_mixing_code_and_comments_does_not_shortcut_to_in_service():
     assert result[0].decided_by == "model"
 
 
+def test_symbol_renamed_and_imported_by_another_changed_file_is_in_service():
+    # #126: file A renames/exports a symbol; file B (changed in the same diff)
+    # imports and uses it. The rename in file A must classify in_service, not
+    # separable -- reverting it would break file B's changes.
+    rename_hunk = DiffHunk(
+        header="@@ -100,3 +100,3 @@", old_start=100, old_lines=3, new_start=100, new_lines=3,
+        content="+def parse_test_function(source: str):\n+    ...",
+    )
+    import_hunk = DiffHunk(
+        header="@@ -1,2 +1,3 @@", old_start=1, old_lines=2, new_start=1, new_lines=3,
+        content="+from acceptance.evidence.extraction import parse_test_function\n+\n+detect_weak_patterns()",
+    )
+    change_set = ChangeSet(base_revision="a", head_revision="b", files=[
+        FileChange(
+            path="src/acceptance/evidence/extraction.py", status="modified",
+            category="source", hunks=[rename_hunk],
+        ),
+        FileChange(
+            path="src/acceptance/evidence/weak_patterns.py", status="added",
+            category="source", hunks=[import_hunk],
+        ),
+    ])
+    changes = [_change(
+        "src/acceptance/evidence/extraction.py", header=rename_hunk.header,
+        kind=UnrequestedChangeKind.INTERNAL,
+    )]
+
+    result = classify_dispositions(
+        changes, [_obligation("ob-1")], [], change_set,
+        ScopeExpansionPolicy.STRICT, _exploding_client(),
+    )
+
+    assert result[0].disposition is UnrequestedChangeDisposition.IN_SERVICE
+    assert result[0].decided_by == "structural"
+    assert result[0].recommendation is None
+
+
+def test_defined_symbol_not_imported_elsewhere_still_escalates_to_the_model():
+    # A renamed symbol that nothing else in the diff imports is genuinely
+    # ambiguous (could still be in_service via coverage, or a distinct helper)
+    # and must still escalate rather than false-positive to in_service.
+    rename_hunk = DiffHunk(
+        header="@@ -100,2 +100,2 @@", old_start=100, old_lines=2, new_start=100, new_lines=2,
+        content="+def unused_helper():\n+    ...",
+    )
+    other_hunk = DiffHunk(
+        header="@@ -1,1 +1,1 @@", old_start=1, old_lines=1, new_start=1, new_lines=1,
+        content="+x = 1",
+    )
+    change_set = ChangeSet(base_revision="a", head_revision="b", files=[
+        FileChange(path="a.py", status="modified", category="source", hunks=[rename_hunk]),
+        FileChange(path="b.py", status="modified", category="source", hunks=[other_hunk]),
+    ])
+    changes = [_change("a.py", header=rename_hunk.header, kind=UnrequestedChangeKind.INTERNAL)]
+    client = client_dispatching({"_DispositionJudgment": {
+        "disposition": "separable", "rationale": "unused new helper",
+    }})
+
+    result = classify_dispositions(
+        changes, [_obligation("ob-1")], [], change_set,
+        ScopeExpansionPolicy.STRICT, client,
+    )
+
+    assert result[0].decided_by == "model"
+
+
 def test_partially_addressed_overlap_does_not_shortcut_to_in_service():
     # A partially_addressed region can be the one that *violates* a leave-as-is
     # obligation (archetype #8), so it must NOT deterministically become


### PR DESCRIPTION
## Summary
- `classify_dispositions` (M3.5.3) gains a third deterministic structural fast-path: a symbol a change defines/renames/exports in one file, imported via a from-import by another file changed in the **same diff**, is `in_service` — not `separable` — for that other file's changes. Fixes the dogfooding-caught bug where promoting `parse_test_function` from private to public (M5.4, needed by `weak_patterns.py`'s new `from acceptance.evidence.extraction import parse_test_function` in the same diff) was flagged `separable` with a "split into its own PR" recommendation, even though reverting it would break the import.
- Detection is purely structural over hunk diff text (regex over `+` lines for top-level `def`/`class`/assignment on the defining side, `from <module> import ...` on the importing side) — no repo access or full-file parse, matching the existing hybrid design and the documented from-import-only limitation already noted in `extraction.py`'s `_production_import_names`.
- The model prompt gets a matching clarifying line as defense-in-depth for cases the heuristic doesn't see (e.g. plain `import module; module.f()` usage).

## Dogfood
Ran `acceptance decompose` + `acceptance classify` against this PR's own diff (task text = issue #126's body, via `current-task.md`):
- 5/6 derived obligations mapped `[addressed]`; the 6th ("preserve existing tests passing") correctly has no diff region to point to (`[unclear] -> no corresponding change`) since it's a non-regression obligation, not a positive change.
- 3 unrequested-change findings (scope-of-the-new-heuristic notes, an internal-helper note, and an extra negative-case test) — all correctly classified `[in_service]`, none `separable`. That itself validates both this fix and #122's docstring/comment fix working together on the very diff that exercises them.

## Test plan
- [x] `pytest -q` — 371 passed
- [x] `ruff check src tests` — clean
- [x] New tests: the issue's exact synthetic case (file A renames/exports, file B imports+uses in the same diff → `in_service`, no model call); a renamed symbol nothing else imports still escalates to the model (no false positive)

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)
