### PR TITLE
Judge and record whether the diff resolves each open question

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,12 +1,12 @@
 # Task
-Fix the disposition classifier (`classify_dispositions`, `coverage/disposition.py`, M3.5.3) so it stops calling a load-bearing cross-file rename `separable`. Surfaced dogfooding M5.4 (#28): `parse_test_function` was promoted from a private helper in `extraction.py` to public, in the same diff as `weak_patterns.py` adding `from acceptance.evidence.extraction import parse_test_function`. `acceptance classify` flagged the rename as an unrequested change and called it `separable`, recommending it be split into its own PR — wrong, since reverting the rename would break the import the same diff depends on.
+Open questions from decomposition are silently dropped downstream of `decompose`, and never gate the verdict. Surfaced dogfooding M4.1: `run_classify` (`cli.py`) and `classify_case` (`benchmark/coverage.py`) both call `decompose(...).obligations` — only the obligations are kept; `.open_questions` is computed and then discarded. Only `render_decomposition` (the standalone `decompose` command's renderer) ever shows open questions to a human at all. This connects to two CLAUDE.md invariants: "Uncertainty is first-class" (open questions are a valid, expected output, not something to quietly discard) and "Positive results are bounded" (a review can't honestly report "no material gaps" while an open question about what the obligation even means remains unresolved).
 
 ## Constraints
-- The removability litmus's deterministic fast-path already checks coverage-region overlap and pure-new-file-addition; it does not check whether a changed/renamed symbol is imported and used by another file changed in the SAME diff — direct structural evidence sitting in the diff, not something requiring semantic judgment.
-- The model-judgment fallback also missed this case; the fix should not rely solely on sharpening the model prompt.
-- This is a general, structural signal — not specific to this repo or this instance.
+- Nearer-term / smaller scope for this task: `Review`/the `classify` pipeline must carry `open_questions` through from decomposition to CLI output, not drop them at the first `.obligations`-only call site — even before M7's verdict machinery exists.
+- The completion verdict itself (M7.2, #33) is out of scope here — that milestone hasn't been reached yet in the plan sequence. Instead, #33's own scope must be updated to explicitly name unresolved open questions as blocking a `no-material-gaps` verdict, so the requirement isn't lost when M7.2 is eventually built.
+- What "resolved" means mechanically is a reviewer/human judgment call made by reading whether the diff answers the question — not a new mechanism this task needs to build or a formal decision record; that judgment is deferred to whoever reads the review (or a future M7.2 capability), not decided here.
 
 ## Completion expectations
-- Implementation
-- A synthetic case: file A renames/exports a symbol; file B (changed in the same diff) imports and uses it. The rename in file A classifies `in_service`, not `separable`, without a model call (the new fast-path).
-- Existing disposition tests (fast-path and model-judgment paths) are unaffected.
+- Implementation: `open_questions` threaded through `Review`, `run_classify`, and `classify_case`; `classify`'s CLI output (`render_classify`) shows open questions the same way `decompose`'s does.
+- Unit tests: rendering with and without open questions; existing coverage/disposition/CLI tests unaffected.
+- #33 updated to explicitly scope in the open_questions -> verdict wiring for when M7.2 lands.

--- a/current-task.md
+++ b/current-task.md
@@ -1,12 +1,14 @@
 # Task
-Open questions from decomposition are silently dropped downstream of `decompose`, and never gate the verdict. Surfaced dogfooding M4.1: `run_classify` (`cli.py`) and `classify_case` (`benchmark/coverage.py`) both call `decompose(...).obligations` — only the obligations are kept; `.open_questions` is computed and then discarded. Only `render_decomposition` (the standalone `decompose` command's renderer) ever shows open questions to a human at all. This connects to two CLAUDE.md invariants: "Uncertainty is first-class" (open questions are a valid, expected output, not something to quietly discard) and "Positive results are bounded" (a review can't honestly report "no material gaps" while an open question about what the obligation even means remains unresolved).
+Open questions from decomposition are silently dropped downstream of `decompose`, and never gate the verdict. Surfaced dogfooding M4.1: `run_classify` (`cli.py`) and `classify_case` (`benchmark/coverage.py`) both call `decompose(...).obligations` — only the obligations are kept; `.open_questions` is computed and then discarded. Only `render_decomposition` (the standalone `decompose` command's renderer) ever shows open questions to a human at all.
 
 ## Constraints
-- Nearer-term / smaller scope for this task: `Review`/the `classify` pipeline must carry `open_questions` through from decomposition to CLI output, not drop them at the first `.obligations`-only call site — even before M7's verdict machinery exists.
-- The completion verdict itself (M7.2, #33) is out of scope here — that milestone hasn't been reached yet in the plan sequence. Instead, #33's own scope must be updated to explicitly name unresolved open questions as blocking a `no-material-gaps` verdict, so the requirement isn't lost when M7.2 is eventually built.
-- What "resolved" means mechanically is a reviewer/human judgment call made by reading whether the diff answers the question — not a new mechanism this task needs to build or a formal decision record; that judgment is deferred to whoever reads the review (or a future M7.2 capability), not decided here.
+- `Review`/the `classify` pipeline must carry open questions through from decomposition to CLI output, not drop them at the first `.obligations`-only call site.
+- When the diff itself makes the answer to an open question clear, that must be noted and the question recorded as resolved — not shown as perpetually "unresolved" on every re-run regardless of whether the diff already answers it. When the diff doesn't answer it, it stays flagged open.
+- What counts as "resolved" beyond "the diff itself makes the answer clear" is reviewer judgment; the tool's job is to make and record that specific judgment, not to build a separate manual sign-off mechanism.
+
+## Scope exclusions
+- The completion verdict itself (M7.2, #33) — whether an unresolved open question blocks a `no-material-gaps` result — is out of scope for this task; that milestone hasn't been reached yet in the plan sequence. #33's own scope has already been updated separately (outside this diff) to carry that requirement forward.
 
 ## Completion expectations
-- Implementation: `open_questions` threaded through `Review`, `run_classify`, and `classify_case`; `classify`'s CLI output (`render_classify`) shows open questions the same way `decompose`'s does.
-- Unit tests: rendering with and without open questions; existing coverage/disposition/CLI tests unaffected.
-- #33 updated to explicitly scope in the open_questions -> verdict wiring for when M7.2 lands.
+- Implementation: open questions threaded through `Review`, `run_classify`, and `classify_case`; a judgment step decides, per open question, whether the diff resolves it, and records that judgment (not just displays it transiently); `classify`'s CLI output shows resolved questions (with the answer and its source) separately from still-open ones.
+- Unit tests: resolved and still-open cases, including a question the model doesn't return a judgment for (must stay open, not vanish); existing coverage/disposition/CLI tests unaffected.

--- a/current-task.md
+++ b/current-task.md
@@ -11,4 +11,4 @@ Open questions from decomposition are silently dropped downstream of `decompose`
 
 ## Completion expectations
 - Implementation: open questions threaded through `Review`, `run_classify`, and `classify_case`; a judgment step decides, per open question, whether the diff resolves it, and records that judgment (not just displays it transiently); `classify`'s CLI output shows resolved questions (with the answer and its source) separately from still-open ones.
-- Unit tests: resolved and still-open cases, including a question the model doesn't return a judgment for (must stay open, not vanish); existing coverage/disposition/CLI tests unaffected.
+- Unit tests: resolved and still-open cases, including a question the model doesn't return a judgment for (must stay open, not vanish); coverage/disposition tests are untouched by this change; existing CLI rendering tests are updated to match the new open-question output format and continue to pass.

--- a/src/acceptance/benchmark/coverage.py
+++ b/src/acceptance/benchmark/coverage.py
@@ -118,7 +118,8 @@ def classify_case(
     `case`. The benchmark's assembled static pipeline — each capability lands
     here as it ships so its §11.1 metric is scored (M3-M5)."""
     parsed = parse_task_file(case.inputs.task_text)
-    obligations = decompose(parsed, client).obligations
+    decomposition = decompose(parsed, client)
+    obligations = decomposition.obligations
     repo = Path(case.inputs.repo)
     change_set = extract_change_set(
         repo, case.inputs.base_revision, case.inputs.head_revision
@@ -156,6 +157,7 @@ def classify_case(
         reviewed_revision=case.inputs.head_revision,
         provenance=provenance_from(client),
         obligation_map=obligations,
+        open_questions=decomposition.open_questions,
         change_set=change_set,
         findings=findings,
     )

--- a/src/acceptance/benchmark/coverage.py
+++ b/src/acceptance/benchmark/coverage.py
@@ -31,6 +31,7 @@ from acceptance.change.diff import extract_change_set
 from acceptance.config import ScopeExpansionPolicy
 from acceptance.coverage.classify import CoverageStatus, ImplementationCoverage, classify_coverage
 from acceptance.coverage.disposition import DispositionedChange, classify_dispositions
+from acceptance.coverage.open_questions import apply_open_question_resolutions, resolve_open_questions
 from acceptance.coverage.unrequested import detect_unrequested_changes
 from acceptance.evidence.discovery import discover_tests
 from acceptance.evidence.discrimination import judge_discrimination
@@ -139,6 +140,8 @@ def classify_case(
     dispositioned = classify_dispositions(
         unrequested, obligations, coverages, change_set, policy, client
     )
+    resolutions = resolve_open_questions(decomposition.open_questions, change_set, client)
+    open_questions = apply_open_question_resolutions(decomposition.open_questions, resolutions)
 
     obligations_by_id = {obligation.id: obligation for obligation in obligations}
     findings = [
@@ -157,7 +160,7 @@ def classify_case(
         reviewed_revision=case.inputs.head_revision,
         provenance=provenance_from(client),
         obligation_map=obligations,
-        open_questions=decomposition.open_questions,
+        open_questions=open_questions,
         change_set=change_set,
         findings=findings,
     )

--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -29,7 +29,7 @@ from acceptance.llm import LLMError, Mode
 from acceptance.report import render_report
 from acceptance.requirement.obligations import Decomposition, Obligation, decompose
 from acceptance.requirement.task_file import parse_task_file
-from acceptance.review_state import ChangeSet, Review
+from acceptance.review_state import ChangeSet, OpenQuestion, Review
 from acceptance.review_store import ReviewStore
 
 
@@ -181,13 +181,20 @@ def render_change_set(change_set: ChangeSet) -> str:
 
 def run_classify(
     task: str, base: str, head: str | None, config: RunConfig, repo: str = "."
-) -> tuple[list[Obligation], list[ImplementationCoverage], list[DispositionedChange]]:
+) -> tuple[
+    list[Obligation], list[OpenQuestion], list[ImplementationCoverage], list[DispositionedChange]
+]:
     """Decompose a task, extract its change set, classify each obligation against
     the diff, flag unrequested changes and classify their dispositions — a live
-    end-to-end dogfood of M1 + M2 + M3.1 + M3.2 + M3.5.3."""
+    end-to-end dogfood of M1 + M2 + M3.1 + M3.2 + M3.5.3.
+
+    Open questions from decomposition are carried through (not dropped at
+    `.obligations`) so a reviewer sees them here too, not only when running
+    `decompose` standalone (#113)."""
     repo_path = Path(repo)
     parsed = parse_task_file(_read_task(task))
-    obligations = decompose(parsed, config.build_client()).obligations
+    decomposition = decompose(parsed, config.build_client())
+    obligations = decomposition.obligations
 
     task_ignore = _task_ignore_pattern(task, repo_path)
     extra_patterns = [task_ignore] if task_ignore else []
@@ -209,16 +216,24 @@ def run_classify(
         unrequested, obligations, coverages, change_set,
         config.scope_expansion_policy, config.build_client(),
     )
-    return obligations, coverages, dispositioned
+    return obligations, decomposition.open_questions, coverages, dispositioned
 
 
 def render_classify(
     obligations: list[Obligation],
+    open_questions: list[OpenQuestion],
     coverages: list[ImplementationCoverage],
     dispositioned: list[DispositionedChange],
 ) -> str:
     descriptions = {o.id: o.description for o in obligations}
-    lines = ["Implementation coverage (code only — not test evidence):"]
+    lines = ["Open questions (unresolved — may block judging whether obligations are met):"]
+    if open_questions:
+        for q in open_questions:
+            lines.append(f"  ? {q.id}: {q.question}")
+    else:
+        lines.append("  (none)")
+    lines.append("")
+    lines.append("Implementation coverage (code only — not test evidence):")
     if not coverages:
         lines.append("  (none)")
     for cov in coverages:
@@ -385,7 +400,7 @@ def main(argv: list[str] | None = None) -> int:
             temperature=args.temperature,
         )
         try:
-            obligations, coverages, dispositioned = run_classify(
+            obligations, open_questions, coverages, dispositioned = run_classify(
                 args.task, args.base, args.head, config, args.repo
             )
         except CliError as exc:
@@ -398,6 +413,7 @@ def main(argv: list[str] | None = None) -> int:
             print(
                 json.dumps(
                     {
+                        "open_questions": [q.to_dict() for q in open_questions],
                         "coverage": [c.to_dict() for c in coverages],
                         "unrequested_changes": [d.to_dict() for d in dispositioned],
                     },
@@ -405,7 +421,7 @@ def main(argv: list[str] | None = None) -> int:
                 )
             )
         else:
-            print(render_classify(obligations, coverages, dispositioned))
+            print(render_classify(obligations, open_questions, coverages, dispositioned))
         return 0
 
     parser.error(f"unknown command: {args.command}")

--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -24,6 +24,7 @@ from acceptance.change.diff import extract_change_set, extract_working_tree_chan
 from acceptance.config import DEFAULT_MODEL, RunConfig
 from acceptance.coverage.classify import ImplementationCoverage, classify_coverage
 from acceptance.coverage.disposition import DispositionedChange, classify_dispositions
+from acceptance.coverage.open_questions import apply_open_question_resolutions, resolve_open_questions
 from acceptance.coverage.unrequested import detect_unrequested_changes
 from acceptance.llm import LLMError, Mode
 from acceptance.report import render_report
@@ -216,7 +217,11 @@ def run_classify(
         unrequested, obligations, coverages, change_set,
         config.scope_expansion_policy, config.build_client(),
     )
-    return obligations, decomposition.open_questions, coverages, dispositioned
+    resolutions = resolve_open_questions(
+        decomposition.open_questions, change_set, config.build_client()
+    )
+    open_questions = apply_open_question_resolutions(decomposition.open_questions, resolutions)
+    return obligations, open_questions, coverages, dispositioned
 
 
 def render_classify(
@@ -226,10 +231,19 @@ def render_classify(
     dispositioned: list[DispositionedChange],
 ) -> str:
     descriptions = {o.id: o.description for o in obligations}
-    lines = ["Open questions (unresolved — may block judging whether obligations are met):"]
+    lines = ["Open questions:"]
     if open_questions:
         for q in open_questions:
-            lines.append(f"  ? {q.id}: {q.question}")
+            if q.resolved:
+                lines.append(f"  [resolved] {q.id}: {q.question}")
+                lines.append(f"      answer: {q.resolution_rationale}")
+                refs = ", ".join(link.ref for link in q.resolution_refs)
+                if refs:
+                    lines.append(f"      -> {refs}")
+            else:
+                lines.append(f"  [open] {q.id}: {q.question}")
+                if q.resolution_rationale:
+                    lines.append(f"      {q.resolution_rationale}")
     else:
         lines.append("  (none)")
     lines.append("")

--- a/src/acceptance/coverage/open_questions.py
+++ b/src/acceptance/coverage/open_questions.py
@@ -1,0 +1,149 @@
+"""Open-question resolution against the diff (#113, §7.3/§9.3).
+
+An `OpenQuestion` surfaced at decomposition time is a material ambiguity a
+reviewer would need answered before judging the obligations it bears on. It
+must not sit "unresolved" forever on every re-run: when the diff itself makes
+the answer clear, that has to be noted and recorded in the review state, not
+left as something only a human conversation happens to have concluded and the
+tool immediately forgets — CLAUDE.md's "structured, persisted review-state,
+not an unstructured model transcript" invariant applies here exactly as it
+does to findings.
+
+A semantic judgment (does this diff resolve this ambiguity), so a
+schema-constrained model call through the M0.4 harness — recorded for replay,
+never a live call in tests. Shape mirrors mapping.py/strength.py: a judgment
+type referencing `OpenQuestion` by id, plus an `apply_` function that writes
+the verdict back onto copies of the entity — not embedding `OpenQuestion`
+directly, which would need `review_state.py` to import back from here.
+"""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from acceptance.coverage.prompt import DiffRef, hunk_labels, render_diff_section, resolve_refs
+from acceptance.llm import ModelClient, StrictResponseModel
+from acceptance.model_base import PersistableModel
+from acceptance.review_state import ChangeSet, Link, OpenQuestion
+
+_SYSTEM_PROMPT = """\
+You judge whether a code diff resolves an OPEN QUESTION raised about a task —
+a material ambiguity a reviewer would otherwise need answered before judging
+whether the requested behavior was actually delivered.
+
+For each open question, decide:
+- resolved: the diff itself makes the answer clear — e.g. it implements one
+  of the possible interpretations unambiguously, or the question no longer
+  applies given what was actually built.
+- NOT resolved: the diff is silent on the question, or the code could still
+  reasonably be read either way.
+
+Only mark a question resolved when the diff ITSELF makes the answer clear —
+not by assumption, convention, or what would be reasonable; if you have to
+guess which reading the diff intends, it is not resolved. When resolved, cite
+`diff_refs` (labels like `path#0`) for the hunks that answer it, and a short
+`rationale` explaining what the diff shows. When not resolved, still return a
+short `rationale` (why the diff doesn't settle it) and leave `diff_refs`
+empty."""
+
+
+class OpenQuestionResolution(PersistableModel):
+    """Whether the diff resolves an open question raised at decomposition."""
+
+    question_id: str
+    resolved: bool
+    rationale: str
+    diff_refs: list[DiffRef] = Field(default_factory=list)
+
+
+class _Judged(StrictResponseModel):
+    question_id: str
+    resolved: bool
+    rationale: str
+    diff_refs: list[str]
+
+
+class _Judgments(StrictResponseModel):
+    resolutions: list[_Judged]
+
+
+def _render_prompt(open_questions: list[OpenQuestion], change_set: ChangeSet) -> str:
+    lines = ["## Open questions", ""]
+    for question in open_questions:
+        lines.append(f"- id={question.id}: {question.question}")
+    lines.append("")
+    lines.extend(render_diff_section(change_set))
+    return "\n".join(lines)
+
+
+def resolve_open_questions(
+    open_questions: list[OpenQuestion], change_set: ChangeSet, client: ModelClient
+) -> list[OpenQuestionResolution]:
+    """Judge each open question against the diff: resolved (with citation) or
+    still open. No open questions -> no model call."""
+    if not open_questions:
+        return []
+
+    label_to_ref = hunk_labels(change_set)
+    messages = [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {"role": "user", "content": _render_prompt(open_questions, change_set)},
+    ]
+    result = client.complete(messages, _Judgments)
+
+    valid_ids = {q.id for q in open_questions}
+    judged_ids: set[str] = set()
+    resolutions = []
+    for judged in result.resolutions:
+        if judged.question_id not in valid_ids:
+            continue  # model referenced an unknown question id -- ignore
+        judged_ids.add(judged.question_id)
+        resolutions.append(
+            OpenQuestionResolution(
+                question_id=judged.question_id,
+                resolved=judged.resolved,
+                rationale=judged.rationale,
+                diff_refs=resolve_refs(judged.diff_refs, label_to_ref),
+            )
+        )
+    # A question the model didn't return a judgment for stays open rather
+    # than silently vanishing from the output (uncertainty is first-class).
+    for question in open_questions:
+        if question.id not in judged_ids:
+            resolutions.append(
+                OpenQuestionResolution(
+                    question_id=question.id,
+                    resolved=False,
+                    rationale="No judgment was returned for this question.",
+                )
+            )
+    return resolutions
+
+
+def apply_open_question_resolutions(
+    open_questions: list[OpenQuestion], resolutions: list[OpenQuestionResolution]
+) -> list[OpenQuestion]:
+    """Return copies of `open_questions` with the resolution judgment written
+    back on — so a resolved question stays resolved on every later render/
+    persist, instead of the tool re-asking (and the answer only ever having
+    existed in a conversation)."""
+    by_id = {r.question_id: r for r in resolutions}
+    updated = []
+    for question in open_questions:
+        resolution = by_id.get(question.id)
+        if resolution is None:
+            updated.append(question)
+            continue
+        updated.append(
+            question.model_copy(
+                update={
+                    "resolved": resolution.resolved,
+                    "resolution_rationale": resolution.rationale,
+                    "resolution_refs": [
+                        Link(kind="code", ref=f"{ref.file}#{ref.hunk_header}")
+                        for ref in resolution.diff_refs
+                    ],
+                }
+            )
+        )
+    return updated

--- a/src/acceptance/coverage/prompt.py
+++ b/src/acceptance/coverage/prompt.py
@@ -35,13 +35,11 @@ def hunk_labels(change_set: ChangeSet) -> dict[str, DiffRef]:
     return labels
 
 
-def render_diff_prompt(obligations: list[Obligation], change_set: ChangeSet) -> str:
-    """Render obligations + the labeled diff for the model to reason over."""
-    lines = ["## Obligations", ""]
-    for obligation in obligations:
-        lines.append(f"- id={obligation.id} [{obligation.type.value}]: {obligation.description}")
-    lines.append("")
-    lines.append("## Diff")
+def render_diff_section(change_set: ChangeSet) -> list[str]:
+    """The `## Diff` block (labeled hunks), shared by every prompt that shows
+    the model a diff — factored out so each caller only supplies what comes
+    before it (obligations, open questions, ...)."""
+    lines = ["## Diff"]
     if not change_set.files:
         lines.append("(no changes)")
     for file_change in change_set.files:
@@ -52,6 +50,16 @@ def render_diff_prompt(obligations: list[Obligation], change_set: ChangeSet) -> 
         for index, hunk in enumerate(file_change.hunks):
             lines.append(f"[{hunk_label(file_change.path, index)}] {hunk.header}")
             lines.append(hunk.content)
+    return lines
+
+
+def render_diff_prompt(obligations: list[Obligation], change_set: ChangeSet) -> str:
+    """Render obligations + the labeled diff for the model to reason over."""
+    lines = ["## Obligations", ""]
+    for obligation in obligations:
+        lines.append(f"- id={obligation.id} [{obligation.type.value}]: {obligation.description}")
+    lines.append("")
+    lines.extend(render_diff_section(change_set))
     return "\n".join(lines)
 
 

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -337,6 +337,7 @@ class Review(_Model):
     declaration: BuilderDeclaration | None = None
     change_set: ChangeSet | None = None
     obligation_map: list[Obligation] = Field(default_factory=list)
+    open_questions: list[OpenQuestion] = Field(default_factory=list)
     findings: list[Finding] = Field(default_factory=list)
     limitations: list[str] = Field(default_factory=list)
     recommendation: str | None = None

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -209,17 +209,38 @@ class Obligation(_Model):
     evidence_class: EvidenceClassification | None = None
 
 
+class Link(_Model):
+    """A link to exact requirement text / code lines / test locations —
+    used by both `Finding` and `OpenQuestion.resolution_refs`. Defined here
+    (ahead of `OpenQuestion`) rather than by `Finding` alone, since both need
+    it and forward references don't resolve for pydantic model fields even
+    under `from __future__ import annotations`."""
+
+    kind: Literal["requirement", "code", "test"]
+    ref: str
+    text: str | None = None
+
+
 class OpenQuestion(_Model):
     """A material ambiguity in the task that needs user judgment (§7.3, §9.3).
 
     Surfaced instead of silently inventing an obligation — uncertainty is a
     first-class, expected output. `source_spans` link to the underspecified
-    task text."""
+    task text.
+
+    `resolved`/`resolution_rationale`/`resolution_refs` are set by
+    `coverage/open_questions.py`'s `apply_open_question_resolutions` (#113):
+    when the diff itself makes the answer clear, that judgment is recorded
+    here rather than left as something a conversation concluded and the tool
+    immediately forgets on the next run."""
 
     id: str
     question: str
     importance: Literal["critical", "normal"] = "normal"
     source_spans: list[TextSpan] = Field(default_factory=list)
+    resolved: bool = False
+    resolution_rationale: str | None = None
+    resolution_refs: list[Link] = Field(default_factory=list)
 
 
 class TestEvidence(_Model):
@@ -245,14 +266,6 @@ class ExecutionEvidence(_Model):
     coverage_of_obligation_lines: bool | None = None
     mutation_descriptor: str | None = None
     outcome: Literal["killed", "survived"] | None = None
-
-
-class Link(_Model):
-    """A finding's link to exact requirement text / code lines / test locations."""
-
-    kind: Literal["requirement", "code", "test"]
-    ref: str
-    text: str | None = None
 
 
 class Finding(_Model):

--- a/tests/coverage/test_open_questions.py
+++ b/tests/coverage/test_open_questions.py
@@ -1,0 +1,150 @@
+"""#113 follow-up: open questions must be judged against the diff, not left
+"unresolved" forever regardless of whether the diff actually answers them.
+
+Judgment is a schema-constrained model call; per the replay-first invariant
+these tests inject the recorded response via completion_fn — no live calls."""
+
+import tempfile
+
+from acceptance.coverage.open_questions import (
+    OpenQuestionResolution,
+    apply_open_question_resolutions,
+    resolve_open_questions,
+)
+from acceptance.llm import Mode, ModelClient, TranscriptStore
+from acceptance.review_state import ChangeSet, DiffHunk, FileChange, OpenQuestion
+from tests.support import client_returning
+
+
+def _question(question_id: str, text: str) -> OpenQuestion:
+    return OpenQuestion(id=question_id, question=text)
+
+
+def _change_set() -> ChangeSet:
+    hunk = DiffHunk(
+        header="@@ -1 +1 @@", old_start=1, old_lines=1, new_start=1, new_lines=1,
+        content="+result = f'-{amount}'",
+    )
+    return ChangeSet(base_revision="a", head_revision="b", files=[
+        FileChange(path="pkg.py", status="modified", category="source", hunks=[hunk]),
+    ])
+
+
+def _exploding_client() -> ModelClient:
+    def boom(**kwargs):
+        raise AssertionError("a model call was issued with no open questions to judge")
+
+    return ModelClient(
+        model="x", mode=Mode.RECORD, store=TranscriptStore(tempfile.mkdtemp()), completion_fn=boom
+    )
+
+
+def test_no_open_questions_issues_no_model_call():
+    resolutions = resolve_open_questions([], _change_set(), _exploding_client())
+    assert resolutions == []
+
+
+def test_diff_resolves_the_question():
+    change_set = _change_set()
+    question = _question("q-1", "Minus sign or parentheses for negative amounts?")
+    response = {
+        "resolutions": [
+            {
+                "question_id": "q-1",
+                "resolved": True,
+                "rationale": "The diff formats negatives with a leading minus sign.",
+                "diff_refs": ["pkg.py#0"],
+            }
+        ]
+    }
+
+    resolutions = resolve_open_questions([question], change_set, client_returning(response))
+
+    assert len(resolutions) == 1
+    assert resolutions[0].question_id == "q-1"
+    assert resolutions[0].resolved is True
+    assert resolutions[0].diff_refs
+    assert resolutions[0].diff_refs[0].file == "pkg.py"
+
+
+def test_diff_does_not_resolve_the_question():
+    change_set = _change_set()
+    question = _question("q-1", "What should happen on a network timeout?")
+    response = {
+        "resolutions": [
+            {
+                "question_id": "q-1",
+                "resolved": False,
+                "rationale": "The diff never touches network or timeout handling.",
+                "diff_refs": [],
+            }
+        ]
+    }
+
+    resolutions = resolve_open_questions([question], change_set, client_returning(response))
+
+    assert resolutions[0].resolved is False
+    assert resolutions[0].diff_refs == []
+
+
+def test_question_missing_from_the_model_response_stays_open():
+    # Uncertainty is first-class -- a question the model silently drops must
+    # not vanish, it must still show up as open rather than disappearing.
+    change_set = _change_set()
+    question = _question("q-1", "Some question the model forgets to answer")
+
+    resolutions = resolve_open_questions(
+        [question], change_set, client_returning({"resolutions": []})
+    )
+
+    assert len(resolutions) == 1
+    assert resolutions[0].resolved is False
+
+
+def test_unknown_question_id_in_response_is_dropped():
+    change_set = _change_set()
+    question = _question("q-1", "A real question")
+    response = {
+        "resolutions": [
+            {"question_id": "ghost", "resolved": True, "rationale": "...", "diff_refs": []}
+        ]
+    }
+
+    resolutions = resolve_open_questions([question], change_set, client_returning(response))
+
+    # The ghost id is dropped, but q-1 still gets its "stays open" fallback.
+    assert len(resolutions) == 1
+    assert resolutions[0].question_id == "q-1"
+    assert resolutions[0].resolved is False
+
+
+def test_apply_resolutions_writes_the_judgment_onto_the_question():
+    question = _question("q-1", "Minus sign or parentheses?")
+    resolution = OpenQuestionResolution(
+        question_id="q-1", resolved=True, rationale="Uses a minus sign.",
+        diff_refs=[],
+    )
+
+    updated = apply_open_question_resolutions([question], [resolution])
+
+    assert updated[0].resolved is True
+    assert updated[0].resolution_rationale == "Uses a minus sign."
+    # Original is untouched (apply_ returns copies, per the mapping.py/strength.py pattern).
+    assert question.resolved is False
+
+
+def test_apply_resolutions_leaves_unjudged_questions_open():
+    question = _question("q-1", "A question with no matching resolution")
+
+    updated = apply_open_question_resolutions([question], [])
+
+    assert updated[0].resolved is False
+    assert updated[0].resolution_rationale is None
+
+
+def test_open_question_resolution_round_trips_through_persistence():
+    resolution = OpenQuestionResolution(
+        question_id="q-1", resolved=True, rationale="...",
+        diff_refs=[],
+    )
+    assert OpenQuestionResolution.from_dict(resolution.to_dict()) == resolution

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -317,7 +317,12 @@ def test_render_classify_output():
     from acceptance.coverage.classify import CoverageStatus, DiffRef, ImplementationCoverage
     from acceptance.coverage.disposition import DispositionedChange
     from acceptance.coverage.unrequested import UnrequestedChange, UnrequestedChangeKind
-    from acceptance.review_state import Obligation, ObligationType, UnrequestedChangeDisposition
+    from acceptance.review_state import (
+        Obligation,
+        ObligationType,
+        OpenQuestion,
+        UnrequestedChangeDisposition,
+    )
 
     obligations = [
         Obligation(id="ob-1", description="Do the thing.", type=ObligationType.FUNCTIONAL,
@@ -347,7 +352,11 @@ def test_render_classify_output():
         )
     ]
 
-    rendered = render_classify(obligations, coverages, dispositioned)
+    open_questions = [OpenQuestion(id="q-1", question="Minus sign or parentheses?")]
+
+    rendered = render_classify(obligations, open_questions, coverages, dispositioned)
+    assert "Open questions" in rendered
+    assert "? q-1: Minus sign or parentheses?" in rendered
     assert "[addressed] ob-1: Do the thing." in rendered
     assert "pkg.py" in rendered
     assert "[not_addressed] ob-2: Handle the edge." in rendered
@@ -358,6 +367,14 @@ def test_render_classify_output():
     assert "[risky] (public_interface) checkout signature changed" in rendered
     assert "cart.py" in rendered
     assert "Scrutinize" in rendered
+
+
+def test_render_classify_shows_none_for_no_open_questions():
+    from acceptance.cli import render_classify
+
+    rendered = render_classify([], [], [], [])
+    assert "Open questions" in rendered
+    assert "(none)" in rendered
 
 
 # --- ignore patterns (#105) ---

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -318,6 +318,7 @@ def test_render_classify_output():
     from acceptance.coverage.disposition import DispositionedChange
     from acceptance.coverage.unrequested import UnrequestedChange, UnrequestedChangeKind
     from acceptance.review_state import (
+        Link,
         Obligation,
         ObligationType,
         OpenQuestion,
@@ -352,11 +353,21 @@ def test_render_classify_output():
         )
     ]
 
-    open_questions = [OpenQuestion(id="q-1", question="Minus sign or parentheses?")]
+    open_questions = [
+        OpenQuestion(id="q-1", question="Minus sign or parentheses?"),
+        OpenQuestion(
+            id="q-2", question="Should the total be tax-inclusive?",
+            resolved=True, resolution_rationale="The diff always adds tax after the subtotal.",
+            resolution_refs=[Link(kind="code", ref="pkg.py#@@ -1 +1 @@")],
+        ),
+    ]
 
     rendered = render_classify(obligations, open_questions, coverages, dispositioned)
     assert "Open questions" in rendered
-    assert "? q-1: Minus sign or parentheses?" in rendered
+    assert "[open] q-1: Minus sign or parentheses?" in rendered
+    assert "[resolved] q-2: Should the total be tax-inclusive?" in rendered
+    assert "answer: The diff always adds tax after the subtotal." in rendered
+    assert "pkg.py#@@ -1 +1 @@" in rendered
     assert "[addressed] ob-1: Do the thing." in rendered
     assert "pkg.py" in rendered
     assert "[not_addressed] ob-2: Handle the edge." in rendered


### PR DESCRIPTION
## Summary
Addresses the "nearer-term/smaller" scope of #113 (open questions raised at decomposition time were dropped everywhere downstream of `.obligations`, so only the standalone `decompose` command ever showed them) — revised after review to also cover the "note and close it" requirement, not just surfacing:

- `Review` gains an `open_questions: list[OpenQuestion]` field; `run_classify` (`cli.py`) and `classify_case` (`benchmark/coverage.py`) both carry `decompose(...).open_questions` through instead of discarding it at the first `.obligations` access.
- `resolve_open_questions` (`coverage/open_questions.py`) judges each open question against the diff — does the diff itself make the answer clear? Follows the same shape as `classify_coverage`/`judge_discrimination`: a judgment record (`OpenQuestionResolution`) referencing the question by id, plus `apply_open_question_resolutions`, which writes the verdict back onto copies of `OpenQuestion` (`resolved` / `resolution_rationale` / `resolution_refs`) — matching the established `apply_evidence_strength`/`apply_test_mapping` pattern. A resolved question stays resolved on every later render/persist instead of the tool re-asking (and the answer only ever having existed in a conversation).
- `render_classify` shows resolved questions (with the answer and its diff source) separately from still-open ones; `classify --json` includes them too.

**Not in this PR:** the verdict-blocking requirement ("a review with unresolved open questions cannot render `no-material-gaps`") — that's M7.2/#33, not yet reached in the milestone sequence. #33's body was updated separately to explicitly scope this in. **#113 is intentionally left open**, tracking that remainder.

**"What counts as resolved"** is the tool's own judgment (does the diff make the answer clear), recorded structurally — not a separate manual sign-off mechanism, per discussion.

## Review history (two real issues caught, both fixed)
1. An earlier version only surfaced open questions without ever marking any resolved — caught in review: *"classify shows unresolved open questions and you're asking to merge anyway."* Fixed by building the actual resolution-judgment capability described above. That version's `current-task.md` also phrased M7.2-owned concerns (verdict-blocking, "positive results are bounded") as if they were this task's own obligations, producing spurious `[unclear]` findings — fixed by moving that content into `current-task.md`'s `Scope exclusions` section (the §7.1 mechanism built for exactly this).
2. The next dogfood run still had one `[unclear]` finding, correctly flagged as a blocker rather than waved through: `current-task.md` claimed "existing coverage/disposition/CLI tests unaffected," which was literally false — `test_cli.py` was intentionally modified to match the new render format. Fixed by splitting that into two precise, non-contradictory claims. Re-running `decompose`/`classify` on the corrected file confirms both resolve cleanly.
3. That same run also surfaced a real, general tool gap: a prohibition-type obligation ("don't change coverage/disposition tests") always classifies `not_addressed` even when genuinely satisfied, because `classify_coverage`'s rubric has no status meaning "confirmed: nothing violates this." Verified independently (`git diff --stat`) that the underlying claim held. This is a general `classify_coverage` limitation, not specific to this PR — filed separately as **#133** rather than fixed here.

## Dogfood (final run)
- `decompose` raised one open question about this task: "What exact data shape should represent the recorded judgment and its source for a resolved open question?"
- `classify` on this diff correctly marked that question `[resolved]`, citing `OpenQuestionResolution`'s exact fields and the files that define them — the tool answered its own open question about itself, correctly, and recorded it as resolved.
- 6 obligations `[addressed]`, 1 (`keep-coverage-disposition-untouched`) `[not_addressed] -> no corresponding change` — the #133 limitation, independently confirmed true via `git diff --stat` (zero changes to `tests/coverage/test_disposition.py`/`test_unrequested.py`).
- Unrequested changes (the `render_diff_section` extraction, `Link`'s relocation, `Review.open_questions`, extra test coverage) all correctly classified `[in_service]`, not `separable`.

## Test plan
- [x] `pytest -q` — 380 passed
- [x] `ruff check src tests` — clean
- [x] New tests (`tests/coverage/test_open_questions.py`): resolved case, not-resolved case, a question the model returns no judgment for (must stay open, not vanish), unknown question id in the response (dropped, not crashed), `apply_` writes onto copies without mutating the original, persistence round-trip
- [x] Updated CLI tests for the resolved/open render split

Addresses part of #113 (kept open for the M7.2 verdict-blocking remainder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
