### PR TITLE
State obligations as positive invariants so prohibitions can be confirmed

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,14 +1,12 @@
 # Task
-Open questions from decomposition are silently dropped downstream of `decompose`, and never gate the verdict. Surfaced dogfooding M4.1: `run_classify` (`cli.py`) and `classify_case` (`benchmark/coverage.py`) both call `decompose(...).obligations` — only the obligations are kept; `.open_questions` is computed and then discarded. Only `render_decomposition` (the standalone `decompose` command's renderer) ever shows open questions to a human at all.
+`classify_coverage` cannot positively confirm a prohibition-style obligation ("leave X unchanged") — it always reads as a gap. Root cause: a negatively-phrased obligation has no positive response by construction, so the coverage classifier, whose frame is "does the diff respond to this?", is structurally doomed to classify it `not_addressed`. Fix it at the source by having `decompose` state obligations as positive invariants, and having `classify_coverage` treat a preserve/maintain obligation as addressed when the diff does not violate it.
 
 ## Constraints
-- `Review`/the `classify` pipeline must carry open questions through from decomposition to CLI output, not drop them at the first `.obligations`-only call site.
-- When the diff itself makes the answer to an open question clear, that must be noted and the question recorded as resolved — not shown as perpetually "unresolved" on every re-run regardless of whether the diff already answers it. When the diff doesn't answer it, it stays flagged open.
-- What counts as "resolved" beyond "the diff itself makes the answer clear" is reviewer judgment; the tool's job is to make and record that specific judgment, not to build a separate manual sign-off mechanism.
-
-## Scope exclusions
-- The completion verdict itself (M7.2, #33) — whether an unresolved open question blocks a `no-material-gaps` result — is out of scope for this task; that milestone hasn't been reached yet in the plan sequence. #33's own scope has already been updated separately (outside this diff) to carry that requirement forward.
+- Keep the existing `CoverageStatus` set; introduce no new status value and no rename. There must be one positive indicator (`addressed`), meaning the evidence was reviewed and the obligation is confirmed handled.
+- `decompose` must state every obligation as a positive invariant — the property the code must hold — converting any prohibition ("don't do X", "leave X unchanged") into the property it protects ("maintain X"). A prohibition and the invariant it protects are the same obligation.
+- `classify_coverage` must treat a preserve/maintain obligation as addressed when it is not violated, including when no diff region touches it (empty diff references are valid for a satisfied invariant); when the diff violates such an obligation, it is not addressed and should cite the violating change.
+- Reframing fixes how obligations are filed, not what evidence exists: an invariant that genuinely needs runtime or non-code evidence still routes to the appropriate status; this change lowers no bar on what counts as confirmed.
 
 ## Completion expectations
-- Implementation: open questions threaded through `Review`, `run_classify`, and `classify_case`; a judgment step decides, per open question, whether the diff resolves it, and records that judgment (not just displays it transiently); `classify`'s CLI output shows resolved questions (with the answer and its source) separately from still-open ones.
-- Unit tests: resolved and still-open cases, including a question the model doesn't return a judgment for (must stay open, not vanish); coverage/disposition tests are untouched by this change; existing CLI rendering tests are updated to match the new open-question output format and continue to pass.
+- Implementation: decompose prompt emits positive invariants; classify prompt handles preserve/maintain obligations and permits a violated invariant to cite the breach; archetype #8's ground-truth obligation rephrased positively for consistency.
+- Unit tests: a preserve obligation not violated classifies addressed with no diff references; a violated preserve obligation classifies not addressed and cites the violating hunk.

--- a/src/acceptance/coverage/classify.py
+++ b/src/acceptance/coverage/classify.py
@@ -54,13 +54,26 @@ obligation. Do NOT judge whether it is tested or correct; that is assessed
 separately.
 
 For each obligation return a `status`:
-- addressed: the diff contains a credible, complete code response.
+- addressed: the evidence in the diff confirms the obligation is handled —
+  either the diff contains a credible, complete code response, OR (for an
+  obligation to PRESERVE or MAINTAIN an existing property — "keep X working",
+  "preserve behavior Y", "keep the dependency set unchanged") the diff does
+  not violate that property. A preserve/maintain obligation can be addressed
+  with NO relevant change at all: if nothing in the diff touches or endangers
+  the property, it is preserved — return `addressed` with empty `diff_refs`
+  and a rationale saying the invariant is not violated. "Addressed" means the
+  evidence was reviewed and the obligation is confirmed handled, not that a
+  change was necessarily made for it.
 - partially_addressed: relevant behavior is present in the diff but a
-  qualifier, branch, condition, or case is missing.
-- not_addressed: no diff region responds to the obligation at all.
+  qualifier, branch, condition, or case is missing; or a preserve/maintain
+  obligation is only partly upheld.
+- not_addressed: a positive obligation has no responding diff region, or a
+  preserve/maintain obligation is clearly VIOLATED by the diff.
 - unclear: the change may be indirect and static evidence is insufficient.
-- requires_non_code_evidence: satisfying it needs docs, visual behavior, or
-  deploy config rather than code.
+- requires_non_code_evidence: confirming it needs evidence the diff alone
+  can't give — e.g. runtime behavior, visual output, or deploy config. (Some
+  invariants, like a latency bound, CAN be confirmed by a suitable test; use
+  this status only when no code-level evidence could settle it.)
 
 Judge each region against the FULL text of the obligation, not against a fixed
 idea of "correct production code." An obligation may ask for an ARTIFACT — a
@@ -74,8 +87,12 @@ behavior. Each file is tagged `(status, category)`; treat a `test`-category
 file as a deliverable artifact, not as production code held to correctness.
 
 Also return a short `rationale` and `diff_refs`: the labels (like `path#0`) of
-the hunks that address the obligation. For not_addressed, `diff_refs` MUST be
-empty. Link only hunks that genuinely respond to the obligation."""
+the hunks the status concerns. Link only hunks that genuinely bear on the
+obligation. `diff_refs` is empty when there is nothing to point at — a
+positive obligation that is not_addressed (no responding region), or a
+preserve/maintain obligation that is addressed by the ABSENCE of any relevant
+change. When a preserve/maintain obligation is not_addressed because the diff
+VIOLATES it, cite the violating hunk(s) so a reviewer can see the breach."""
 
 
 class _Classification(StrictResponseModel):

--- a/src/acceptance/requirement/obligations.py
+++ b/src/acceptance/requirement/obligations.py
@@ -41,6 +41,20 @@ an obligation for it. Instead return an `open_question` with a stable `id`, the
 `question` to put to the user, an `importance`, and a `source_quote` for the
 ambiguous text.
 
+State every obligation as a POSITIVE invariant — the property the delivered
+code must HOLD — never as a prohibition. A requirement phrased as "don't ...",
+"never ...", or "leave X unchanged" describes a property to PRESERVE; restate
+it as that property:
+- "Don't change the existing checkout behavior" -> "Preserve the existing
+  checkout behavior."
+- "Don't add new dependencies" -> "Keep the dependency set unchanged."
+- "Don't slow down the report" -> "Keep the report's runtime within its
+  current bound."
+A prohibition and the invariant it protects are the same obligation; emit the
+positive form, because it states what must be TRUE rather than what must be
+absent — an obligation that only says what must be absent can never be shown
+addressed by looking at what the diff contains.
+
 Granularity — isolate distinct computations, keep cohesive behaviors whole:
 
 - Isolate a sub-clause that defines a DISTINCT COMPUTATION or derived value — a

--- a/tests/benchmark/test_coverage.py
+++ b/tests/benchmark/test_coverage.py
@@ -256,7 +256,7 @@ def test_archetype_8_unrequested_change_gap_matches_via_its_obligation(tmp_path)
         },
         {
             "id": "leave-existing",
-            "description": "Leave existing behavior as-is; only apply_discount was requested",
+            "description": "Preserve the existing checkout behavior; only apply_discount was requested",
             "type": "compatibility",
             "source_quote": "existing behavior should be left as-is",
         },
@@ -332,7 +332,7 @@ def test_archetype_8_unrequested_change_metric_does_not_route_through_coverage(t
         },
         {
             "id": "leave-existing",
-            "description": "Leave existing behavior as-is; only apply_discount was requested",
+            "description": "Preserve the existing checkout behavior; only apply_discount was requested",
             "type": "compatibility",
             "source_quote": "existing behavior should be left as-is",
         },

--- a/tests/coverage/test_classify.py
+++ b/tests/coverage/test_classify.py
@@ -117,6 +117,65 @@ def test_archetype_2_missing_qualifier_is_partially_addressed(tmp_path):
     assert by_id["backward-compat"].diff_refs[0].file == pricing
 
 
+def test_preserve_obligation_not_violated_is_addressed_with_no_refs(tmp_path):
+    # #133: a preserve/maintain obligation is "addressed" (evidence reviewed,
+    # invariant confirmed not violated) even when nothing in the diff responds
+    # to it -- empty diff_refs. Under the old rubric this could only be
+    # `not_addressed`, which every consumer reads as a gap.
+    change_set = _archetype_change_set("01-missed-obligation", tmp_path)
+    obligations = [
+        _obligation(
+            "preserve-auth", "Preserve the existing authentication behavior",
+            ObligationType.COMPATIBILITY,
+        ),
+    ]
+    response = {
+        "classifications": [
+            {
+                "obligation_id": "preserve-auth",
+                "status": "addressed",
+                "rationale": "No diff region touches authentication; the invariant is not violated.",
+                "diff_refs": [],
+            }
+        ]
+    }
+
+    coverages = classify_coverage(obligations, change_set, _client_returning(response))
+
+    assert coverages[0].status == CoverageStatus.ADDRESSED
+    assert coverages[0].diff_refs == []  # satisfied by the absence of a violating change
+
+
+def test_violated_preserve_obligation_is_not_addressed_but_cites_the_breach(tmp_path):
+    # #133: a preserve obligation the diff VIOLATES is not_addressed AND cites
+    # the offending hunk -- the old rubric forbade this ("not_addressed MUST be
+    # empty"), leaving a reviewer no pointer to the breach.
+    change_set = _archetype_change_set("08-unrequested-change", tmp_path)
+    cart = _source_file(change_set, "cart.py")
+    obligations = [
+        _obligation(
+            "preserve-checkout", "Preserve the existing checkout behavior",
+            ObligationType.COMPATIBILITY,
+        ),
+    ]
+    response = {
+        "classifications": [
+            {
+                "obligation_id": "preserve-checkout",
+                "status": "not_addressed",
+                "rationale": "checkout gained a tax_rate parameter; the existing behavior was changed.",
+                "diff_refs": [f"{cart}#0"],
+            }
+        ]
+    }
+
+    coverages = classify_coverage(obligations, change_set, _client_returning(response))
+
+    assert coverages[0].status == CoverageStatus.NOT_ADDRESSED
+    assert coverages[0].diff_refs  # cites the violating change, not empty
+    assert coverages[0].diff_refs[0].file == cart
+
+
 def test_missing_classification_defaults_to_unclear(tmp_path):
     change_set = _archetype_change_set("01-missed-obligation", tmp_path)
     obligations = [_obligation("only", "Some obligation", ObligationType.FUNCTIONAL)]

--- a/tests/coverage/test_unrequested.py
+++ b/tests/coverage/test_unrequested.py
@@ -34,11 +34,11 @@ def test_archetype_8_public_interface_change_is_flagged(tmp_path):
     change_set = _archetype_change_set("08-unrequested-change", tmp_path)
     cart = _source_file(change_set, "cart.py")
 
-    # The task only asked for apply_discount; leave-existing forbids changing
+    # The task only asked for apply_discount; leave-existing requires preserving
     # unrelated behavior. checkout's signature change is unrequested.
     obligations = [
         _obligation("apply-discount", "Add apply_discount(total, percent)", ObligationType.FUNCTIONAL),
-        _obligation("leave-existing", "Leave existing behavior as-is", ObligationType.COMPATIBILITY),
+        _obligation("leave-existing", "Preserve the existing checkout behavior", ObligationType.COMPATIBILITY),
     ]
     response = {
         "unrequested_changes": [

--- a/tests/fixtures/archetypes/08-unrequested-change/labels.json
+++ b/tests/fixtures/archetypes/08-unrequested-change/labels.json
@@ -10,7 +10,7 @@
     },
     {
       "id": "leave-existing",
-      "description": "Leave existing behavior as-is; only apply_discount was requested",
+      "description": "Preserve the existing checkout behavior; only apply_discount was requested",
       "explicit": true,
       "evidence_class": "partially_supported",
       "evidence_rationale": "The test asserts checkout's default still returns 5.0, so a mutant that changes the default output is killed; but the actual unrequested change (added tax_rate parameter and rounding) leaves the default path unchanged, so that mutant survives - kills some, misses some.",


### PR DESCRIPTION
## Summary
Fixes #133 — a prohibition-style obligation ("leave X unchanged") always classified as a gap, even when genuinely satisfied.

**Root cause (revised from the issue's original framing):** not a missing `CoverageStatus`, but that a *negatively-phrased* obligation has no positive response by construction, so `classify_coverage` — whose whole frame is "does the diff respond to this?" — is structurally doomed to classify it `not_addressed`. Fixed at the source:

- **`decompose`** (`requirement/obligations.py` prompt) states every obligation as a positive invariant, converting a prohibition into the property it protects ("don't change existing coverage" → "maintain existing coverage").
- **`classify_coverage`** (`coverage/classify.py` prompt) treats a preserve/maintain obligation as `addressed` when the diff doesn't violate it — including with **empty `diff_refs`** (satisfied by the absence of any relevant change) — and `not_addressed` when violated, now **citing the violating hunk** (the old "not_addressed MUST be empty" rule is relaxed for this case).

**No new `CoverageStatus`, no rename** (both discussed and decided against): one positive indicator, `addressed`, kept deliberately — it reads as *evidence reviewed and confirmed handled*, which honestly covers confirming an invariant isn't violated, without the direct-proof overclaim "satisfied" would carry. The satisfied-by-absence vs. satisfied-by-change nuance lives in the rationale + whether `diff_refs` is empty.

The breadth of negative obligations (behavioral / dependency / performance — not just "don't touch this file") falls out by evidence type once obligations are positive: a dependency invariant is statically checkable; a runtime invariant may need a test or `requires_non_code_evidence`. The reframe fixes *filing*, not *evidence* — it lowers no bar (per "positive results are bounded").

Archetype #8's ground-truth `leave-existing` obligation is rephrased positively for consistency; its `source_quote` stays the raw negative task text (real tasks say "don't"; only the *derived* obligation is positive).

## Dogfood (the fix demonstrates itself)
Ran `decompose` + `classify` against this PR's own diff:
- `decompose` produced **only positive obligations** — including the task's own constraint "introduce no new status value," which it correctly reframed to "**Preserve** the existing CoverageStatus set." No negative obligations emitted.
- `classify` marked `keep-coverage-status-set-unchanged` (a preserve obligation) **`[addressed]` → `no corresponding change`** — the exact case that was `[not_addressed]` (a spurious gap) before this change. All 6 obligations `[addressed]`, zero `[unclear]`/`[not_addressed]`; the one unrequested change correctly `[in_service]`.

## Test plan
- [x] `pytest -q` — 382 passed
- [x] `ruff check src tests` — clean
- [x] New classify tests: a preserve obligation not violated → `addressed` with empty `diff_refs` (the previously-inexpressible satisfied prohibition); a violated preserve obligation → `not_addressed` citing the breach (previously forbidden by the "must be empty" rule)
- [x] Existing archetype-8 benchmark tests updated to the positive ground-truth phrasing, scoring unchanged
- [x] Prompt-quality (decompose actually converts negatives) validated via the live dogfood run above, not an injected-response test

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)
