### PR TITLE
Parse the §7.4 builder declaration; record its absence as a minor finding

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,12 +1,12 @@
 # Task
-`classify_coverage` cannot positively confirm a prohibition-style obligation ("leave X unchanged") — it always reads as a gap. Root cause: a negatively-phrased obligation has no positive response by construction, so the coverage classifier, whose frame is "does the diff respond to this?", is structurally doomed to classify it `not_addressed`. Fix it at the source by having `decompose` state obligations as positive invariants, and having `classify_coverage` treat a preserve/maintain obligation as addressed when the diff does not violate it.
+Parse the nine-section §7.4 builder declaration when present; when absent, record a minor finding and proceed with a full review (§7.4 optional-by-default).
 
 ## Constraints
-- Keep the existing `CoverageStatus` set; introduce no new status value and no rename. There must be one positive indicator (`addressed`), meaning the evidence was reviewed and the obligation is confirmed handled.
-- `decompose` must state every obligation as a positive invariant — the property the code must hold — converting any prohibition ("don't do X", "leave X unchanged") into the property it protects ("maintain X"). A prohibition and the invariant it protects are the same obligation.
-- `classify_coverage` must treat a preserve/maintain obligation as addressed when it is not violated, including when no diff region touches it (empty diff references are valid for a satisfied invariant); when the diff violates such an obligation, it is not addressed and should cite the violating change.
-- Reframing fixes how obligations are filed, not what evidence exists: an invariant that genuinely needs runtime or non-code evidence still routes to the appropriate status; this change lowers no bar on what counts as confirmed.
+- The declaration is optional by default in local mode; its absence must never block or degrade the rest of the review.
+- A declaration may be partial (some of the nine sections omitted); a partial declaration is still a valid declaration, not an error.
+- A declaration is a claim, not proof — parsing must not compare its content against evidence or judge truthfulness; that is a separate, later capability.
 
 ## Completion expectations
-- Implementation: decompose prompt emits positive invariants; classify prompt handles preserve/maintain obligations and permits a violated invariant to cite the breach; archetype #8's ground-truth obligation rephrased positively for consistency.
-- Unit tests: a preserve obligation not violated classifies addressed with no diff references; a violated preserve obligation classifies not addressed and cites the violating hunk.
+- Implementation
+- A run without a declaration completes and emits the "declaration absent" minor finding.
+- A run with one populates the declaration state, including a partial (not all nine sections present) declaration.

--- a/current-task.md
+++ b/current-task.md
@@ -2,7 +2,8 @@
 Parse the nine-section §7.4 builder declaration when present; when absent, record a minor finding and proceed with a full review (§7.4 optional-by-default).
 
 ## Constraints
-- The declaration is optional by default in local mode; its absence must never block or degrade the rest of the review.
+- Stage 1 is entirely local mode (`Review.mode == "local"`) — the checker has no GitHub App, hosted service, or CI access, and no other mode exists yet (Mode B / GitHub Acceptance Review is Stage 2, out of scope). "Optional by default in local mode" therefore names Stage 1's only mode, not a branching condition; this task adds no mode-determination logic.
+- The declaration's absence must never block or degrade the rest of the review.
 - A declaration may be partial (some of the nine sections omitted); a partial declaration is still a valid declaration, not an error.
 - A declaration is a claim, not proof — parsing must not compare its content against evidence or judge truthfulness; that is a separate, later capability.
 

--- a/src/acceptance/benchmark/coverage.py
+++ b/src/acceptance/benchmark/coverage.py
@@ -40,6 +40,7 @@ from acceptance.evidence.mapping import apply_test_mapping, map_tests_to_obligat
 from acceptance.evidence.strength import apply_evidence_strength, classify_strength
 from acceptance.evidence_tier import Component, EvidenceTier
 from acceptance.llm import ModelClient
+from acceptance.requirement.declaration import declaration_absent_finding, parse_declaration
 from acceptance.requirement.obligations import decompose
 from acceptance.requirement.task_file import parse_task_file
 from acceptance.review_state import (
@@ -155,6 +156,12 @@ def classify_case(
         if finding is not None
     )
 
+    if case.inputs.declaration_text is not None:
+        declaration = parse_declaration(case.inputs.declaration_text)
+    else:
+        declaration = None
+        findings.append(declaration_absent_finding())
+
     review = Review(
         mode="local",
         reviewed_revision=case.inputs.head_revision,
@@ -162,6 +169,7 @@ def classify_case(
         obligation_map=obligations,
         open_questions=open_questions,
         change_set=change_set,
+        declaration=declaration,
         findings=findings,
     )
     return scored_copy(case, review)

--- a/src/acceptance/requirement/declaration.py
+++ b/src/acceptance/requirement/declaration.py
@@ -1,0 +1,103 @@
+"""Builder declaration ingestion (M6.1, §7.4).
+
+Parses an optional end-of-cycle builder declaration — the nine §7.4 template
+sections, as raw text — when the reviewed change ships one. A declaration is
+**optional by default** in local mode: when absent, the review proceeds in
+full and a minor finding records the absence, rather than blocking or
+degrading anything else (§7.4, "optional-by-default").
+
+A declaration is "a claim, not proof" (§7.4) — `BuilderDeclaration` holds raw
+text for a later capability (M6.2, #31) to compare against actual evidence;
+parsing here does no comparison and makes no judgment about truthfulness. A
+declaration may also be partial — informally omitting a section is not an
+error, since §7.4 doesn't require every section be filled in; an omitted
+section is recorded as an empty string, not rejected.
+
+Markdown is parsed with markdown-it-py, the same approach `task_file.py`
+(M1.1) uses, since both ingest a fixed-shape §7 template.
+"""
+
+from __future__ import annotations
+
+from markdown_it import MarkdownIt
+from markdown_it.tree import SyntaxTreeNode
+
+from acceptance.evidence_tier import Component, EvidenceTier
+from acceptance.review_state import DECLARATION_ABSENT, BuilderDeclaration, Finding, Link
+
+__all__ = ["parse_declaration", "declaration_absent_finding"]
+
+# §7.4 template section headings, normalized (lowercased), to the
+# BuilderDeclaration field each fills. A section a declaration omits is left
+# as "" rather than rejected — a partial declaration is still a declaration.
+_SECTIONS = {
+    "mandate as understood": "mandate_as_understood",
+    "implementation summary": "implementation_summary",
+    "scope exclusions": "scope_exclusions",
+    "assumptions": "assumptions",
+    "changed components": "changed_components",
+    "test evidence": "test_evidence",
+    "regression evidence": "regression_evidence",
+    "known limitations": "known_limitations",
+    "additional behavioral changes": "additional_behavioral_changes",
+}
+
+
+def parse_declaration(text: str) -> BuilderDeclaration:
+    """Parse a builder declaration's §7.4 sections from raw markdown text."""
+    tree = SyntaxTreeNode(MarkdownIt().parse(text))
+    content_by_field: dict[str, str] = {}
+    field: str | None = None
+
+    for node in tree.children:
+        if node.type == "heading":
+            field = _SECTIONS.get(_inline_content(node).strip().lower())
+            continue
+        if field is None:
+            continue
+        block = _block_text(node)
+        if not block:
+            continue
+        existing = content_by_field.get(field, "")
+        content_by_field[field] = f"{existing}\n\n{block}" if existing else block
+
+    return BuilderDeclaration(**{name: content_by_field.get(name, "") for name in _SECTIONS.values()})
+
+
+def _inline_content(node: SyntaxTreeNode) -> str:
+    """The raw inline text of a heading / paragraph / list-item node."""
+    if node.type == "inline":
+        return node.content
+    for child in node.children:
+        found = _inline_content(child)
+        if found:
+            return found
+    return ""
+
+
+def _block_text(node: SyntaxTreeNode) -> str:
+    """Render a non-heading block (paragraph, bullet/ordered list, ...) to
+    plain text for a declaration section — declaration content is prose or a
+    short list, not code requiring exact formatting preservation."""
+    if node.type in ("bullet_list", "ordered_list"):
+        return "\n".join(f"- {_block_text(item)}" for item in node.children)
+    if node.type == "list_item":
+        return "\n".join(_block_text(child) for child in node.children if _block_text(child)).strip()
+    return _inline_content(node)
+
+
+def declaration_absent_finding() -> Finding:
+    """§7.4: when no declaration is present, a full review proceeds and its
+    absence is recorded as a minor finding — not a blocker, not silence."""
+    return Finding(
+        type=DECLARATION_ABSENT,
+        severity="low",
+        description=(
+            "No builder declaration was supplied for this review. §7.4 treats "
+            "a declaration as optional by default in local mode; the review "
+            "proceeds in full without one."
+        ),
+        evidence_tier=EvidenceTier.STATIC,
+        produced_by=Component.STATIC_ANALYZER,
+        links=[Link(kind="declaration", ref="declaration", text="no declaration was provided")],
+    )

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -31,6 +31,7 @@ __all__ = [
     "EvidenceClassification",
     "UnrequestedChangeDisposition",
     "UNREQUESTED_CHANGE",
+    "DECLARATION_ABSENT",
     "Project",
     "TaskSource",
     "MandateInterpretation",
@@ -69,13 +70,18 @@ class ObligationType(str, Enum):
 # must agree on the exact spelling.
 UNREQUESTED_CHANGE = "unrequested_change"
 
+# The canonical `Finding.type` for §7.4's "declaration absent" minor finding
+# (M6.1) — single-sourced for the same reason as UNREQUESTED_CHANGE.
+DECLARATION_ABSENT = "declaration_absent"
+
 # Finding types allowed to be obligation-less (related_obligation is None).
 # Almost every finding is *about* an obligation and must name it; an
 # unrequested change is the code→obligation dual and is obligation-less by
-# construction (§9.2, DR-081). M6 (builder-declaration comparison) adds
-# `declaration_mismatch` here: a claim of undone work outside the mandate is
-# obligation-less too, and advisory — see issue #31.
-_OBLIGATION_LESS_TYPES = frozenset({UNREQUESTED_CHANGE})
+# construction (§9.2, DR-081). A declaration-absent finding is about the
+# review's inputs, not any one obligation (M6.1). M6.2 (builder-declaration
+# comparison) adds `declaration_mismatch` here too: a claim of undone work
+# outside the mandate is obligation-less as well, and advisory — see issue #31.
+_OBLIGATION_LESS_TYPES = frozenset({UNREQUESTED_CHANGE, DECLARATION_ABSENT})
 
 
 class UnrequestedChangeDisposition(str, Enum):
@@ -210,13 +216,14 @@ class Obligation(_Model):
 
 
 class Link(_Model):
-    """A link to exact requirement text / code lines / test locations —
-    used by both `Finding` and `OpenQuestion.resolution_refs`. Defined here
-    (ahead of `OpenQuestion`) rather than by `Finding` alone, since both need
-    it and forward references don't resolve for pydantic model fields even
-    under `from __future__ import annotations`."""
+    """A link to exact requirement text / code lines / test locations / a
+    builder declaration — used by both `Finding` and
+    `OpenQuestion.resolution_refs`. Defined here (ahead of `OpenQuestion`)
+    rather than by `Finding` alone, since both need it and forward references
+    don't resolve for pydantic model fields even under
+    `from __future__ import annotations`."""
 
-    kind: Literal["requirement", "code", "test"]
+    kind: Literal["requirement", "code", "test", "declaration"]
     ref: str
     text: str | None = None
 

--- a/tests/benchmark/test_coverage.py
+++ b/tests/benchmark/test_coverage.py
@@ -297,8 +297,9 @@ def test_archetype_8_unrequested_change_gap_matches_via_its_obligation(tmp_path)
     scored = classify_case(case, client)
     findings_by_type = {f.type for f in scored.reviewer_output.findings}
 
-    # Both M3.1 and M3.2 output are fed in as findings...
-    assert findings_by_type == {"coverage_gap", "unrequested_change"}
+    # Both M3.1 and M3.2 output are fed in as findings, plus M6.1's
+    # declaration-absent finding (this archetype ships no declaration.md)...
+    assert findings_by_type == {"coverage_gap", "unrequested_change", "declaration_absent"}
     # ...but only the obligation-linked coverage gap moves the gap metric,
     # matching the ground-truth gap that is itself linked to leave-existing.
     assert scored.score.gap_recall == 1.0
@@ -377,6 +378,43 @@ def test_archetype_8_unrequested_change_metric_does_not_route_through_coverage(t
     # entirely independent of the (wrong) coverage classification.
     assert scored.score.unrequested_recall == 1.0
     assert scored.score.unrequested_precision == 1.0
+
+
+def test_declaration_present_is_parsed_onto_the_review(tmp_path):
+    # M6.1: archetype #7 ships a real (partial, 4-of-9-section) declaration.md
+    # -- it must be parsed onto Review.declaration, and NO declaration_absent
+    # finding should appear since one was actually supplied.
+    case = build_benchmark_case(ARCHETYPES_DIR / "07-declaration-mismatch", tmp_path / "repo")
+
+    obligations = [
+        {
+            "id": "get-user",
+            "description": "Return the user record matching user_id from the users mapping",
+            "type": "functional",
+            "source_quote": "returning the user record (a dict) that matches `user_id`",
+        },
+    ]
+    client = _client_dispatching(
+        {
+            "_Mappings": {"mappings": []},
+            "_Decomposition": _decomposition_response(obligations),
+            "_Coverage": _classification_response(
+                [{"obligation_id": "get-user", "status": "addressed"}]
+            ),
+            "_Detections": {"unrequested_changes": []},
+        }
+    )
+
+    scored = classify_case(case, client)
+    review = scored.reviewer_output
+
+    assert review.declaration is not None
+    assert review.declaration.mandate_as_understood == (
+        "Provide a lookup that returns a user record by its id."
+    )
+    # Sections the fixture omits are empty, not missing.
+    assert review.declaration.scope_exclusions == ""
+    assert "declaration_absent" not in {f.type for f in review.findings}
 
 
 def test_classify_case_does_not_mutate_the_input_case(tmp_path):

--- a/tests/requirement/test_declaration.py
+++ b/tests/requirement/test_declaration.py
@@ -1,0 +1,130 @@
+"""M6.1 acceptance: the §7.4 nine-section builder declaration is parsed when
+present (full or partial); its absence is recorded as a minor finding rather
+than blocking or degrading the rest of the review.
+
+Parsing is pure markdown structure (no model call, no comparison judgment —
+that's M6.2, #31), so these tests assert real parsed output directly."""
+
+from acceptance.evidence_tier import Component, EvidenceTier
+from acceptance.requirement.declaration import declaration_absent_finding, parse_declaration
+from acceptance.review_state import DECLARATION_ABSENT, BuilderDeclaration
+
+_FULL = """\
+# Builder Declaration
+## Mandate as understood
+Add a discount function to the cart.
+
+## Implementation summary
+Added `apply_discount(total, percent)`.
+
+## Scope exclusions
+Did not touch checkout.
+
+## Assumptions
+Percent is given as a whole number, e.g. 10 for 10%.
+
+## Changed components
+- cart.py
+
+## Test evidence
+test_apply_discount asserts the discounted total.
+
+## Regression evidence
+test_checkout_default_unchanged still passes.
+
+## Known limitations
+Does not validate percent is within 0-100.
+
+## Additional behavioral changes
+none
+"""
+
+
+def test_full_nine_section_declaration_is_parsed():
+    declaration = parse_declaration(_FULL)
+
+    assert declaration.mandate_as_understood == "Add a discount function to the cart."
+    assert declaration.implementation_summary == "Added `apply_discount(total, percent)`."
+    assert declaration.scope_exclusions == "Did not touch checkout."
+    assert declaration.assumptions == "Percent is given as a whole number, e.g. 10 for 10%."
+    assert declaration.changed_components == "- cart.py"
+    assert declaration.test_evidence == "test_apply_discount asserts the discounted total."
+    assert declaration.regression_evidence == "test_checkout_default_unchanged still passes."
+    assert declaration.known_limitations == "Does not validate percent is within 0-100."
+    assert declaration.additional_behavioral_changes == "none"
+
+
+def test_partial_declaration_leaves_omitted_sections_empty():
+    # Matches archetype #7's real fixture shape: only 4 of the 9 sections
+    # are present. A partial declaration is a valid declaration, not an error.
+    text = """\
+# Builder declaration
+
+## Mandate as understood
+Provide a lookup that returns a user record by its id.
+
+## Implementation summary
+Added `get_user(users, user_id)`, which returns the matching user record.
+
+## Test evidence
+Covered the happy path: an existing id returns the expected record.
+
+## Known limitations
+Raises `KeyError` with a clear message when the id is not present.
+"""
+    declaration = parse_declaration(text)
+
+    assert declaration.mandate_as_understood == "Provide a lookup that returns a user record by its id."
+    assert declaration.implementation_summary.startswith("Added `get_user")
+    assert declaration.test_evidence.startswith("Covered the happy path")
+    assert declaration.known_limitations.startswith("Raises `KeyError`")
+    # Omitted sections are "", not missing/rejected.
+    assert declaration.scope_exclusions == ""
+    assert declaration.assumptions == ""
+    assert declaration.changed_components == ""
+    assert declaration.regression_evidence == ""
+    assert declaration.additional_behavioral_changes == ""
+
+
+def test_empty_text_parses_to_an_all_empty_declaration():
+    declaration = parse_declaration("")
+    assert declaration.mandate_as_understood == ""
+    assert declaration.additional_behavioral_changes == ""
+
+
+def test_multi_paragraph_section_is_joined():
+    text = """\
+## Mandate as understood
+First paragraph.
+
+Second paragraph.
+"""
+    declaration = parse_declaration(text)
+    assert declaration.mandate_as_understood == "First paragraph.\n\nSecond paragraph."
+
+
+def test_bullet_list_section_is_rendered():
+    text = """\
+## Changed components
+- cart.py
+- checkout.py
+"""
+    declaration = parse_declaration(text)
+    assert declaration.changed_components == "- cart.py\n- checkout.py"
+
+
+def test_declaration_round_trips_through_persistence():
+    declaration = parse_declaration(_FULL)
+    assert BuilderDeclaration.from_dict(declaration.to_dict()) == declaration
+
+
+def test_declaration_absent_finding_shape():
+    finding = declaration_absent_finding()
+
+    assert finding.type == DECLARATION_ABSENT
+    assert finding.severity == "low"
+    assert finding.evidence_tier == EvidenceTier.STATIC
+    assert finding.produced_by == Component.STATIC_ANALYZER
+    assert finding.related_obligation is None  # obligation-less by construction
+    assert finding.links
+    assert finding.links[0].kind == "declaration"


### PR DESCRIPTION
## Summary
M6.1 — declaration ingestion, first of two M6 issues (M6.2/#31 is the declaration-vs-evidence comparison, landing separately).

- `parse_declaration` (`requirement/declaration.py`) reads the nine §7.4 template sections from raw markdown — same approach as `task_file.py` (M1.1), since both ingest a fixed-shape §7 template.
- A declaration may be **partial**: an omitted section parses to `""`, not rejected — matching archetype #7's real fixture, which only fills 4 of the 9 sections.
- `declaration_absent_finding()` is a minor, obligation-less `Finding` (`evidence_tier=STATIC`, `produced_by=STATIC_ANALYZER`) recording that no declaration was supplied — per §7.4's "optional by default in local mode," the review proceeds in full either way; absence is recorded, not silenced or penalized.
- Wired into `classify_case` (`benchmark/coverage.py`): present → parsed onto `Review.declaration`; absent → the minor finding is appended, nothing else changes.

**Not in this PR:** CLI wiring (`run_classify` has no `--declaration` input and doesn't build a `Review` object at all — same M7-assembly boundary already drawn for M5.1/M5.4's capabilities). `DECLARATION_ABSENT` joins `UNREQUESTED_CHANGE` in `_OBLIGATION_LESS_TYPES`; `Link.kind` gains a `"declaration"` variant so the finding links honestly to the declaration artifact.

## Review history
First dogfood run raised a genuine open question — "how is 'local mode' determined, does this apply only in local mode?" — and I initially accepted it as "correctly left open" since it wasn't a misclassification. Caught in review: *an unresolved open question is a blocker regardless of whether the tool was right to leave it open.* Investigated: `mode="local"` isn't arbitrary — per CLAUDE.md, Stage 1 has no other mode (GitHub/Mode B is Stage 2, explicitly out of scope), so there's no branching logic to determine. That context was missing from `current-task.md`, which is exactly why the ambiguity was real. Added it; re-running `decompose`/`classify` on the corrected file confirms the open question no longer arises.

## Dogfood (final run)
- `decompose`: 10 positive obligations, **zero open questions**.
- `classify`: all 10 `[addressed]`. 2 unrequested-change notes, both correctly `[in_service]` — accurate scope observations (parser behavior beyond the strict obligations, `Link.kind` widening), not defects.

## Test plan
- [x] `pytest -q` — 390 passed
- [x] `ruff check src tests` — clean
- [x] New tests (`tests/requirement/test_declaration.py`): full 9-section parse, partial parse (archetype #7's shape), empty text, multi-paragraph joining, bullet-list rendering, persistence round-trip, absent-finding shape
- [x] New benchmark test: archetype #7 (which ships a real declaration.md) parses onto `Review.declaration` with no `declaration_absent` finding; existing archetype-8 test updated for the now-present finding (every other archetype has no `declaration.md`)

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)
