### PR TITLE
Compare builder declaration against evidence; emit advisory mismatch findings

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,13 +1,13 @@
 # Task
-Parse the nine-section §7.4 builder declaration when present; when absent, record a minor finding and proceed with a full review (§7.4 optional-by-default).
+Compare the builder declaration's claimed mandate, implementation, tests, exclusions, assumptions, and limitations against the obligations, the diff, and the tests; emit discrepancies as findings treated as claims, never proof. Archetype #7's shape: the declaration claims `get_user` raises `KeyError` on a missing id, but the code returns `None` and no test exercises the missing-id path — a claim matching neither the task nor the code.
 
 ## Constraints
-- Stage 1 is entirely local mode (`Review.mode == "local"`) — the checker has no GitHub App, hosted service, or CI access, and no other mode exists yet (Mode B / GitHub Acceptance Review is Stage 2, out of scope). "Optional by default in local mode" therefore names Stage 1's only mode, not a branching condition; this task adds no mode-determination logic.
-- The declaration's absence must never block or degrade the rest of the review.
-- A declaration may be partial (some of the nine sections omitted); a partial declaration is still a valid declaration, not an error.
-- A declaration is a claim, not proof — parsing must not compare its content against evidence or judge truthfulness; that is a separate, later capability.
+- A declaration is a claim, not proof — every discrepancy finding carries the weakest (builder-claim) evidence tier.
+- Keep two situations apart. A claim of work that was actually done (real code changed, even outside the mandate) is a separate unrequested-change concern and must not be re-flagged here. Only a claim of work that was claimed but not done — no code path and no test — is a declaration mismatch.
+- A declaration mismatch is advisory and low-weight: nothing was mis-delivered in the code, so it flags the declaration as untrustworthy without blocking acceptance of the actual change. It is obligation-less by construction.
+- The comparison is a semantic judgment routed through the model harness, recorded for replay; no live model call in tests.
 
 ## Completion expectations
 - Implementation
-- A run without a declaration completes and emits the "declaration absent" minor finding.
-- A run with one populates the declaration state, including a partial (not all nine sections present) declaration.
+- Archetype #7 produces a discrepancy finding for the claimed-but-absent error condition (declares an error condition implemented; no code path or test found).
+- A truthful declaration whose claims the code and tests support produces no discrepancy finding.

--- a/src/acceptance/benchmark/coverage.py
+++ b/src/acceptance/benchmark/coverage.py
@@ -30,6 +30,10 @@ from acceptance.benchmark.hooks import provenance_from, scored_copy
 from acceptance.change.diff import extract_change_set
 from acceptance.config import ScopeExpansionPolicy
 from acceptance.coverage.classify import CoverageStatus, ImplementationCoverage, classify_coverage
+from acceptance.coverage.declaration_comparison import (
+    compare_declaration,
+    declaration_mismatch_finding,
+)
 from acceptance.coverage.disposition import DispositionedChange, classify_dispositions
 from acceptance.coverage.open_questions import apply_open_question_resolutions, resolve_open_questions
 from acceptance.coverage.unrequested import detect_unrequested_changes
@@ -158,6 +162,10 @@ def classify_case(
 
     if case.inputs.declaration_text is not None:
         declaration = parse_declaration(case.inputs.declaration_text)
+        mismatches = compare_declaration(
+            declaration, obligations, change_set, test_evidence, client
+        )
+        findings.extend(declaration_mismatch_finding(m) for m in mismatches)
     else:
         declaration = None
         findings.append(declaration_absent_finding())

--- a/src/acceptance/coverage/declaration_comparison.py
+++ b/src/acceptance/coverage/declaration_comparison.py
@@ -1,0 +1,169 @@
+"""Declaration-vs-evidence comparison (M6.2, §7.4, issue #31).
+
+Compares a builder declaration's claims — mandate as understood, implementation,
+tests, scope exclusions, assumptions, limitations, behavioral changes — against
+what the review actually found: the obligations (M1), the diff (M2), and the
+test evidence (M5). A claim matching neither the task nor the code/tests is a
+`declaration_mismatch` finding.
+
+Two situations are deliberately kept apart (issue #31 design note):
+
+- A claim of work that was **actually done** (real code changed outside the
+  mandate) is an `unrequested_change` (M3.2), not our concern — it weighs on
+  acceptance because real scope expanded. We must NOT re-flag it here.
+- A claim of work that was **claimed but not done** (no code path, no test) is
+  the `declaration_mismatch` this capability produces. It is **advisory /
+  low-weight**: nothing was actually mis-delivered in the code, so a bogus
+  claim flags the declaration as untrustworthy without blocking acceptance of
+  the real change. Archetype #7's shape: the declaration claims `get_user`
+  raises `KeyError` on a missing id, but the code returns `None` and no test
+  exercises the missing-id path.
+
+A semantic judgment, so a schema-constrained model call through the M0.4
+harness — recorded for replay, never a live call in tests. Findings are a
+claim, not proof (§7.4): they carry the BUILDER_CLAIM tier, the weakest rung
+of the ladder.
+"""
+
+from __future__ import annotations
+
+from acceptance.coverage.prompt import render_diff_section
+from acceptance.evidence_tier import Component, EvidenceTier
+from acceptance.llm import ModelClient, StrictResponseModel
+from acceptance.model_base import PersistableModel
+from acceptance.review_state import (
+    DECLARATION_MISMATCH,
+    BuilderDeclaration,
+    ChangeSet,
+    Finding,
+    Link,
+    Obligation,
+    TestEvidence,
+)
+
+_SYSTEM_PROMPT = """\
+You compare a BUILDER DECLARATION against what a review actually found. The
+declaration is the builder's own end-of-cycle account of what they believe was
+requested and completed — a CLAIM, not proof. You are given the obligations the
+task actually required, the diff that was actually made, and the tests that
+actually exist.
+
+Find declaration claims that match NEITHER the task NOR the code/tests — most
+importantly, a claim of BEHAVIOR OR WORK THAT WAS NOT ACTUALLY DONE: the
+declaration asserts the code does something (handles an error, enforces a
+limit, covers a case) that no diff hunk implements and no test exercises.
+
+For each such claim return the `claim` (what the declaration asserts, quoted or
+closely paraphrased) and a short `rationale` (why it is unsupported — what the
+code actually does instead, and that no test covers it).
+
+Do NOT report:
+- A claim that the obligations, diff, or tests DO support — a truthful claim is
+  not a discrepancy.
+- A claim of work that WAS actually done but wasn't requested. Real
+  unrequested code is handled by a separate analysis; only report claims with
+  NO backing code and NO backing test.
+- Vague or stylistic wording differences. Report a claim only when the code and
+  tests genuinely fail to support a concrete asserted behavior.
+
+If every claim is supported, return an empty list."""
+
+
+class DeclarationMismatch(PersistableModel):
+    """A declaration claim matching neither the task nor the code/tests."""
+
+    claim: str
+    rationale: str
+
+
+class _Mismatch(StrictResponseModel):
+    claim: str
+    rationale: str
+
+
+class _Mismatches(StrictResponseModel):
+    mismatches: list[_Mismatch]
+
+
+def _render_prompt(
+    declaration: BuilderDeclaration,
+    obligations: list[Obligation],
+    change_set: ChangeSet,
+    test_evidence: list[TestEvidence],
+) -> str:
+    lines = ["## Builder declaration", ""]
+    for label, value in _declaration_sections(declaration):
+        if value:
+            lines.append(f"### {label}")
+            lines.append(value)
+            lines.append("")
+
+    lines.append("## Obligations the task actually required")
+    if obligations:
+        for obligation in obligations:
+            lines.append(f"- {obligation.description}")
+    else:
+        lines.append("(none)")
+    lines.append("")
+
+    lines.extend(render_diff_section(change_set))
+    lines.append("")
+
+    lines.append("## Tests that actually exist")
+    if test_evidence:
+        for evidence in test_evidence:
+            assertions = "; ".join(evidence.assertions) or "(no assertions parsed)"
+            lines.append(f"- {evidence.identifier}: {assertions}")
+    else:
+        lines.append("(none)")
+    return "\n".join(lines)
+
+
+def _declaration_sections(declaration: BuilderDeclaration) -> list[tuple[str, str]]:
+    return [
+        ("Mandate as understood", declaration.mandate_as_understood),
+        ("Implementation summary", declaration.implementation_summary),
+        ("Scope exclusions", declaration.scope_exclusions),
+        ("Assumptions", declaration.assumptions),
+        ("Changed components", declaration.changed_components),
+        ("Test evidence", declaration.test_evidence),
+        ("Regression evidence", declaration.regression_evidence),
+        ("Known limitations", declaration.known_limitations),
+        ("Additional behavioral changes", declaration.additional_behavioral_changes),
+    ]
+
+
+def compare_declaration(
+    declaration: BuilderDeclaration,
+    obligations: list[Obligation],
+    change_set: ChangeSet,
+    test_evidence: list[TestEvidence],
+    client: ModelClient,
+) -> list[DeclarationMismatch]:
+    """Flag declaration claims matching neither the task nor the code/tests."""
+    messages = [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {
+            "role": "user",
+            "content": _render_prompt(declaration, obligations, change_set, test_evidence),
+        },
+    ]
+    result = client.complete(messages, _Mismatches)
+    return [
+        DeclarationMismatch(claim=m.claim, rationale=m.rationale) for m in result.mismatches
+    ]
+
+
+def declaration_mismatch_finding(mismatch: DeclarationMismatch) -> Finding:
+    """A §7.4 declaration-vs-evidence discrepancy, as an advisory, obligation-
+    less finding. Low severity and the BUILDER_CLAIM tier: it flags the
+    declaration as inaccurate, but nothing was mis-delivered in the code, so it
+    does not block acceptance of the actual change (issue #31)."""
+    return Finding(
+        type=DECLARATION_MISMATCH,
+        severity="low",
+        description=f"Declaration claim unsupported by code or tests: {mismatch.rationale}",
+        evidence_tier=EvidenceTier.BUILDER_CLAIM,
+        produced_by=Component.BUILDER_DECLARATION,
+        links=[Link(kind="declaration", ref="declaration", text=mismatch.claim)],
+    )

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -32,6 +32,7 @@ __all__ = [
     "UnrequestedChangeDisposition",
     "UNREQUESTED_CHANGE",
     "DECLARATION_ABSENT",
+    "DECLARATION_MISMATCH",
     "Project",
     "TaskSource",
     "MandateInterpretation",
@@ -74,14 +75,23 @@ UNREQUESTED_CHANGE = "unrequested_change"
 # (M6.1) — single-sourced for the same reason as UNREQUESTED_CHANGE.
 DECLARATION_ABSENT = "declaration_absent"
 
+# The canonical `Finding.type` for a §7.4 declaration-vs-evidence discrepancy
+# (M6.2): a declaration claim matching neither the task nor the code/tests —
+# e.g. a claimed behavior the code doesn't implement and no test exercises.
+DECLARATION_MISMATCH = "declaration_mismatch"
+
 # Finding types allowed to be obligation-less (related_obligation is None).
 # Almost every finding is *about* an obligation and must name it; an
 # unrequested change is the code→obligation dual and is obligation-less by
 # construction (§9.2, DR-081). A declaration-absent finding is about the
-# review's inputs, not any one obligation (M6.1). M6.2 (builder-declaration
-# comparison) adds `declaration_mismatch` here too: a claim of undone work
-# outside the mandate is obligation-less as well, and advisory — see issue #31.
-_OBLIGATION_LESS_TYPES = frozenset({UNREQUESTED_CHANGE, DECLARATION_ABSENT})
+# review's inputs, not any one obligation (M6.1). A declaration-mismatch is a
+# claim matching neither the task nor the code — obligation-less too, and
+# advisory / low-weight on the verdict, since nothing was actually mis-delivered
+# in the code (M6.2, issue #31); distinct from an unrequested change, which is
+# real code that *was* changed.
+_OBLIGATION_LESS_TYPES = frozenset(
+    {UNREQUESTED_CHANGE, DECLARATION_ABSENT, DECLARATION_MISMATCH}
+)
 
 
 class UnrequestedChangeDisposition(str, Enum):

--- a/tests/benchmark/test_coverage.py
+++ b/tests/benchmark/test_coverage.py
@@ -402,6 +402,7 @@ def test_declaration_present_is_parsed_onto_the_review(tmp_path):
                 [{"obligation_id": "get-user", "status": "addressed"}]
             ),
             "_Detections": {"unrequested_changes": []},
+            "_Mismatches": {"mismatches": []},
         }
     )
 
@@ -415,6 +416,51 @@ def test_declaration_present_is_parsed_onto_the_review(tmp_path):
     # Sections the fixture omits are empty, not missing.
     assert review.declaration.scope_exclusions == ""
     assert "declaration_absent" not in {f.type for f in review.findings}
+
+
+def test_archetype_7_declaration_overclaim_produces_a_mismatch_finding(tmp_path):
+    # M6.2 acceptance: archetype #7's declaration claims get_user raises
+    # KeyError on a missing id, but the code returns None and no test exercises
+    # it -- a declaration_mismatch finding, obligation-less and advisory.
+    case = build_benchmark_case(ARCHETYPES_DIR / "07-declaration-mismatch", tmp_path / "repo")
+
+    obligations = [
+        {
+            "id": "get-user",
+            "description": "Return the user record matching user_id from the users mapping",
+            "type": "functional",
+            "source_quote": "returning the user record (a dict) that matches `user_id`",
+        },
+    ]
+    client = _client_dispatching(
+        {
+            "_Mappings": {"mappings": []},
+            "_Decomposition": _decomposition_response(obligations),
+            "_Coverage": _classification_response(
+                [{"obligation_id": "get-user", "status": "addressed"}]
+            ),
+            "_Detections": {"unrequested_changes": []},
+            "_Mismatches": {
+                "mismatches": [
+                    {
+                        "claim": "get_user raises KeyError with a clear message on a missing id",
+                        "rationale": (
+                            "The implementation returns None on a missing id and no test "
+                            "exercises the missing-id path."
+                        ),
+                    }
+                ]
+            },
+        }
+    )
+
+    scored = classify_case(case, client)
+    findings = scored.reviewer_output.findings
+    mismatch_findings = [f for f in findings if f.type == "declaration_mismatch"]
+
+    assert len(mismatch_findings) == 1
+    assert mismatch_findings[0].related_obligation is None  # obligation-less
+    assert mismatch_findings[0].severity == "low"  # advisory, not acceptance-blocking
 
 
 def test_classify_case_does_not_mutate_the_input_case(tmp_path):

--- a/tests/coverage/test_declaration_comparison.py
+++ b/tests/coverage/test_declaration_comparison.py
@@ -1,0 +1,113 @@
+"""M6.2 acceptance: a builder-declaration claim matching neither the task nor
+the code/tests is produced as an advisory `declaration_mismatch` finding.
+
+Comparison is a schema-constrained model call; per the replay-first invariant
+these tests inject the recorded response via completion_fn — no live calls.
+Comparison *accuracy* against the real model is shown by the PR's record run."""
+
+from acceptance.coverage.declaration_comparison import (
+    DeclarationMismatch,
+    compare_declaration,
+    declaration_mismatch_finding,
+)
+from acceptance.evidence_tier import Component, EvidenceTier
+from acceptance.review_state import (
+    DECLARATION_MISMATCH,
+    BuilderDeclaration,
+    ChangeSet,
+    DiffHunk,
+    FileChange,
+    ObligationType,
+    TestEvidence,
+)
+from tests.support import client_returning as _client_returning
+from tests.support import make_obligation as _obligation
+
+
+def _declaration(**overrides: str) -> BuilderDeclaration:
+    base = {name: "" for name in BuilderDeclaration.model_fields}
+    base.update(overrides)
+    return BuilderDeclaration(**base)
+
+
+def _archetype_7_inputs():
+    # get_user returns None on a miss; the declaration claims it raises KeyError.
+    declaration = _declaration(
+        mandate_as_understood="Provide a lookup that returns a user record by its id.",
+        implementation_summary="Added `get_user(users, user_id)`.",
+        known_limitations="Raises `KeyError` with a clear message when the id is not present.",
+    )
+    obligations = [
+        _obligation("lookup", "Return the user record matching user_id", ObligationType.FUNCTIONAL),
+    ]
+    change_set = ChangeSet(base_revision="a", head_revision="b", files=[
+        FileChange(
+            path="users.py", status="modified", category="source",
+            hunks=[DiffHunk(
+                header="@@ -1,2 +1,2 @@", old_start=1, old_lines=2, new_start=1, new_lines=2,
+                content="-    raise NotImplementedError\n+    return users.get(user_id)",
+            )],
+        ),
+    ])
+    test_evidence = [
+        TestEvidence(
+            identifier="test_users.py::test_existing_id_returns_the_record",
+            location="test_users.py",
+            assertions=["get_user(users, 1) == {'name': 'Ada'}"],
+        ),
+    ]
+    return declaration, obligations, change_set, test_evidence
+
+
+def test_overclaimed_error_condition_is_flagged():
+    declaration, obligations, change_set, test_evidence = _archetype_7_inputs()
+    response = {
+        "mismatches": [
+            {
+                "claim": "get_user raises KeyError with a clear message on a missing id",
+                "rationale": (
+                    "The implementation returns None on a missing id and no test exercises "
+                    "the missing-id path; no code path or test supports the claim."
+                ),
+            }
+        ]
+    }
+
+    mismatches = compare_declaration(
+        declaration, obligations, change_set, test_evidence, _client_returning(response)
+    )
+
+    assert len(mismatches) == 1
+    assert "KeyError" in mismatches[0].claim
+
+
+def test_truthful_declaration_flags_nothing():
+    declaration, obligations, change_set, test_evidence = _archetype_7_inputs()
+
+    mismatches = compare_declaration(
+        declaration, obligations, change_set, test_evidence,
+        _client_returning({"mismatches": []}),
+    )
+
+    assert mismatches == []
+
+
+def test_mismatch_finding_is_advisory_and_obligation_less():
+    mismatch = DeclarationMismatch(
+        claim="get_user raises KeyError on a missing id",
+        rationale="The code returns None and no test covers the missing-id path.",
+    )
+    finding = declaration_mismatch_finding(mismatch)
+
+    assert finding.type == DECLARATION_MISMATCH
+    assert finding.severity == "low"  # advisory / low-weight (issue #31)
+    assert finding.evidence_tier == EvidenceTier.BUILDER_CLAIM  # a claim, not proof
+    assert finding.produced_by == Component.BUILDER_DECLARATION
+    assert finding.related_obligation is None  # obligation-less by construction
+    assert finding.links[0].kind == "declaration"
+    assert "KeyError" in finding.links[0].text
+
+
+def test_declaration_mismatch_round_trips_through_persistence():
+    mismatch = DeclarationMismatch(claim="c", rationale="r")
+    assert DeclarationMismatch.from_dict(mismatch.to_dict()) == mismatch


### PR DESCRIPTION
## Summary
M6.2 — declaration-vs-evidence comparison, the second and final M6 issue (M6.1/#30 landed the parse).

- `compare_declaration` (`coverage/declaration_comparison.py`) is a schema-constrained model call comparing a declaration's claims against the obligations (M1), the diff (M2), and the test evidence (M5). A claim matching **neither the task nor the code/tests** becomes a `declaration_mismatch` finding.
- Per issue #31's design note, two situations are kept apart: a claim of work that **was** done (real unrequested code) stays an `unrequested_change` (M3.2) and is *not* re-flagged here; only a claim of work that was **claimed but not done** — no code path, no test — becomes a `declaration_mismatch`.
- The finding is **obligation-less** (added to `_OBLIGATION_LESS_TYPES`), **low-severity**, **`BUILDER_CLAIM` tier** — advisory: it flags the declaration as untrustworthy without blocking acceptance of the actual delivered change, since nothing was mis-delivered in the code.
- Wired into `classify_case`: when a declaration is present, run the comparison and append its findings alongside the M6.1 parse.

**Deferred (Option A, agreed):** scoring these obligation-less findings against archetype #7's obligation-less ground-truth gap needs a match-key design mirroring the unrequested-change axis — filed as **#136**. No existing test asserts archetype #7's `gap_recall`, so nothing regresses.

## Dogfood
**Live RECORD run of the real capability against archetype #7** (the acceptance criterion — injected-response unit tests can't prove the model actually finds it):
```
=== 1 mismatch(es) ===
CLAIM:     Raises `KeyError` with a clear message when the id is not present.
RATIONALE: The implemented function uses `users.get(user_id)`, which returns `None` for a
           missing id rather than raising `KeyError`. The only test covers the existing-id
           happy path and does not exercise any missing-id behavior.
```
That is exactly the issue's acceptance case ("declares an error condition implemented; no code path or test found"), produced by the real model end-to-end.

`decompose` + `classify` on this PR's own diff: 7 positive obligations, **zero open questions**, all `[addressed]`; 3 unrequested-change notes all correctly `[in_service]` (the model-call plumbing, the `classify_case` wiring, the internal support types — accurate scope observations, not defects).

## Test plan
- [x] `pytest -q` — 395 passed
- [x] `ruff check src tests` — clean
- [x] Live RECORD run above (prompt-quality / real-model acceptance)
- [x] Unit tests (`tests/coverage/test_declaration_comparison.py`): overclaimed error condition flagged; truthful declaration flags nothing; finding is advisory + obligation-less + `BUILDER_CLAIM` + declaration-linked; round-trip
- [x] Benchmark integration test: archetype #7 → a `declaration_mismatch` finding on the `Review`; M6.1 parse test updated for the added `_Mismatches` call

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)
