### PR TITLE
Generate structured §9.5 test recommendations for weak criteria

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,13 +1,13 @@
 # Task
-Compare the builder declaration's claimed mandate, implementation, tests, exclusions, assumptions, and limitations against the obligations, the diff, and the tests; emit discrepancies as findings treated as claims, never proof. Archetype #7's shape: the declaration claims `get_user` raises `KeyError` on a missing id, but the code returns `None` and no test exercises the missing-id path — a claim matching neither the task nor the code.
+For each criterion whose test evidence is missing or weak, produce a machine-readable §9.5 recommendation with the criterion, required input characteristics, boundary or negative conditions, expected output or relationship, required assertions, the plausible defect it should detect, and relevant repo conventions or fixtures. Archetype #4's shape: the daily-rate criterion's only test uses a 30-day month, where dividing by days_in_month and dividing by a hard-coded 30 give the same answer, so the recommendation must prescribe a discriminating test.
 
 ## Constraints
-- A declaration is a claim, not proof — every discrepancy finding carries the weakest (builder-claim) evidence tier.
-- Keep two situations apart. A claim of work that was actually done (real code changed, even outside the mandate) is a separate unrequested-change concern and must not be re-flagged here. Only a claim of work that was claimed but not done — no code path and no test — is a declaration mismatch.
-- A declaration mismatch is advisory and low-weight: nothing was mis-delivered in the code, so it flags the declaration as untrustworthy without blocking acceptance of the actual change. It is obligation-less by construction.
-- The comparison is a semantic judgment routed through the model harness, recorded for replay; no live model call in tests.
+- Recommend a test for every obligation whose evidence class is anything short of strongly supported; an obligation with no evidence class set yet is not yet classified and is not recommended for.
+- The plausible defect the recommended test must catch is the surviving defect the discrimination step already identified, not a newly invented one, so a passing added test demonstrably closes the gap rather than nominally addressing it.
+- Every recommendation is structured, machine-readable data a coding agent can pick up and implement in a single iteration; "add more tests" is insufficient.
+- The product recommends and never modifies code. Generation is a semantic judgment routed through the model harness, recorded for replay; no live model call in tests.
 
 ## Completion expectations
 - Implementation
-- Archetype #7 produces a discrepancy finding for the claimed-but-absent error condition (declares an error condition implemented; no code path or test found).
-- A truthful declaration whose claims the code and tests support produces no discrepancy finding.
+- Archetype #4's weak daily-rate criterion yields a recommendation with every §9.5 field populated, prescribing an input where a correct and a defective implementation differ.
+- A strongly supported obligation yields no recommendation, and no model call is made when nothing is weak.

--- a/src/acceptance/benchmark/coverage.py
+++ b/src/acceptance/benchmark/coverage.py
@@ -36,6 +36,7 @@ from acceptance.coverage.declaration_comparison import (
 )
 from acceptance.coverage.disposition import DispositionedChange, classify_dispositions
 from acceptance.coverage.open_questions import apply_open_question_resolutions, resolve_open_questions
+from acceptance.coverage.recommendations import recommend_tests
 from acceptance.coverage.unrequested import detect_unrequested_changes
 from acceptance.evidence.discovery import discover_tests
 from acceptance.evidence.discrimination import judge_discrimination
@@ -147,6 +148,7 @@ def classify_case(
     )
     resolutions = resolve_open_questions(decomposition.open_questions, change_set, client)
     open_questions = apply_open_question_resolutions(decomposition.open_questions, resolutions)
+    recommendations = recommend_tests(obligations, discriminations, change_set, client)
 
     obligations_by_id = {obligation.id: obligation for obligation in obligations}
     findings = [
@@ -179,5 +181,6 @@ def classify_case(
         change_set=change_set,
         declaration=declaration,
         findings=findings,
+        recommendations=recommendations,
     )
     return scored_copy(case, review)

--- a/src/acceptance/coverage/recommendations.py
+++ b/src/acceptance/coverage/recommendations.py
@@ -1,0 +1,151 @@
+"""Structured test recommendations (M7.1, §9.5).
+
+For each criterion whose evidence is missing or weak — anything the §9.3
+strength classifier (M5.3) rates below `strongly_supported` — prescribe the
+test that would strengthen it, as machine-readable data a coding agent can
+pick up and implement in a single iteration. "Add more tests" is insufficient
+(§9.5, principle 9): every recommendation ties to a specific obligation, the
+plausible defect it must detect, a discriminating setup, and required
+assertions.
+
+The plausible defect (§9.5 field 6) is not re-derived here — it is the
+SURVIVING defect the M5.2 discrimination judge already named (the one the
+current tests fail to catch). Reusing it keeps the recommendation pointed at
+the exact weakness §8.2 found, so a green run of the added test demonstrably
+closes the gap (§8.4) rather than nominally addressing it.
+
+A semantic judgment (what test, with what inputs/assertions, catches this
+defect), so a schema-constrained model call through the M0.4 harness —
+recorded for replay, never a live call in tests. The product recommends; it
+never modifies code (§9.5).
+"""
+
+from __future__ import annotations
+
+from acceptance.coverage.prompt import render_diff_section
+from acceptance.evidence.discrimination import ObligationDiscrimination
+from acceptance.llm import ModelClient, StrictResponseModel
+from acceptance.review_state import ChangeSet, Obligation, TestRecommendation
+
+# §9.3 classes that represent a real evidence gap — anything short of
+# strongly_supported earns a recommendation (the M7.1 trigger). An obligation
+# with no evidence_class set yet (not classified) is not recommended for here.
+_STRONG = "strongly_supported"
+
+_SYSTEM_PROMPT = """\
+You prescribe ADDITIONAL TESTS for criteria whose current test evidence is
+missing or weak. For each criterion you are given the plausible DEFECT that its
+current tests fail to catch — the test you prescribe must catch exactly that
+defect.
+
+"Add more tests" is not acceptable. For each criterion return a structured
+recommendation with these discrete fields:
+- required_inputs: the input characteristics the test must use — chosen so a
+  CORRECT and an INCORRECT (defective) implementation produce DIFFERENT
+  results. This is the crux: inputs where the defect changes the outcome.
+- boundary_conditions: the boundary or negative conditions to cover (empty,
+  zero, max, the error path), if any.
+- expected_output: the expected output or relationship the test asserts.
+- required_assertions: the specific assertions the test must make (a list).
+- plausible_defect: restate the defect this test is designed to detect — the
+  test must fail if that defect is present.
+- repo_conventions: relevant conventions or fixtures from the diff to follow
+  (test file, naming, existing fixtures) so the added test fits the repo.
+
+Return one recommendation per criterion you are given, keyed by its
+`obligation_id`. If given no criteria, return an empty list."""
+
+
+class _Recommendation(StrictResponseModel):
+    obligation_id: str
+    required_inputs: str
+    boundary_conditions: str
+    expected_output: str
+    required_assertions: list[str]
+    plausible_defect: str
+    repo_conventions: str
+
+
+class _Recommendations(StrictResponseModel):
+    recommendations: list[_Recommendation]
+
+
+def _weak_obligations(obligations: list[Obligation]) -> list[Obligation]:
+    """Obligations with a real evidence gap — evidence_class set and below
+    strongly_supported (the M7.1 trigger)."""
+    return [
+        obligation
+        for obligation in obligations
+        if obligation.evidence_class is not None and obligation.evidence_class != _STRONG
+    ]
+
+
+def _surviving_defects(discrimination: ObligationDiscrimination | None) -> list[str]:
+    if discrimination is None:
+        return []
+    return [d.description for d in discrimination.defects if not d.would_be_caught]
+
+
+def _render_prompt(
+    weak: list[Obligation],
+    discriminations_by_obligation: dict[str, ObligationDiscrimination],
+    change_set: ChangeSet,
+) -> str:
+    lines = ["## Criteria needing stronger test evidence", ""]
+    for obligation in weak:
+        lines.append(f"### id={obligation.id}")
+        lines.append(f"criterion: {obligation.observable_behavior or obligation.description}")
+        lines.append(f"evidence class: {obligation.evidence_class}")
+        defects = _surviving_defects(discriminations_by_obligation.get(obligation.id))
+        if defects:
+            lines.append("plausible defects the current tests do NOT catch:")
+            lines.extend(f"  - {d}" for d in defects)
+        lines.append("")
+    lines.extend(render_diff_section(change_set))
+    return "\n".join(lines)
+
+
+def recommend_tests(
+    obligations: list[Obligation],
+    discriminations: list[ObligationDiscrimination],
+    change_set: ChangeSet,
+    client: ModelClient,
+) -> list[TestRecommendation]:
+    """Prescribe a §9.5 test recommendation for each not-strongly-supported
+    obligation. No weak obligations -> no model call."""
+    weak = _weak_obligations(obligations)
+    if not weak:
+        return []
+
+    discriminations_by_obligation = {d.obligation_id: d for d in discriminations}
+    messages = [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {
+            "role": "user",
+            "content": _render_prompt(weak, discriminations_by_obligation, change_set),
+        },
+    ]
+    result = client.complete(messages, _Recommendations)
+
+    criterion_by_id = {
+        obligation.id: (obligation.observable_behavior or obligation.description)
+        for obligation in weak
+    }
+    recommendations = []
+    for rec in result.recommendations:
+        criterion = criterion_by_id.get(rec.obligation_id)
+        if criterion is None:
+            continue  # model named an obligation that isn't weak / doesn't exist
+        recommendations.append(
+            TestRecommendation(
+                obligation_id=rec.obligation_id,
+                criterion=criterion,
+                required_inputs=rec.required_inputs,
+                boundary_conditions=rec.boundary_conditions,
+                expected_output=rec.expected_output,
+                required_assertions=rec.required_assertions,
+                plausible_defect=rec.plausible_defect,
+                repo_conventions=rec.repo_conventions,
+            )
+        )
+    return recommendations

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -46,6 +46,7 @@ __all__ = [
     "ExecutionEvidence",
     "Link",
     "Finding",
+    "TestRecommendation",
     "ReviewProvenance",
     "Review",
 ]
@@ -345,6 +346,26 @@ class Finding(_Model):
         return self
 
 
+class TestRecommendation(_Model):
+    """A §9.5 structured recommendation for additional test evidence (M7.1).
+
+    Emitted for a criterion whose evidence is missing/weak, in a
+    machine-readable form a coding agent can pick up and implement in a single
+    iteration. The product recommends — it never modifies code (§9.5). Each
+    field is one of §9.5's discrete prescriptions; `plausible_defect` is the
+    surviving §8.2 defect the recommended test must catch, so a green run
+    demonstrably closes the gap rather than nominally addressing it (§8.4)."""
+
+    obligation_id: str
+    criterion: str  # the obligation's observable behavior, restated
+    required_inputs: str
+    boundary_conditions: str
+    expected_output: str
+    required_assertions: list[str] = Field(default_factory=list)
+    plausible_defect: str
+    repo_conventions: str
+
+
 class ReviewProvenance(_Model):
     """How a review was produced (§13.6 trustworthiness). Stored so a reader
     can tell what determinism controls were in force — a fixed-seed replay is
@@ -369,6 +390,7 @@ class Review(_Model):
     obligation_map: list[Obligation] = Field(default_factory=list)
     open_questions: list[OpenQuestion] = Field(default_factory=list)
     findings: list[Finding] = Field(default_factory=list)
+    recommendations: list[TestRecommendation] = Field(default_factory=list)
     limitations: list[str] = Field(default_factory=list)
     recommendation: str | None = None
 

--- a/tests/benchmark/test_coverage.py
+++ b/tests/benchmark/test_coverage.py
@@ -106,6 +106,7 @@ def test_archetype_1_missed_obligation_yields_full_recall_and_precision(tmp_path
                 ]
             ),
             "_Detections": {"unrequested_changes": []},
+            "_Recommendations": {"recommendations": []},
         }
     )
 
@@ -171,6 +172,7 @@ def test_archetype_1_evidence_agreement_reports_a_real_number(tmp_path):
                 ]
             ),
             "_Detections": {"unrequested_changes": []},
+            "_Recommendations": {"recommendations": []},
         }
     )
 
@@ -222,6 +224,7 @@ def test_archetype_2_missed_qualifier_yields_full_recall_and_precision(tmp_path)
                 ]
             ),
             "_Detections": {"unrequested_changes": []},
+            "_Recommendations": {"recommendations": []},
         }
     )
 
@@ -291,6 +294,7 @@ def test_archetype_8_unrequested_change_gap_matches_via_its_obligation(tmp_path)
                 "disposition": "risky",
                 "rationale": "edits checkout's existing public signature; could hide a regression.",
             },
+            "_Recommendations": {"recommendations": []},
         }
     )
 
@@ -366,6 +370,7 @@ def test_archetype_8_unrequested_change_metric_does_not_route_through_coverage(t
                 "disposition": "risky",
                 "rationale": "edits checkout's existing public signature; could hide a regression.",
             },
+            "_Recommendations": {"recommendations": []},
         }
     )
 
@@ -402,6 +407,7 @@ def test_declaration_present_is_parsed_onto_the_review(tmp_path):
                 [{"obligation_id": "get-user", "status": "addressed"}]
             ),
             "_Detections": {"unrequested_changes": []},
+            "_Recommendations": {"recommendations": []},
             "_Mismatches": {"mismatches": []},
         }
     )
@@ -440,6 +446,7 @@ def test_archetype_7_declaration_overclaim_produces_a_mismatch_finding(tmp_path)
                 [{"obligation_id": "get-user", "status": "addressed"}]
             ),
             "_Detections": {"unrequested_changes": []},
+            "_Recommendations": {"recommendations": []},
             "_Mismatches": {
                 "mismatches": [
                     {
@@ -471,6 +478,7 @@ def test_classify_case_does_not_mutate_the_input_case(tmp_path):
             "_Decomposition": _decomposition_response([]),
             "_Coverage": {"classifications": []},
             "_Detections": {"unrequested_changes": []},
+            "_Recommendations": {"recommendations": []},
         }
     )
 

--- a/tests/coverage/test_recommendations.py
+++ b/tests/coverage/test_recommendations.py
@@ -1,0 +1,122 @@
+"""M7.1 acceptance: for a criterion whose test evidence is weak, a §9.5
+structured recommendation is produced with every field populated — the
+non-discriminating contractual-accrual/daily-rate case (archetype #4).
+
+Generation is a schema-constrained model call; per the replay-first invariant
+these tests inject the recorded response via completion_fn — no live calls.
+Recommendation *quality* against the real model is shown by the PR's record run."""
+
+from acceptance.coverage.recommendations import recommend_tests
+from acceptance.evidence.discrimination import ObligationDiscrimination, PlausibleDefect
+from acceptance.review_state import ChangeSet, DiffHunk, FileChange, Obligation, ObligationType
+from tests.support import client_returning as _client_returning
+
+
+def _obligation(obligation_id: str, description: str, evidence_class: str | None) -> Obligation:
+    return Obligation(
+        id=obligation_id, description=description, type=ObligationType.FUNCTIONAL,
+        importance="critical", explicit=True, observable_behavior=description,
+        evidence_class=evidence_class,
+    )
+
+
+def _change_set() -> ChangeSet:
+    return ChangeSet(base_revision="a", head_revision="b", files=[
+        FileChange(path="billing.py", status="modified", category="source", hunks=[
+            DiffHunk(header="@@ -1 +3 @@", old_start=1, old_lines=1, new_start=1, new_lines=3,
+                     content="+    return round(monthly_price / days_in_month * days_used, 2)"),
+        ]),
+    ])
+
+
+def _exploding_client():
+    from acceptance.llm import Mode, ModelClient, TranscriptStore
+    import tempfile
+
+    def boom(**kwargs):
+        raise AssertionError("a model call was issued with no weak obligations")
+
+    return ModelClient(
+        model="x", mode=Mode.RECORD, store=TranscriptStore(tempfile.mkdtemp()), completion_fn=boom
+    )
+
+
+def test_weak_criterion_gets_a_fully_populated_recommendation():
+    # Archetype #4's daily-rate gap: the only test uses a 30-day month, where
+    # price/days_in_month and a hard-coded price/30 give the same answer.
+    obligations = [
+        _obligation("daily-rate", "Daily rate is monthly_price divided by days_in_month",
+                    "nominally_supported"),
+    ]
+    discriminations = [
+        ObligationDiscrimination(
+            obligation_id="daily-rate",
+            defects=[PlausibleDefect(
+                description="hard-codes price/30 instead of price/days_in_month",
+                would_be_caught=False, reason="a 30-day month gives the same result either way",
+            )],
+            discriminating=False,
+        )
+    ]
+    response = {
+        "recommendations": [
+            {
+                "obligation_id": "daily-rate",
+                "required_inputs": "A month whose length is not 30, e.g. days_in_month=28.",
+                "boundary_conditions": "0 days used and a full month.",
+                "expected_output": "prorate(28*price, 14, 28) uses price/28, differing from price/30.",
+                "required_assertions": ["assert prorate(280, 14, 28) == 140.0"],
+                "plausible_defect": "implementation hard-codes /30 instead of /days_in_month",
+                "repo_conventions": "add to test_billing.py alongside test_half_of_a_month",
+            }
+        ]
+    }
+
+    recommendations = recommend_tests(
+        obligations, discriminations, _change_set(), _client_returning(response)
+    )
+
+    assert len(recommendations) == 1
+    rec = recommendations[0]
+    assert rec.obligation_id == "daily-rate"
+    assert rec.criterion == "Daily rate is monthly_price divided by days_in_month"
+    # Every §9.5 field is populated.
+    assert rec.required_inputs
+    assert rec.boundary_conditions
+    assert rec.expected_output
+    assert rec.required_assertions
+    assert "30" in rec.plausible_defect
+    assert rec.repo_conventions
+
+
+def test_strongly_supported_obligations_get_no_recommendation_and_no_model_call():
+    obligations = [
+        _obligation("solid", "Well-tested behavior", "strongly_supported"),
+    ]
+    # The exploding client proves no model call is issued when nothing is weak.
+    recommendations = recommend_tests(obligations, [], _change_set(), _exploding_client())
+    assert recommendations == []
+
+
+def test_unclassified_obligations_are_not_recommended():
+    # evidence_class=None means "not yet classified", not "weak" — skip it.
+    obligations = [_obligation("pending", "Not yet classified", None)]
+    recommendations = recommend_tests(obligations, [], _change_set(), _exploding_client())
+    assert recommendations == []
+
+
+def test_recommendation_round_trips_through_persistence():
+    obligations = [_obligation("daily-rate", "Daily rate rule", "partially_supported")]
+    response = {
+        "recommendations": [
+            {
+                "obligation_id": "daily-rate", "required_inputs": "i", "boundary_conditions": "b",
+                "expected_output": "o", "required_assertions": ["a"], "plausible_defect": "d",
+                "repo_conventions": "c",
+            }
+        ]
+    }
+    from acceptance.review_state import TestRecommendation
+
+    rec = recommend_tests(obligations, [], _change_set(), _client_returning(response))[0]
+    assert TestRecommendation.from_dict(rec.to_dict()) == rec


### PR DESCRIPTION
## Summary
M7.1 — structured recommendations, the entry point of the M7 assembly milestone.

- `recommend_tests` (`coverage/recommendations.py`) is a schema-constrained model call that, for each obligation whose M5.3 `evidence_class` is short of `strongly_supported`, prescribes the test that would strengthen it — the §9.5 fields as discrete machine-readable data a coding agent can implement in one iteration: `required_inputs`, `boundary_conditions`, `expected_output`, `required_assertions`, `plausible_defect`, `repo_conventions`.
- The plausible defect (§9.5 field 6) is **not re-derived** — it's the *surviving* defect M5.2's discrimination judge already named (`would_be_caught=False`), so a green run of the added test demonstrably closes the gap (§8.4) rather than nominally addressing it.
- Trigger (confirmed decision): **any not-strongly-supported obligation**. An obligation with no `evidence_class` (unclassified) is skipped; no weak obligations → no model call.
- `TestRecommendation` added to `review_state.py`, carried on `Review.recommendations`; wired into `classify_case` after strength classification. The existing singular `Review.recommendation` string is untouched (that's M7.3's next-instruction pointer).

## Dogfood
**Live RECORD run against archetype #4** (the acceptance criterion — injected-response unit tests can't prove the model produces a genuinely *discriminating* recommendation):
```
required_inputs:    ...days_in_month is not 30, e.g. 31.0, 1, 31 ... so price/30 differs from price/days_in_month
expected_output:    ...for 31.0, 1, 31 the expected output is 1.0, not 1.03
required_assertions:[..., 'Assert the result is not the value produced by dividing by 30 ...']
plausible_defect:   Implementation hard-codes daily_rate as monthly_price / 30 ...
repo_conventions:   Follow the existing pytest style in test_billing.py ...
```
That's the direct analog of §9.5's contractual-accrual example, all seven fields populated, produced by the real model.

`decompose` + `classify` on this PR's own diff: 9 obligations, **zero open questions**, all `[addressed]`. One unrequested-change finding came back `[separable]` (the `_Recommendations` dispatch entries added to ~8 existing benchmark tests) — **investigated and confirmed a classifier false-positive**: those edits are load-bearing (7 tests fail without them, verified), so they're `in_service`, not separable. Filed as **#139** (a recurring disposition-classifier gap on same-diff-required test-fixture updates, same family as #122/#126), not a real scope issue with this PR.

## Test plan
- [x] `pytest -q` — 399 passed
- [x] `ruff check src tests` — clean
- [x] Live RECORD run above (prompt-quality / real-model acceptance)
- [x] Unit tests (`tests/coverage/test_recommendations.py`): weak criterion → all §9.5 fields populated; strongly-supported → no recommendation and no model call; unclassified → skipped; round-trip
- [x] Existing benchmark tests updated with `_Recommendations` dispatch (required by the shared-pipeline wiring — see #139)

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)
