### PR TITLE
Derive the completion verdict deterministically from findings

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,13 +1,13 @@
 # Task
-For each criterion whose test evidence is missing or weak, produce a machine-readable §9.5 recommendation with the criterion, required input characteristics, boundary or negative conditions, expected output or relationship, required assertions, the plausible defect it should detect, and relevant repo conventions or fixtures. Archetype #4's shape: the daily-rate criterion's only test uses a 30-day month, where dividing by days_in_month and dividing by a hard-coded 30 give the same answer, so the recommendation must prescribe a discriminating test.
+Derive an overall completion result — no-material-gaps, incomplete, needs-clarification, needs-non-code-review, or unable-to-determine — from the review's findings, with stated confidence limitations. A positive (no-material-gaps) result renders the §3.7 caveat that it means no material gaps at the achievable evidence tier, not proof of correctness. An unresolved open question cannot render a positive result.
 
 ## Constraints
-- Recommend a test for every obligation whose evidence class is anything short of strongly supported; an obligation with no evidence class set yet is not yet classified and is not recommended for.
-- The plausible defect the recommended test must catch is the surviving defect the discrimination step already identified, not a newly invented one, so a passing added test demonstrably closes the gap rather than nominally addressing it.
-- Every recommendation is structured, machine-readable data a coding agent can pick up and implement in a single iteration; "add more tests" is insufficient.
-- The product recommends and never modifies code. Generation is a semantic judgment routed through the model harness, recorded for replay; no live model call in tests.
+- The verdict is a deterministic, pure function of the findings — never a model call — so the headline result is auditable and traces to the exact obligations and findings that produced it, not a free-text conclusion.
+- Any coverage gap or any non-strong test evidence blocks a positive result (positive results are bounded); severity or importance weighted materiality is a deliberate future refinement, not built now.
+- Advisory findings — an unrequested change or a declaration mismatch — never move the verdict; a change whose obligations are all strongly supported is no-material-gaps even alongside an advisory finding.
+- Obligations whose evidence is indeterminate are surfaced as escalation candidates: the set where deeper retrieval or execution could move the verdict, so a future try-harder loop attaches there while this rollup stays a stable function.
 
 ## Completion expectations
 - Implementation
-- Archetype #4's weak daily-rate criterion yields a recommendation with every §9.5 field populated, prescribing an input where a correct and a defective implementation differ.
-- A strongly supported obligation yields no recommendation, and no model call is made when nothing is weak.
+- Each verdict state is produced for its corresponding finding pattern; a coverage gap or weak evidence yields incomplete, an unresolved open question yields needs-clarification, and all-strong yields no-material-gaps with the §3.7 caveat.
+- An indeterminate obligation yields unable-to-determine and is listed as an escalation candidate.

--- a/src/acceptance/benchmark/coverage.py
+++ b/src/acceptance/benchmark/coverage.py
@@ -48,6 +48,7 @@ from acceptance.llm import ModelClient
 from acceptance.requirement.declaration import declaration_absent_finding, parse_declaration
 from acceptance.requirement.obligations import decompose
 from acceptance.requirement.task_file import parse_task_file
+from acceptance.verdict import derive_verdict
 from acceptance.review_state import (
     UNREQUESTED_CHANGE,
     Finding,
@@ -172,6 +173,8 @@ def classify_case(
         declaration = None
         findings.append(declaration_absent_finding())
 
+    completion = derive_verdict(obligations, findings, open_questions)
+
     review = Review(
         mode="local",
         reviewed_revision=case.inputs.head_revision,
@@ -182,5 +185,6 @@ def classify_case(
         declaration=declaration,
         findings=findings,
         recommendations=recommendations,
+        completion=completion,
     )
     return scored_copy(case, review)

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -47,6 +47,8 @@ __all__ = [
     "Link",
     "Finding",
     "TestRecommendation",
+    "CompletionVerdict",
+    "CompletionResult",
     "ReviewProvenance",
     "Review",
 ]
@@ -366,6 +368,33 @@ class TestRecommendation(_Model):
     repo_conventions: str
 
 
+class CompletionVerdict(str, Enum):
+    """§10.1 step 11 overall completion result. A positive verdict
+    (`no_material_gaps`) is bounded — "no material gaps at the achievable
+    evidence tier," never proof of correctness (§3.7)."""
+
+    NO_MATERIAL_GAPS = "no_material_gaps"
+    INCOMPLETE = "incomplete"
+    NEEDS_CLARIFICATION = "needs_clarification"
+    NEEDS_NON_CODE_REVIEW = "needs_non_code_review"
+    UNABLE_TO_DETERMINE = "unable_to_determine"
+
+
+class CompletionResult(_Model):
+    """The overall completion verdict, derived deterministically from the
+    findings (M7.2). Kept a pure rollup so the headline result is auditable —
+    it traces to the exact findings that produced it, never a free-text model
+    conclusion (§13.6). `escalation_candidates` names the obligations whose
+    evidence is indeterminate — the set where spending more effort (deeper
+    retrieval, execution, §8/M8) could move the verdict; the seam a future
+    "try harder" loop attaches to, re-deriving this same function afterward."""
+
+    verdict: CompletionVerdict
+    rationale: str
+    limitations: list[str] = Field(default_factory=list)
+    escalation_candidates: list[str] = Field(default_factory=list)
+
+
 class ReviewProvenance(_Model):
     """How a review was produced (§13.6 trustworthiness). Stored so a reader
     can tell what determinism controls were in force — a fixed-seed replay is
@@ -391,6 +420,7 @@ class Review(_Model):
     open_questions: list[OpenQuestion] = Field(default_factory=list)
     findings: list[Finding] = Field(default_factory=list)
     recommendations: list[TestRecommendation] = Field(default_factory=list)
+    completion: CompletionResult | None = None
     limitations: list[str] = Field(default_factory=list)
     recommendation: str | None = None
 

--- a/src/acceptance/verdict.py
+++ b/src/acceptance/verdict.py
@@ -1,0 +1,147 @@
+"""Completion verdict derivation (M7.2, §10.1 step 11, §3.7).
+
+Rolls the findings up into one overall result:
+no-material-gaps / incomplete / needs-clarification / needs-non-code-review /
+unable-to-determine.
+
+This is a **deterministic, pure function of the findings** — never a model
+call. The headline result is the product's most consequential output, so it
+must be auditable: it traces to the exact obligations/findings that produced
+it, not a free-text conclusion a model asserted (§13.6, "no free-text
+conclusions"). "Trying harder" on a hard case belongs upstream — resolving an
+`indeterminate` finding via deeper retrieval or execution raises its evidence,
+and then this same function re-derives cleanly. `escalation_candidates` names
+exactly where that extra effort would matter, so the seam for a future
+"try harder" loop is explicit while the rollup stays a stable function.
+
+Materiality is strict here: any coverage gap or any non-strong test evidence
+blocks a positive verdict ("positive results are bounded," §3.7 — decision A).
+Severity/importance-weighted materiality (a low-severity gap on a normal-
+importance obligation counting as immaterial) is a deliberate future
+refinement, not built now.
+
+Advisory findings never move the verdict: an `unrequested_change` (real code,
+scored on its own axis) and a `declaration_mismatch` (a bogus claim about
+undone work) are flagged but do not block acceptance of the delivered change
+(DR-081, issue #31) — so a change whose obligations are all strongly supported
+is `no_material_gaps` even alongside an advisory declaration overclaim.
+"""
+
+from __future__ import annotations
+
+from acceptance.review_state import (
+    CompletionResult,
+    CompletionVerdict,
+    Finding,
+    Obligation,
+    OpenQuestion,
+)
+
+# §9.3 classes that are a real evidence gap short of strong support (decision A).
+_WEAK_EVIDENCE = {"partially_supported", "nominally_supported", "unsupported"}
+
+_POSITIVE_CAVEAT = (
+    "No material gaps found at the achievable evidence tier — not proof of "
+    "correctness. The full application was not independently executed (§3.7)."
+)
+_STATIC_CAVEAT = (
+    "Judgments are static inferences unless a higher tier is recorded; the "
+    "full application was not independently executed."
+)
+
+
+def derive_verdict(
+    obligations: list[Obligation],
+    findings: list[Finding],
+    open_questions: list[OpenQuestion],
+) -> CompletionResult:
+    """Deterministically roll the review up into one completion verdict."""
+    if not obligations:
+        return CompletionResult(
+            verdict=CompletionVerdict.UNABLE_TO_DETERMINE,
+            rationale="No obligations were derived from the task; nothing to assess.",
+            limitations=[_STATIC_CAVEAT],
+        )
+
+    gap_obligations = {
+        finding.related_obligation
+        for finding in findings
+        if finding.type == "coverage_gap" and finding.related_obligation is not None
+    }
+
+    material_gaps: list[str] = []
+    weak_evidence: list[str] = []
+    non_code: list[str] = []
+    indeterminate: list[str] = []
+    for obligation in obligations:
+        if obligation.description in gap_obligations:
+            material_gaps.append(obligation.id)  # code missing/partial — a coverage gap
+            continue
+        evidence = obligation.evidence_class
+        if evidence == "requires_other_evidence":
+            non_code.append(obligation.id)
+        elif evidence in _WEAK_EVIDENCE:
+            weak_evidence.append(obligation.id)  # present but non-discriminating tests
+        elif evidence == "indeterminate" or evidence is None:
+            indeterminate.append(obligation.id)
+        # strongly_supported -> no gap
+
+    unresolved = [q.id for q in open_questions if not q.resolved]
+
+    # Precedence: an unresolved material ambiguity undermines every other
+    # judgment, so it comes first; a definite gap (code or evidence) outranks
+    # mere uncertainty (indeterminate); advisory findings never appear here.
+    if unresolved:
+        return CompletionResult(
+            verdict=CompletionVerdict.NEEDS_CLARIFICATION,
+            rationale=(
+                f"{len(unresolved)} open question(s) remain unresolved by the diff; "
+                "the delivered behavior cannot be judged until they are answered."
+            ),
+            limitations=[_STATIC_CAVEAT],
+            escalation_candidates=indeterminate,
+        )
+    if material_gaps or weak_evidence:
+        return CompletionResult(
+            verdict=CompletionVerdict.INCOMPLETE,
+            rationale=_incomplete_rationale(material_gaps, weak_evidence),
+            limitations=[_STATIC_CAVEAT],
+            escalation_candidates=indeterminate,
+        )
+    if non_code:
+        return CompletionResult(
+            verdict=CompletionVerdict.NEEDS_NON_CODE_REVIEW,
+            rationale=(
+                f"{len(non_code)} obligation(s) require evidence the code and tests "
+                "cannot provide (docs, runtime, or deploy behavior)."
+            ),
+            limitations=[_STATIC_CAVEAT],
+            escalation_candidates=indeterminate,
+        )
+    if indeterminate:
+        return CompletionResult(
+            verdict=CompletionVerdict.UNABLE_TO_DETERMINE,
+            rationale=(
+                f"{len(indeterminate)} obligation(s) could not be classified from static "
+                "evidence; deeper retrieval or execution would be needed to decide."
+            ),
+            limitations=[_STATIC_CAVEAT],
+            escalation_candidates=indeterminate,
+        )
+    return CompletionResult(
+        verdict=CompletionVerdict.NO_MATERIAL_GAPS,
+        rationale="Every obligation is addressed and strongly supported by discriminating tests.",
+        limitations=[_POSITIVE_CAVEAT],
+    )
+
+
+def _incomplete_rationale(material_gaps: list[str], weak_evidence: list[str]) -> str:
+    parts = []
+    if material_gaps:
+        parts.append(f"{len(material_gaps)} obligation(s) not fully implemented ({', '.join(material_gaps)})")
+    if weak_evidence:
+        parts.append(
+            f"{len(weak_evidence)} obligation(s) with non-discriminating test evidence "
+            f"({', '.join(weak_evidence)})"
+        )
+    return "; ".join(parts) + "."

--- a/tests/benchmark/test_coverage.py
+++ b/tests/benchmark/test_coverage.py
@@ -119,6 +119,8 @@ def test_archetype_1_missed_obligation_yields_full_recall_and_precision(tmp_path
     )
     assert scored.score.gap_recall == 1.0
     assert scored.score.gap_precision == 1.0
+    # M7.2: a real coverage gap yields an `incomplete` verdict.
+    assert scored.reviewer_output.completion.verdict.value == "incomplete"
 
 
 def test_archetype_1_evidence_agreement_reports_a_real_number(tmp_path):

--- a/tests/test_verdict.py
+++ b/tests/test_verdict.py
@@ -1,0 +1,140 @@
+"""M7.2 acceptance: the completion verdict is derived deterministically from
+the findings, one of no-material-gaps / incomplete / needs-clarification /
+needs-non-code-review / unable-to-determine; a positive verdict renders the
+§3.7 "no material gaps at the achievable tier" caveat; an unresolved open
+question blocks a positive verdict (#113).
+
+derive_verdict is a pure function, so these assert its output directly — no
+model call is involved in the headline result at all."""
+
+from acceptance.review_state import (
+    CompletionVerdict,
+    Finding,
+    Link,
+    Obligation,
+    ObligationType,
+    OpenQuestion,
+)
+from acceptance.evidence_tier import Component, EvidenceTier
+from acceptance.verdict import derive_verdict
+
+
+def _obligation(obligation_id: str, evidence_class: str | None, importance: str = "critical") -> Obligation:
+    return Obligation(
+        id=obligation_id, description=f"{obligation_id} behavior", type=ObligationType.FUNCTIONAL,
+        importance=importance, explicit=True, observable_behavior="...", evidence_class=evidence_class,
+    )
+
+
+def _coverage_gap(obligation_description: str) -> Finding:
+    return Finding(
+        type="coverage_gap", severity="high", description="missing",
+        evidence_tier=EvidenceTier.STATIC, produced_by=Component.STATIC_ANALYZER,
+        links=[Link(kind="requirement", ref="x", text="x")],
+        related_obligation=obligation_description,
+    )
+
+
+def _advisory_finding(finding_type: str) -> Finding:
+    return Finding(
+        type=finding_type, severity="low", description="advisory",
+        evidence_tier=EvidenceTier.BUILDER_CLAIM, produced_by=Component.BUILDER_DECLARATION,
+        links=[Link(kind="declaration", ref="declaration", text="claim")],
+    )
+
+
+def _open_question(question_id: str, resolved: bool) -> OpenQuestion:
+    return OpenQuestion(id=question_id, question="?", resolved=resolved)
+
+
+def test_all_strong_is_no_material_gaps_with_the_caveat():
+    result = derive_verdict([_obligation("a", "strongly_supported")], [], [])
+
+    assert result.verdict is CompletionVerdict.NO_MATERIAL_GAPS
+    assert any("achievable evidence tier" in lim for lim in result.limitations)  # §3.7 caveat
+    assert any("not proof of correctness" in lim for lim in result.limitations)
+
+
+def test_coverage_gap_is_incomplete():
+    obligations = [_obligation("a", "strongly_supported")]
+    findings = [_coverage_gap("a behavior")]
+
+    result = derive_verdict(obligations, findings, [])
+
+    assert result.verdict is CompletionVerdict.INCOMPLETE
+    assert "a" in result.rationale
+
+
+def test_weak_evidence_is_incomplete():
+    # Decision A: present-but-non-discriminating evidence blocks the positive.
+    for weak in ("partially_supported", "nominally_supported", "unsupported"):
+        result = derive_verdict([_obligation("a", weak)], [], [])
+        assert result.verdict is CompletionVerdict.INCOMPLETE, weak
+
+
+def test_unresolved_open_question_blocks_positive_and_needs_clarification():
+    # #113: even with every obligation strong, an unresolved open question
+    # cannot render no-material-gaps.
+    obligations = [_obligation("a", "strongly_supported")]
+    result = derive_verdict(obligations, [], [_open_question("q", resolved=False)])
+
+    assert result.verdict is CompletionVerdict.NEEDS_CLARIFICATION
+
+
+def test_resolved_open_question_does_not_block():
+    obligations = [_obligation("a", "strongly_supported")]
+    result = derive_verdict(obligations, [], [_open_question("q", resolved=True)])
+
+    assert result.verdict is CompletionVerdict.NO_MATERIAL_GAPS
+
+
+def test_requires_non_code_evidence_is_needs_non_code_review():
+    result = derive_verdict([_obligation("a", "requires_other_evidence")], [], [])
+    assert result.verdict is CompletionVerdict.NEEDS_NON_CODE_REVIEW
+
+
+def test_indeterminate_is_unable_to_determine_and_an_escalation_candidate():
+    result = derive_verdict([_obligation("a", "indeterminate")], [], [])
+
+    assert result.verdict is CompletionVerdict.UNABLE_TO_DETERMINE
+    assert result.escalation_candidates == ["a"]  # the seam a try-harder loop consumes
+
+
+def test_unclassified_evidence_is_treated_as_indeterminate():
+    result = derive_verdict([_obligation("a", None)], [], [])
+    assert result.verdict is CompletionVerdict.UNABLE_TO_DETERMINE
+
+
+def test_no_obligations_is_unable_to_determine():
+    result = derive_verdict([], [], [])
+    assert result.verdict is CompletionVerdict.UNABLE_TO_DETERMINE
+
+
+def test_advisory_findings_do_not_block_a_positive_verdict():
+    # A declaration mismatch / unrequested change is advisory (DR-081, #31):
+    # the delivered obligation is strong, so the verdict stays positive.
+    obligations = [_obligation("a", "strongly_supported")]
+    findings = [_advisory_finding("declaration_mismatch"), _advisory_finding("unrequested_change")]
+
+    result = derive_verdict(obligations, findings, [])
+
+    assert result.verdict is CompletionVerdict.NO_MATERIAL_GAPS
+
+
+def test_definite_gap_outranks_indeterminate():
+    # A concrete coverage gap is more actionable than uncertainty -> incomplete,
+    # and the indeterminate obligation is still surfaced for escalation.
+    obligations = [_obligation("a", "strongly_supported"), _obligation("b", "indeterminate")]
+    findings = [_coverage_gap("a behavior")]
+
+    result = derive_verdict(obligations, findings, [])
+
+    assert result.verdict is CompletionVerdict.INCOMPLETE
+    assert result.escalation_candidates == ["b"]
+
+
+def test_completion_result_round_trips_through_persistence():
+    from acceptance.review_state import CompletionResult
+
+    result = derive_verdict([_obligation("a", "strongly_supported")], [], [])
+    assert CompletionResult.from_dict(result.to_dict()) == result


### PR DESCRIPTION
## Summary
M7.2 — the completion verdict (§10.1 step 11), second of M7's six issues.

`derive_verdict` (`verdict.py`) rolls the findings up into one overall result — `no_material_gaps` / `incomplete` / `needs_clarification` / `needs_non_code_review` / `unable_to_determine` — as a **pure, deterministic function**. The headline result is the product's most consequential output, so it must be auditable: it traces to the exact obligations/findings that produced it, never a free-text model conclusion (§13.6).

**Mapping** (precedence top-down):
| Condition | Verdict |
|---|---|
| No obligations, or evidence dominantly `indeterminate`/unclassified | `unable_to_determine` |
| Any *unresolved* open question | `needs_clarification` (blocks positive — #113) |
| Any coverage gap **or** any non-strong evidence | `incomplete` (bounded positive — §3.7, decision A) |
| Remaining blockers only need non-code evidence (`requires_other_evidence`) | `needs_non_code_review` |
| None of the above | `no_material_gaps` + §3.7 caveat |

Advisory findings (`unrequested_change`, `declaration_mismatch`) **never move the verdict** (DR-081, #31). A positive verdict renders the §3.7 *"no material gaps at the achievable tier — not proof of correctness"* caveat.

## Deterministic + escalation-ready (the design discussion)
Per the discussion on this issue: the verdict is deterministic **layer-2** (auditable rollup), while "try harder with more model calls / tool use" belongs **upstream in layer-1** (resolving findings, raising evidence tiers). To keep that seam explicit, `CompletionResult.escalation_candidates` names the `indeterminate` obligations — exactly where deeper retrieval or execution (M8, the #131 drill-down decision) could move the verdict. A future try-harder loop wraps this stable function and re-derives after raising evidence, rather than the verdict itself becoming a model call. Severity/importance-weighted materiality is a deliberate future refinement, not built now.

## Dogfood
`decompose` + `classify` on this PR's own diff: 17 obligations, all `[addressed]`. `decompose` raised one open question (the `needs_non_code_review` trigger, which I'd named but not defined in the task file) — **resolved by the diff** (the tool cited `verdict.py`'s `requires_other_evidence → needs_non_code_review` definition), the #113 resolve-and-record behavior working as designed. 5 unrequested-change findings, all correctly `[in_service]`, none `separable`.

## Test plan
- [x] `pytest -q` — 411 passed
- [x] `ruff check src tests` — clean
- [x] Unit tests (`tests/test_verdict.py`): every verdict state; weak evidence → incomplete (all three classes); unresolved open question → needs-clarification and resolved → not; advisory findings don't block; indeterminate → unable-to-determine + escalation candidate; definite gap outranks indeterminate; round-trip
- [x] Benchmark integration: archetype #1 (real coverage gap) → `incomplete`
- [x] No live RECORD run — the verdict is deterministic (no prompt to validate)

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)
