### PR TITLE
Share one review pipeline and render the real §16 report

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,13 +1,15 @@
 # Task
-Derive an overall completion result — no-material-gaps, incomplete, needs-clarification, needs-non-code-review, or unable-to-determine — from the review's findings, with stated confidence limitations. A positive (no-material-gaps) result renders the §3.7 caveat that it means no material gaps at the achievable evidence tier, not proof of correctness. An unresolved open question cannot render a positive result.
+Produce the §16 CLI output — obligation coverage, test evidence with per-line evidence tier tags, unrequested changes, and a recommended-next-instruction pointer. The `check` command must run the full assembled review pipeline so the report reflects everything the checker computes.
 
 ## Constraints
-- The verdict is a deterministic, pure function of the findings — never a model call — so the headline result is auditable and traces to the exact obligations and findings that produced it, not a free-text conclusion.
-- Any coverage gap or any non-strong test evidence blocks a positive result (positive results are bounded); severity or importance weighted materiality is a deliberate future refinement, not built now.
-- Advisory findings — an unrequested change or a declaration mismatch — never move the verdict; a change whose obligations are all strongly supported is no-material-gaps even alongside an advisory finding.
-- Obligations whose evidence is indeterminate are surfaced as escalation candidates: the set where deeper retrieval or execution could move the verdict, so a future try-harder loop attaches there while this rollup stays a stable function.
+- One shared pipeline serves both the CLI and the benchmark. Previously every capability from test discovery onward reached only the benchmark path, so the command used to dogfood the tool ran an older, shorter chain and could not show test evidence or a verdict at all; sharing one function keeps the two consumers identical by construction.
+- Implementation coverage and test evidence are two distinct axes and render as separate sections: coverage answers whether the code responds to an obligation, evidence answers whether the tests discriminate.
+- Every test-evidence line shows its evidence tier, so a static inference is never presented as execution-confirmed.
+- The headline verdict is the computed completion result; a review with no computed verdict renders as indeterminate rather than assumed good.
+- Unrequested changes render as advisory, each showing its disposition.
 
 ## Completion expectations
 - Implementation
-- Each verdict state is produced for its corresponding finding pattern; a coverage gap or weak evidence yields incomplete, an unresolved open question yields needs-clarification, and all-strong yields no-material-gaps with the §3.7 caveat.
-- An indeterminate obligation yields unable-to-determine and is listed as an escalation candidate.
+- Rendered output matches the §16 layout, with every test-evidence line showing its evidence tier.
+- The benchmark and the CLI produce their reviews from the same pipeline function.
+- `check` accepts an optional builder declaration and reviews the working tree when no head revision is given.

--- a/current-task.md
+++ b/current-task.md
@@ -1,10 +1,13 @@
 # Task
-Produce the §16 CLI output — obligation coverage, test evidence with per-line evidence tier tags, unrequested changes, and a recommended-next-instruction pointer. The `check` command must run the full assembled review pipeline so the report reflects everything the checker computes.
+Produce the §16 CLI output — a per-obligation report where each obligation carries its own code evidence and test evidence, plus unrequested changes and a recommended-next-instruction pointer. The `check` command must run the full assembled review pipeline so the report reflects everything the checker computes.
 
 ## Constraints
-- One shared pipeline serves both the CLI and the benchmark. Previously every capability from test discovery onward reached only the benchmark path, so the command used to dogfood the tool ran an older, shorter chain and could not show test evidence or a verdict at all; sharing one function keeps the two consumers identical by construction.
-- Implementation coverage and test evidence are two distinct axes and render as separate sections: coverage answers whether the code responds to an obligation, evidence answers whether the tests discriminate.
+- One shared pipeline function serves both the CLI and the benchmark. Previously every capability from test discovery onward reached only the benchmark path, so the command used to dogfood the tool ran an older, shorter chain and could not show test evidence or a verdict at all; sharing one function keeps the two consumers identical by construction.
+- The report is organized by obligation: each obligation is a block carrying both of its evidence axes beneath it, rather than two separate lists the reader must join by eye. Code evidence answers whether the code responds to the obligation; test evidence answers whether the tests discriminate.
 - Every test-evidence line shows its evidence tier, so a static inference is never presented as execution-confirmed.
+- Status is stated in words rather than symbols, and obligations, evidence items, findings, questions and recommendations are numbered so a reader can refer to any one of them precisely.
+- A test citation names the specific test, not merely the file that contains it. A code citation names the specific changed region.
+- An obligation records the code regions that satisfy it whatever its status, so the report can say where an obligation was satisfied and not merely that it was.
 - The headline verdict is the computed completion result; a review with no computed verdict renders as indeterminate rather than assumed good.
 - Unrequested changes render as advisory, each showing its disposition.
 

--- a/docs/AI-Assisted-Software-Development-Review-Spec.md
+++ b/docs/AI-Assisted-Software-Development-Review-Spec.md
@@ -407,23 +407,37 @@ Will not: require/privilege a specific agent; read full agent prompt histories; 
 ```
 acceptance check --task .acceptance/current-task.md --base main --head HEAD
 ```
+Output is organized **by obligation**, so a criterion's two axes — code evidence (§9.2) and test evidence (§9.3) — sit together rather than in separate lists the reader must join by eye. Status is stated in words, and every item is numbered (`1.`, `1.1`, …) so a reader can refer to one precisely. Numbering is positional within a report; the durable per-entity ids live in the data model (§15).
+
 ```
 Task completion: INCOMPLETE
 
-Obligation coverage:
-  ✓ CSV generation implemented
-  ✗ Active filters applied
-  ? Displayed column order preserved
-  ✗ 100,000-row limit handled
+2 obligation(s) not fully implemented; 1 with non-discriminating test evidence.
 
-Test evidence:
-  ✓ Basic CSV generation        [execution-confirmed]
-  ✓ Escaping                    [static]
-  ✗ Filter behavior             [unsupported]
-  ✗ Row-limit failure           [unsupported]
+Obligations:
+
+  1. CSV generation implemented
+       code evidence: addressed
+         1.1  export/csv.py#@@ -12,6 +12,28 @@
+       test evidence: strongly supported  [tier: execution-confirmed]
+         1.2  tests/test_export.py::test_generates_csv
+         1.3  tests/test_export.py::test_escaping
+
+  2. Active filters applied to the export
+       code evidence: not addressed
+         (no corresponding change)
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  3. Displayed column order preserved
+       code evidence: unclear
+         3.1  export/csv.py#@@ -40,3 +40,7 @@
+       test evidence: nominally supported  [tier: static]
+         3.2  tests/test_export.py::test_columns
 
 Unrequested changes:
-  ! Export filename behavior changed
+  1. [separable] Export filename behavior changed
+       export/naming.py#@@ -5,2 +5,6 @@
 
 Recommended next instruction: .acceptance/next-instruction.md
 ```

--- a/src/acceptance/benchmark/coverage.py
+++ b/src/acceptance/benchmark/coverage.py
@@ -1,9 +1,12 @@
-"""Coverage & evidence scoring hook (M3.3, extended M5.5).
+"""Coverage & evidence scoring hook (M3.3, extended M5.5; pipeline shared M7.4).
 
 Wires the checker's static-analysis capabilities into the M-B0.3 §11.1
-metrics. Like M1.4's decompose_case (decomposition.py), this stays lighter
-than the full checker pipeline (M-B0.2's run_case) — it only needs a case's
-task text and its materialized repo's diff, no test execution.
+metrics. Since M7.4 the analysis itself lives in `pipeline.py::run_review`,
+shared with the CLI — this module is now just the benchmark's adapter around
+it: materialize the case's diff, run the review, attach it to a scored copy.
+Keeping one pipeline is deliberate: the CLI and the benchmark previously
+drifted (every capability from M4 on reached only the benchmark), which meant
+dogfooding exercised less than the benchmark measured.
 
 `scoring.py`'s gap metric (`_gap_counts`) matches a ground-truth gap to a
 reported `Finding` by the description of the obligation the gap concerns
@@ -14,11 +17,6 @@ covered, so it becomes a Finding linked to that obligation. An
 about code that shouldn't have changed, not about an obligation going
 unmet — so it becomes an unlinked Finding: reported for a human to read, but
 not yet counted by a metric that only scores obligation-linked gaps.
-
-M5.5 adds the test-evidence chain (discover -> map -> extract -> discriminate
--> classify strength) ahead of coverage classification, so `Obligation.
-evidence_class` is set from real analysis of the case's own tests before
-`scoring.py`'s evidence-classification-agreement metric reads it.
 """
 
 from __future__ import annotations
@@ -29,90 +27,8 @@ from acceptance.benchmark.case import BenchmarkCase
 from acceptance.benchmark.hooks import provenance_from, scored_copy
 from acceptance.change.diff import extract_change_set
 from acceptance.config import ScopeExpansionPolicy
-from acceptance.coverage.classify import CoverageStatus, ImplementationCoverage, classify_coverage
-from acceptance.coverage.declaration_comparison import (
-    compare_declaration,
-    declaration_mismatch_finding,
-)
-from acceptance.coverage.disposition import DispositionedChange, classify_dispositions
-from acceptance.coverage.open_questions import apply_open_question_resolutions, resolve_open_questions
-from acceptance.coverage.recommendations import recommend_tests
-from acceptance.coverage.unrequested import detect_unrequested_changes
-from acceptance.evidence.discovery import discover_tests
-from acceptance.evidence.discrimination import judge_discrimination
-from acceptance.evidence.extraction import extract_test_evidence
-from acceptance.evidence.mapping import apply_test_mapping, map_tests_to_obligations
-from acceptance.evidence.strength import apply_evidence_strength, classify_strength
-from acceptance.evidence_tier import Component, EvidenceTier
 from acceptance.llm import ModelClient
-from acceptance.requirement.declaration import declaration_absent_finding, parse_declaration
-from acceptance.requirement.obligations import decompose
-from acceptance.requirement.task_file import parse_task_file
-from acceptance.verdict import derive_verdict
-from acceptance.review_state import (
-    UNREQUESTED_CHANGE,
-    Finding,
-    Link,
-    Obligation,
-    Review,
-    UnrequestedChangeDisposition,
-)
-
-_SEVERITY_BY_STATUS = {
-    CoverageStatus.NOT_ADDRESSED: "high",
-    CoverageStatus.PARTIALLY_ADDRESSED: "medium",
-    CoverageStatus.UNCLEAR: "low",
-    CoverageStatus.REQUIRES_NON_CODE_EVIDENCE: "low",
-}
-
-# An in_service change is accepted; separable should be split; risky demands
-# scrutiny — so severity tracks disposition, not the change's raw kind.
-_SEVERITY_BY_DISPOSITION = {
-    UnrequestedChangeDisposition.IN_SERVICE: "low",
-    UnrequestedChangeDisposition.SEPARABLE: "medium",
-    UnrequestedChangeDisposition.RISKY: "high",
-}
-
-
-def _coverage_finding(obligation: Obligation, coverage: ImplementationCoverage) -> Finding:
-    if coverage.diff_refs:
-        links = [
-            Link(kind="code", ref=f"{ref.file}#{ref.hunk_header}", text=coverage.rationale)
-            for ref in coverage.diff_refs
-        ]
-    else:
-        links = [Link(kind="requirement", ref=obligation.id, text=obligation.description)]
-    return Finding(
-        type="coverage_gap",
-        severity=_SEVERITY_BY_STATUS[coverage.status],
-        description=coverage.rationale,
-        evidence_tier=EvidenceTier.STATIC,
-        produced_by=Component.STATIC_ANALYZER,
-        links=links,
-        related_obligation=obligation.description,
-    )
-
-
-def _unrequested_finding(dispositioned: DispositionedChange) -> Finding | None:
-    change = dispositioned.change
-    # No diff location to point to means nothing a human can act on; the
-    # required-link invariant (Finding._require_at_least_one_link) would
-    # reject it anyway, so skip rather than fabricate a link.
-    if not change.diff_refs:
-        return None
-    return Finding(
-        type=UNREQUESTED_CHANGE,
-        severity=_SEVERITY_BY_DISPOSITION[dispositioned.disposition],
-        description=change.rationale,
-        evidence_tier=EvidenceTier.STATIC,
-        produced_by=Component.STATIC_ANALYZER,
-        links=[
-            Link(kind="code", ref=f"{ref.file}#{ref.hunk_header}", text=change.rationale)
-            for ref in change.diff_refs
-        ],
-        disposition=dispositioned.disposition,
-        recommended_action=dispositioned.recommendation,
-    )
+from acceptance.pipeline import run_review
 
 
 def classify_case(
@@ -120,71 +36,21 @@ def classify_case(
     client: ModelClient,
     policy: ScopeExpansionPolicy = ScopeExpansionPolicy.STRICT,
 ) -> BenchmarkCase:
-    """Decompose; discover and map candidate tests; extract, discriminate, and
-    classify their evidence strength; classify coverage, detect unrequested
-    changes and their dispositions for a case's diff; return a scored copy of
-    `case`. The benchmark's assembled static pipeline — each capability lands
-    here as it ships so its §11.1 metric is scored (M3-M5)."""
-    parsed = parse_task_file(case.inputs.task_text)
-    decomposition = decompose(parsed, client)
-    obligations = decomposition.obligations
+    """Run the shared review pipeline over a case's diff and return a scored
+    copy of `case`. The benchmark's adapter around `run_review` — every
+    capability the CLI runs is scored here, by construction."""
     repo = Path(case.inputs.repo)
     change_set = extract_change_set(
         repo, case.inputs.base_revision, case.inputs.head_revision
     )
-
-    discovered = discover_tests(repo, change_set)
-    mapping = map_tests_to_obligations(obligations, discovered.tests, client)
-    obligations = apply_test_mapping(obligations, mapping)
-
-    test_evidence = extract_test_evidence(repo, discovered.tests, change_set, mapping)
-    discriminations = judge_discrimination(obligations, test_evidence, change_set, client)
-    strengths = classify_strength(obligations, test_evidence, discriminations)
-    obligations = apply_evidence_strength(obligations, strengths)
-
-    coverages = classify_coverage(obligations, change_set, client)
-    unrequested = detect_unrequested_changes(obligations, change_set, client)
-    dispositioned = classify_dispositions(
-        unrequested, obligations, coverages, change_set, policy, client
-    )
-    resolutions = resolve_open_questions(decomposition.open_questions, change_set, client)
-    open_questions = apply_open_question_resolutions(decomposition.open_questions, resolutions)
-    recommendations = recommend_tests(obligations, discriminations, change_set, client)
-
-    obligations_by_id = {obligation.id: obligation for obligation in obligations}
-    findings = [
-        _coverage_finding(obligations_by_id[coverage.obligation_id], coverage)
-        for coverage in coverages
-        if coverage.status != CoverageStatus.ADDRESSED
-    ]
-    findings.extend(
-        finding
-        for finding in (_unrequested_finding(change) for change in dispositioned)
-        if finding is not None
-    )
-
-    if case.inputs.declaration_text is not None:
-        declaration = parse_declaration(case.inputs.declaration_text)
-        mismatches = compare_declaration(
-            declaration, obligations, change_set, test_evidence, client
-        )
-        findings.extend(declaration_mismatch_finding(m) for m in mismatches)
-    else:
-        declaration = None
-        findings.append(declaration_absent_finding())
-
-    completion = derive_verdict(obligations, findings, open_questions)
-
-    review = Review(
-        mode="local",
-        reviewed_revision=case.inputs.head_revision,
-        provenance=provenance_from(client),
-        obligation_map=obligations,
-        open_questions=open_questions,
+    review = run_review(
+        task_text=case.inputs.task_text,
         change_set=change_set,
-        declaration=declaration,
-        findings=findings,
-        recommendations=recommendations,
-        completion=completion,
+        repo=repo,
+        client=client,
+        reviewed_revision=case.inputs.head_revision,
+        declaration_text=case.inputs.declaration_text,
+        policy=policy,
+        provenance=provenance_from(client),
     )
     return scored_copy(case, review)

--- a/src/acceptance/benchmark/runner.py
+++ b/src/acceptance/benchmark/runner.py
@@ -15,6 +15,7 @@ from acceptance.benchmark.case import BenchmarkCase
 from acceptance.benchmark.scoring import score_case
 from acceptance.cli import run_check
 from acceptance.config import RunConfig
+from acceptance.llm import ModelClient
 from acceptance.review_store import ReviewStore
 
 
@@ -22,6 +23,7 @@ def run_case(
     case: BenchmarkCase,
     config: RunConfig | None = None,
     review_store: ReviewStore | None = None,
+    client: ModelClient | None = None,
 ) -> BenchmarkCase:
     """Run the checker over `case.inputs` and return a scored copy of `case`."""
     config = config if config is not None else RunConfig()
@@ -42,6 +44,7 @@ def run_case(
             config=config,
             store=review_store,
             repo=repo,
+            client=client,
         )
     finally:
         task_path.unlink(missing_ok=True)

--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -26,7 +26,8 @@ from acceptance.coverage.classify import ImplementationCoverage, classify_covera
 from acceptance.coverage.disposition import DispositionedChange, classify_dispositions
 from acceptance.coverage.open_questions import apply_open_question_resolutions, resolve_open_questions
 from acceptance.coverage.unrequested import detect_unrequested_changes
-from acceptance.llm import LLMError, Mode
+from acceptance.llm import LLMError, Mode, ModelClient
+from acceptance.pipeline import run_review
 from acceptance.report import render_report
 from acceptance.requirement.obligations import Decomposition, Obligation, decompose
 from acceptance.requirement.task_file import parse_task_file
@@ -63,6 +64,15 @@ def _read_task(task_path: str, repo: Path | None = None) -> str:
     return path.read_text()
 
 
+def _read_declaration(declaration: str | None, repo: Path | None = None) -> str | None:
+    """The optional §7.4 builder declaration's text, or None when not supplied.
+    Optional by default in local mode (§7.4) — its absence is recorded as a
+    minor finding by the pipeline, never an error."""
+    if declaration is None:
+        return None
+    return _read_task(declaration, repo=repo)
+
+
 def _task_ignore_pattern(task_path: str, repo: Path) -> str | None:
     """The `--task` file's path relative to `repo`, as a root-anchored
     gitignore pattern, if the file lives inside the repo — `None` otherwise
@@ -86,10 +96,12 @@ def _task_ignore_pattern(task_path: str, repo: Path) -> str | None:
 def run_check(
     task: str,
     base: str,
-    head: str,
+    head: str | None,
     config: RunConfig,
     store: ReviewStore,
     repo: Path | None = None,
+    declaration: str | None = None,
+    client: ModelClient | None = None,
 ) -> Review:
     """Walking-skeleton pipeline: ingest → build empty Review → persist.
 
@@ -99,23 +111,42 @@ def run_check(
     explicitly instead, since it processes many cases without changing the
     process's working directory.
 
-    The obligation/coverage/test analysis that consumes config.build_client()
-    lands in M1+. What is real here is the end-to-end shape: a task and a
-    revision range in, a well-formed persisted Review out.
+    Since M7.4 this runs the full shared pipeline (`pipeline.run_review`) —
+    the same one the benchmark scores — so the §16 report shows real
+    obligation coverage, test evidence with tiers, unrequested changes, and
+    the computed verdict. `head=None` reviews the working tree (§5.1), so a
+    check can run before a commit exists.
     """
-    _read_task(task, repo=repo)
+    repo_path = repo if repo is not None else Path(".")
+    task_text = _read_task(task, repo=repo)
     base_sha = _resolve_revision(base, repo=repo)
-    head_sha = _resolve_revision(head, repo=repo)
-    review = Review(
-        mode="local",
-        reviewed_revision=head_sha,
+
+    # The task file is the specification, not part of the reviewed deliverable —
+    # it must never appear in its own diff (same rule as run_classify).
+    task_ignore = _task_ignore_pattern(task, repo_path)
+    extra_patterns = [task_ignore] if task_ignore else []
+
+    if head is None:
+        change_set = extract_working_tree_change_set(
+            repo_path, base_sha, extra_ignore_patterns=extra_patterns
+        )
+        reviewed_revision = "<working-tree>"
+    else:
+        reviewed_revision = _resolve_revision(head, repo=repo)
+        change_set = extract_change_set(
+            repo_path, base_sha, reviewed_revision, extra_ignore_patterns=extra_patterns
+        )
+
+    declaration_text = _read_declaration(declaration, repo=repo)
+    review = run_review(
+        task_text=task_text,
+        change_set=change_set,
+        repo=repo_path,
+        client=client if client is not None else config.build_client(),
+        reviewed_revision=reviewed_revision,
+        declaration_text=declaration_text,
+        policy=config.scope_expansion_policy,
         provenance=config.provenance(),
-        # Diff endpoints only; real extraction exists (change/diff.py, dogfooded
-        # via `acceptance diff`) but isn't wired into this pipeline yet (M7).
-        # When it is, pass extra_ignore_patterns=[_task_ignore_pattern(task,
-        # repo)] the same way run_classify does — the task file must never
-        # appear in its own diff.
-        change_set=ChangeSet(base_revision=base_sha, head_revision=head_sha),
     )
     store.write(review)
     return review
@@ -293,7 +324,16 @@ def build_parser() -> argparse.ArgumentParser:
     check = subparsers.add_parser("check", help="Run a local completion check.")
     check.add_argument("--task", required=True, help="Path to the task file.")
     check.add_argument("--base", required=True, help="Base Git revision.")
-    check.add_argument("--head", required=True, help="Head Git revision.")
+    check.add_argument(
+        "--head",
+        default=None,
+        help="Head Git revision. Omit to review the working tree (§5.1).",
+    )
+    check.add_argument(
+        "--declaration",
+        default=None,
+        help="Path to an optional §7.4 builder declaration (absence is a minor finding).",
+    )
     _add_model_flags(check, default_mode=Mode.REPLAY.value)  # never call live unbidden
     check.add_argument(
         "--json",
@@ -363,9 +403,15 @@ def main(argv: list[str] | None = None) -> int:
             temperature=args.temperature,
         )
         try:
-            review = run_check(args.task, args.base, args.head, config, ReviewStore())
+            review = run_check(
+                args.task, args.base, args.head, config, ReviewStore(),
+                declaration=args.declaration,
+            )
         except CliError as exc:
             print(f"acceptance: error: {exc}", file=sys.stderr)
+            return 1
+        except LLMError as exc:
+            print(f"acceptance: model error: {exc}", file=sys.stderr)
             return 1
         if args.json:
             print(json.dumps(review.to_dict(), indent=2))

--- a/src/acceptance/pipeline.py
+++ b/src/acceptance/pipeline.py
@@ -112,15 +112,30 @@ def unrequested_finding(dispositioned: DispositionedChange) -> Finding | None:
 def _apply_coverage_status(
     obligations: list[Obligation], coverages: list[ImplementationCoverage]
 ) -> list[Obligation]:
-    """Record each obligation's §9.2 coverage status on it, so the report can
-    render the implementation-coverage axis faithfully (✓/✗/?) instead of
-    inferring it from which findings happen to exist — findings are lossy here
-    (an `addressed` obligation produces none, and so does an unanalyzed one)."""
-    status_by_id = {c.obligation_id: c.status.value for c in coverages}
-    return [
-        obligation.model_copy(update={"coverage_status": status_by_id.get(obligation.id)})
-        for obligation in obligations
-    ]
+    """Record each obligation's §9.2 coverage status AND the code regions that
+    satisfy it, so the report can render the implementation-coverage axis
+    faithfully instead of inferring it from which findings happen to exist —
+    findings are lossy here (an `addressed` obligation produces none, and so
+    does an unanalyzed one, yet they mean opposite things). Carrying the refs
+    is what lets the review say *where* an obligation was satisfied, not just
+    that it was."""
+    coverage_by_id = {c.obligation_id: c for c in coverages}
+    updated = []
+    for obligation in obligations:
+        coverage = coverage_by_id.get(obligation.id)
+        updated.append(
+            obligation.model_copy(
+                update={
+                    "coverage_status": coverage.status.value if coverage else None,
+                    "coverage_refs": (
+                        [f"{ref.file}#{ref.hunk_header}" for ref in coverage.diff_refs]
+                        if coverage
+                        else []
+                    ),
+                }
+            )
+        )
+    return updated
 
 
 def run_review(

--- a/src/acceptance/pipeline.py
+++ b/src/acceptance/pipeline.py
@@ -1,0 +1,195 @@
+"""The assembled static review pipeline (M7.4).
+
+ONE pipeline, called by both consumers — the CLI (`acceptance check`) and the
+benchmark (`benchmark/coverage.py::classify_case`). Before this existed the two
+had drifted badly: every capability from M4 onward (test discovery/mapping,
+evidence extraction, discrimination, strength, declaration comparison,
+recommendations, verdict) was wired only into the benchmark path, so the CLI —
+the very command used to dogfood the tool against its own changes — still ran
+the M3-era chain and could not show test evidence or a verdict at all. Sharing
+one function makes that divergence impossible by construction rather than by
+keeping two copies in step.
+
+Order follows §10.1: decompose → discover/map tests → extract, discriminate,
+and classify test evidence → implementation coverage → unrequested changes and
+their dispositions → resolve open questions → recommendations → declaration
+comparison → completion verdict.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from acceptance.config import ScopeExpansionPolicy
+from acceptance.coverage.classify import CoverageStatus, ImplementationCoverage, classify_coverage
+from acceptance.coverage.declaration_comparison import (
+    compare_declaration,
+    declaration_mismatch_finding,
+)
+from acceptance.coverage.disposition import DispositionedChange, classify_dispositions
+from acceptance.coverage.open_questions import apply_open_question_resolutions, resolve_open_questions
+from acceptance.coverage.recommendations import recommend_tests
+from acceptance.coverage.unrequested import detect_unrequested_changes
+from acceptance.evidence.discovery import discover_tests
+from acceptance.evidence.discrimination import judge_discrimination
+from acceptance.evidence.extraction import extract_test_evidence
+from acceptance.evidence.mapping import apply_test_mapping, map_tests_to_obligations
+from acceptance.evidence.strength import apply_evidence_strength, classify_strength
+from acceptance.evidence_tier import Component, EvidenceTier
+from acceptance.llm import ModelClient
+from acceptance.requirement.declaration import declaration_absent_finding, parse_declaration
+from acceptance.requirement.obligations import decompose
+from acceptance.requirement.task_file import parse_task_file
+from acceptance.review_state import (
+    UNREQUESTED_CHANGE,
+    ChangeSet,
+    Finding,
+    Link,
+    Obligation,
+    Review,
+    ReviewProvenance,
+    UnrequestedChangeDisposition,
+)
+from acceptance.verdict import derive_verdict
+
+_SEVERITY_BY_STATUS = {
+    CoverageStatus.NOT_ADDRESSED: "high",
+    CoverageStatus.PARTIALLY_ADDRESSED: "medium",
+    CoverageStatus.UNCLEAR: "low",
+    CoverageStatus.REQUIRES_NON_CODE_EVIDENCE: "low",
+}
+
+# An in_service change is accepted; separable should be split; risky demands
+# scrutiny — so severity tracks disposition, not the change's raw kind.
+_SEVERITY_BY_DISPOSITION = {
+    UnrequestedChangeDisposition.IN_SERVICE: "low",
+    UnrequestedChangeDisposition.SEPARABLE: "medium",
+    UnrequestedChangeDisposition.RISKY: "high",
+}
+
+
+def coverage_finding(obligation: Obligation, coverage: ImplementationCoverage) -> Finding:
+    if coverage.diff_refs:
+        links = [
+            Link(kind="code", ref=f"{ref.file}#{ref.hunk_header}", text=coverage.rationale)
+            for ref in coverage.diff_refs
+        ]
+    else:
+        links = [Link(kind="requirement", ref=obligation.id, text=obligation.description)]
+    return Finding(
+        type="coverage_gap",
+        severity=_SEVERITY_BY_STATUS[coverage.status],
+        description=coverage.rationale,
+        evidence_tier=EvidenceTier.STATIC,
+        produced_by=Component.STATIC_ANALYZER,
+        links=links,
+        related_obligation=obligation.description,
+    )
+
+
+def unrequested_finding(dispositioned: DispositionedChange) -> Finding | None:
+    change = dispositioned.change
+    # No diff location to point to means nothing a human can act on; the
+    # required-link invariant (Finding._require_at_least_one_link) would
+    # reject it anyway, so skip rather than fabricate a link.
+    if not change.diff_refs:
+        return None
+    return Finding(
+        type=UNREQUESTED_CHANGE,
+        severity=_SEVERITY_BY_DISPOSITION[dispositioned.disposition],
+        description=change.rationale,
+        evidence_tier=EvidenceTier.STATIC,
+        produced_by=Component.STATIC_ANALYZER,
+        links=[
+            Link(kind="code", ref=f"{ref.file}#{ref.hunk_header}", text=change.rationale)
+            for ref in change.diff_refs
+        ],
+        disposition=dispositioned.disposition,
+        recommended_action=dispositioned.recommendation,
+    )
+
+
+def _apply_coverage_status(
+    obligations: list[Obligation], coverages: list[ImplementationCoverage]
+) -> list[Obligation]:
+    """Record each obligation's §9.2 coverage status on it, so the report can
+    render the implementation-coverage axis faithfully (✓/✗/?) instead of
+    inferring it from which findings happen to exist — findings are lossy here
+    (an `addressed` obligation produces none, and so does an unanalyzed one)."""
+    status_by_id = {c.obligation_id: c.status.value for c in coverages}
+    return [
+        obligation.model_copy(update={"coverage_status": status_by_id.get(obligation.id)})
+        for obligation in obligations
+    ]
+
+
+def run_review(
+    task_text: str,
+    change_set: ChangeSet,
+    repo: Path,
+    client: ModelClient,
+    reviewed_revision: str,
+    declaration_text: str | None = None,
+    policy: ScopeExpansionPolicy = ScopeExpansionPolicy.STRICT,
+    provenance: ReviewProvenance | None = None,
+) -> Review:
+    """Run the full static review pipeline and return the assembled Review."""
+    parsed = parse_task_file(task_text)
+    decomposition = decompose(parsed, client)
+    obligations = decomposition.obligations
+
+    discovered = discover_tests(repo, change_set)
+    mapping = map_tests_to_obligations(obligations, discovered.tests, client)
+    obligations = apply_test_mapping(obligations, mapping)
+
+    test_evidence = extract_test_evidence(repo, discovered.tests, change_set, mapping)
+    discriminations = judge_discrimination(obligations, test_evidence, change_set, client)
+    strengths = classify_strength(obligations, test_evidence, discriminations)
+    obligations = apply_evidence_strength(obligations, strengths)
+
+    coverages = classify_coverage(obligations, change_set, client)
+    obligations = _apply_coverage_status(obligations, coverages)
+    unrequested = detect_unrequested_changes(obligations, change_set, client)
+    dispositioned = classify_dispositions(
+        unrequested, obligations, coverages, change_set, policy, client
+    )
+    resolutions = resolve_open_questions(decomposition.open_questions, change_set, client)
+    open_questions = apply_open_question_resolutions(decomposition.open_questions, resolutions)
+    recommendations = recommend_tests(obligations, discriminations, change_set, client)
+
+    obligations_by_id = {obligation.id: obligation for obligation in obligations}
+    findings = [
+        coverage_finding(obligations_by_id[coverage.obligation_id], coverage)
+        for coverage in coverages
+        if coverage.status != CoverageStatus.ADDRESSED
+    ]
+    findings.extend(
+        finding
+        for finding in (unrequested_finding(change) for change in dispositioned)
+        if finding is not None
+    )
+
+    if declaration_text is not None:
+        declaration = parse_declaration(declaration_text)
+        mismatches = compare_declaration(
+            declaration, obligations, change_set, test_evidence, client
+        )
+        findings.extend(declaration_mismatch_finding(m) for m in mismatches)
+    else:
+        declaration = None
+        findings.append(declaration_absent_finding())
+
+    completion = derive_verdict(obligations, findings, open_questions)
+
+    return Review(
+        mode="local",
+        reviewed_revision=reviewed_revision,
+        provenance=provenance,
+        obligation_map=obligations,
+        open_questions=open_questions,
+        change_set=change_set,
+        declaration=declaration,
+        findings=findings,
+        recommendations=recommendations,
+        completion=completion,
+    )

--- a/src/acceptance/report.py
+++ b/src/acceptance/report.py
@@ -1,13 +1,17 @@
-"""§16 CLI report rendering (M0.6 skeleton; filled in by M7.4).
+"""§16 CLI report rendering (M0.6 skeleton; filled in and restructured by M7.4).
 
-Renders a Review as the §16 layout: the completion verdict, the two review
-axes as separate sections — implementation coverage (§9.2, "does the code
-respond") and test evidence (§9.3, "do the tests discriminate") — advisory
-unrequested changes, and the next-instruction pointer.
+Renders a Review as a numbered, per-obligation report: each obligation is a
+block carrying BOTH review axes beneath it — code evidence (§9.2, "does the
+code respond") and test evidence (§9.3, "do the tests discriminate"). Grouping
+by obligation keeps a criterion's two axes together, where a flat pair of
+sections made the reader join them by eye.
 
-Every conclusion is labeled with its evidence tier (§8.1, §16): a static
-inference is never presented as execution-confirmed. Test-evidence lines carry
-both the §9.3 strength class and the tier that produced it.
+Every line is numbered so a reader can refer to one precisely ("evidence 2.3",
+"unrequested change 1"). Numbering is positional within a report — for a
+stable cross-run handle, obligations also carry their `id` in the data model.
+
+Status is stated in words, not symbols, and every evidence line carries its
+§8.1 tier: a static inference is never presented as execution-confirmed.
 """
 
 from __future__ import annotations
@@ -15,26 +19,8 @@ from __future__ import annotations
 from acceptance.review_state import UNREQUESTED_CHANGE, Obligation, Review
 
 _EMPTY = "  (none)"
-
-# §16 obligation-coverage markers: addressed / not addressed / uncertain.
-_COVERAGE_MARKER = {
-    "addressed": "✓",
-    "partially_addressed": "✗",
-    "not_addressed": "✗",
-    "unclear": "?",
-    "requires_non_code_evidence": "?",
-}
-
-# §9.3 evidence classes that count as real support in the §16 test-evidence
-# column; everything else is a gap the reader must see as unmet.
-_EVIDENCE_MARKER = {
-    "strongly_supported": "✓",
-    "partially_supported": "✗",
-    "nominally_supported": "✗",
-    "unsupported": "✗",
-    "requires_other_evidence": "?",
-    "indeterminate": "?",
-}
+_NO_CODE = "(no corresponding change)"
+_NO_TESTS = "(no mapped test)"
 
 
 def render_report(review: Review) -> str:
@@ -45,19 +31,11 @@ def render_report(review: Review) -> str:
         lines.append(completion.rationale)
         lines.append("")
 
-    lines.append("Obligation coverage:")
+    lines.append("Obligations:")
     if review.obligation_map:
-        lines += [
-            f"  {_COVERAGE_MARKER.get(o.coverage_status or '', '?')} {o.description}"
-            for o in review.obligation_map
-        ]
-    else:
-        lines.append(_EMPTY)
-    lines.append("")
-
-    lines.append("Test evidence:")
-    if review.obligation_map:
-        lines += [_evidence_line(o) for o in review.obligation_map]
+        for index, obligation in enumerate(review.obligation_map, start=1):
+            lines.append("")
+            lines.extend(_obligation_block(index, obligation))
     else:
         lines.append(_EMPTY)
     lines.append("")
@@ -65,31 +43,36 @@ def render_report(review: Review) -> str:
     lines.append("Unrequested changes:")
     unrequested = [f for f in review.findings if f.type == UNREQUESTED_CHANGE]
     if unrequested:
-        for finding in unrequested:
+        for index, finding in enumerate(unrequested, start=1):
             disposition = finding.disposition.value if finding.disposition else "unclassified"
-            lines.append(f"  ! [{disposition}] {finding.description}")
+            lines.append(f"  {index}. [{disposition}] {finding.description}")
+            for link in finding.links:
+                lines.append(f"       {link.ref}")
     else:
         lines.append(_EMPTY)
     lines.append("")
 
     if review.open_questions:
         lines.append("Open questions:")
-        for question in review.open_questions:
-            marker = "resolved" if question.resolved else "open"
-            lines.append(f"  [{marker}] {question.question}")
+        for index, question in enumerate(review.open_questions, start=1):
+            state = "resolved" if question.resolved else "open"
+            lines.append(f"  {index}. [{state}] {question.question}")
+            if question.resolved and question.resolution_rationale:
+                lines.append(f"       {question.resolution_rationale}")
         lines.append("")
 
     if review.recommendations:
         lines.append("Recommended tests:")
-        for rec in review.recommendations:
-            lines.append(f"  - {rec.criterion}")
-            lines.append(f"      inputs: {rec.required_inputs}")
-            lines.append(f"      detects: {rec.plausible_defect}")
+        for index, rec in enumerate(review.recommendations, start=1):
+            lines.append(f"  {index}. {rec.criterion}")
+            lines.append(f"       inputs:  {rec.required_inputs}")
+            lines.append(f"       detects: {rec.plausible_defect}")
         lines.append("")
 
     if completion is not None and completion.limitations:
         lines.append("Evidence limitations:")
-        lines += [f"  - {limitation}" for limitation in completion.limitations]
+        for index, limitation in enumerate(completion.limitations, start=1):
+            lines.append(f"  {index}. {limitation}")
         lines.append("")
 
     lines.append(f"Recommended next instruction: {review.recommendation or '(none)'}")
@@ -97,15 +80,35 @@ def render_report(review: Review) -> str:
     return "\n".join(lines)
 
 
-def _evidence_line(obligation: Obligation) -> str:
-    """One §16 test-evidence line: marker, criterion, §9.3 class, and the §8.1
-    tier that produced it — a static prediction is never shown as confirmed."""
-    evidence = obligation.evidence_class
-    marker = _EVIDENCE_MARKER.get(evidence or "", "?")
-    label = (evidence or "unclassified").replace("_", " ")
+def _obligation_block(index: int, obligation: Obligation) -> list[str]:
+    """One numbered obligation with both evidence axes nested beneath it.
+
+    Evidence items are numbered `<obligation>.<item>` continuously across both
+    axes, so every citation in the report has a unique handle."""
+    lines = [f"  {index}. {obligation.description}"]
+    item = 0
+
+    coverage = (obligation.coverage_status or "unclassified").replace("_", " ")
+    lines.append(f"       code evidence: {coverage}")
+    if obligation.coverage_refs:
+        for ref in obligation.coverage_refs:
+            item += 1
+            lines.append(f"         {index}.{item}  {ref}")
+    else:
+        lines.append(f"         {_NO_CODE}")
+
+    evidence = (obligation.evidence_class or "unclassified").replace("_", " ")
     tier = obligation.achieved_evidence_tier
     tier_name = tier.name.lower().replace("_", "-") if tier is not None else "none"
-    return f"  {marker} {obligation.description}  [{label}; tier: {tier_name}]"
+    lines.append(f"       test evidence: {evidence}  [tier: {tier_name}]")
+    if obligation.test_evidence:
+        for test_id in obligation.test_evidence:
+            item += 1
+            lines.append(f"         {index}.{item}  {test_id}")
+    else:
+        lines.append(f"         {_NO_TESTS}")
+
+    return lines
 
 
 def _completion_status(review: Review) -> str:

--- a/src/acceptance/report.py
+++ b/src/acceptance/report.py
@@ -1,56 +1,117 @@
-"""§16 CLI report rendering (M0.6).
+"""§16 CLI report rendering (M0.6 skeleton; filled in by M7.4).
 
-Renders a Review as the human-readable §16 shell — every section always
-present, empty ones shown as "(none)". This is the walking skeleton's output:
-with an empty Review it prints the full shape with nothing in it, and later
-milestones (M3 coverage classification, M5 test evidence, M7 verdict and
-next-instruction) fill the sections in.
+Renders a Review as the §16 layout: the completion verdict, the two review
+axes as separate sections — implementation coverage (§9.2, "does the code
+respond") and test evidence (§9.3, "do the tests discriminate") — advisory
+unrequested changes, and the next-instruction pointer.
 
-The completion status is INDETERMINATE for a review with no analyzed
-obligations — a first-class, valid outcome (§9.3), not a fabricated verdict.
-M7.2 adds the real computed verdict.
+Every conclusion is labeled with its evidence tier (§8.1, §16): a static
+inference is never presented as execution-confirmed. Test-evidence lines carry
+both the §9.3 strength class and the tier that produced it.
 """
 
 from __future__ import annotations
 
-from acceptance.review_state import Review
+from acceptance.review_state import UNREQUESTED_CHANGE, Obligation, Review
 
 _EMPTY = "  (none)"
 
-# M3 replaces this with real ✓/✗/? coverage classification per obligation.
-_OBLIGATION_MARKER = "?"
+# §16 obligation-coverage markers: addressed / not addressed / uncertain.
+_COVERAGE_MARKER = {
+    "addressed": "✓",
+    "partially_addressed": "✗",
+    "not_addressed": "✗",
+    "unclear": "?",
+    "requires_non_code_evidence": "?",
+}
+
+# §9.3 evidence classes that count as real support in the §16 test-evidence
+# column; everything else is a gap the reader must see as unmet.
+_EVIDENCE_MARKER = {
+    "strongly_supported": "✓",
+    "partially_supported": "✗",
+    "nominally_supported": "✗",
+    "unsupported": "✗",
+    "requires_other_evidence": "?",
+    "indeterminate": "?",
+}
 
 
 def render_report(review: Review) -> str:
     lines: list[str] = [f"Task completion: {_completion_status(review)}", ""]
 
+    completion = review.completion
+    if completion is not None and completion.rationale:
+        lines.append(completion.rationale)
+        lines.append("")
+
     lines.append("Obligation coverage:")
     if review.obligation_map:
-        lines += [f"  {_OBLIGATION_MARKER} {o.description}" for o in review.obligation_map]
+        lines += [
+            f"  {_COVERAGE_MARKER.get(o.coverage_status or '', '?')} {o.description}"
+            for o in review.obligation_map
+        ]
     else:
         lines.append(_EMPTY)
     lines.append("")
 
     lines.append("Test evidence:")
-    if review.findings:
-        for finding in review.findings:
-            tier = finding.evidence_tier.name.lower().replace("_", "-")
-            lines.append(f"  - {finding.description} [{tier}]")
+    if review.obligation_map:
+        lines += [_evidence_line(o) for o in review.obligation_map]
     else:
         lines.append(_EMPTY)
     lines.append("")
 
     lines.append("Unrequested changes:")
-    # Unrequested-change detection is M3.2; the section is present but empty.
-    lines.append(_EMPTY)
+    unrequested = [f for f in review.findings if f.type == UNREQUESTED_CHANGE]
+    if unrequested:
+        for finding in unrequested:
+            disposition = finding.disposition.value if finding.disposition else "unclassified"
+            lines.append(f"  ! [{disposition}] {finding.description}")
+    else:
+        lines.append(_EMPTY)
     lines.append("")
+
+    if review.open_questions:
+        lines.append("Open questions:")
+        for question in review.open_questions:
+            marker = "resolved" if question.resolved else "open"
+            lines.append(f"  [{marker}] {question.question}")
+        lines.append("")
+
+    if review.recommendations:
+        lines.append("Recommended tests:")
+        for rec in review.recommendations:
+            lines.append(f"  - {rec.criterion}")
+            lines.append(f"      inputs: {rec.required_inputs}")
+            lines.append(f"      detects: {rec.plausible_defect}")
+        lines.append("")
+
+    if completion is not None and completion.limitations:
+        lines.append("Evidence limitations:")
+        lines += [f"  - {limitation}" for limitation in completion.limitations]
+        lines.append("")
 
     lines.append(f"Recommended next instruction: {review.recommendation or '(none)'}")
 
     return "\n".join(lines)
 
 
+def _evidence_line(obligation: Obligation) -> str:
+    """One §16 test-evidence line: marker, criterion, §9.3 class, and the §8.1
+    tier that produced it — a static prediction is never shown as confirmed."""
+    evidence = obligation.evidence_class
+    marker = _EVIDENCE_MARKER.get(evidence or "", "?")
+    label = (evidence or "unclassified").replace("_", " ")
+    tier = obligation.achieved_evidence_tier
+    tier_name = tier.name.lower().replace("_", "-") if tier is not None else "none"
+    return f"  {marker} {obligation.description}  [{label}; tier: {tier_name}]"
+
+
 def _completion_status(review: Review) -> str:
-    # M7.2 computes the real verdict from obligation/finding state; until then a
-    # review with nothing analyzed is honestly INDETERMINATE (§9.3).
-    return "INDETERMINATE"
+    """The M7.2 verdict, rendered as the §16 headline. A review with no
+    computed verdict is honestly INDETERMINATE (§9.3) rather than assumed
+    good — uncertainty is a first-class result."""
+    if review.completion is None:
+        return "INDETERMINATE"
+    return review.completion.verdict.value.replace("_", "-").upper()

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -232,6 +232,12 @@ class Obligation(_Model):
     # The two axes are deliberately separate: coverage_status is "does the code
     # respond", evidence_class is "do the tests discriminate" (§9.2 vs §9.3).
     coverage_status: str | None = None
+    # The code regions that satisfy this obligation, as "path#hunk" refs —
+    # symmetric with `test_evidence`'s test node ids, so each obligation
+    # carries BOTH axes' citations. Kept for every status, not just gaps: an
+    # `addressed` obligation produces no finding, so without this the review
+    # could say an obligation was satisfied but never say where (M7.4).
+    coverage_refs: list[str] = Field(default_factory=list)
 
 
 class Link(_Model):

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -226,6 +226,12 @@ class Obligation(_Model):
     achieved_evidence_tier: EvidenceTier | None = None
     test_evidence: list[str] = Field(default_factory=list)
     evidence_class: EvidenceClassification | None = None
+    # M3.1 implementation-coverage status, as its string value (the
+    # `CoverageStatus` enum lives in coverage/classify.py, which imports from
+    # here — same reason ReviewProvenance stores determinism_mode as a string).
+    # The two axes are deliberately separate: coverage_status is "does the code
+    # respond", evidence_class is "do the tests discriminate" (§9.2 vs §9.3).
+    coverage_status: str | None = None
 
 
 class Link(_Model):
@@ -357,6 +363,8 @@ class TestRecommendation(_Model):
     field is one of §9.5's discrete prescriptions; `plausible_defect` is the
     surviving §8.2 defect the recommended test must catch, so a green run
     demonstrably closes the gap rather than nominally addressing it (§8.4)."""
+
+    __test__ = False  # not a pytest test class; name matches §9.5's "recommendation"
 
     obligation_id: str
     criterion: str  # the obligation's observable behavior, restated

--- a/tests/benchmark/test_coverage.py
+++ b/tests/benchmark/test_coverage.py
@@ -27,7 +27,11 @@ from pathlib import Path
 from acceptance.benchmark.coverage import classify_case
 from acceptance.benchmark.fixtures import build_benchmark_case
 from acceptance.change.diff import extract_change_set
+from acceptance.cli import run_check
+from acceptance.config import RunConfig
+from acceptance.review_store import ReviewStore
 from tests.support import client_dispatching as _client_dispatching
+from tests.support import client_finding_nothing
 
 ARCHETYPES_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "archetypes"
 
@@ -488,3 +492,44 @@ def test_classify_case_does_not_mutate_the_input_case(tmp_path):
 
     assert case.reviewer_output is None
     assert case.score is None
+
+
+def test_cli_and_benchmark_share_one_pipeline(tmp_path, monkeypatch):
+    """Regression guard for the divergence M7.4 fixed: the CLI and the
+    benchmark must derive their Review from the SAME pipeline function.
+
+    They drifted for several milestones — every capability from M4 on reached
+    only `classify_case`, so `acceptance check` silently ran a shorter chain
+    and could not report test evidence or a verdict. Asserting both paths call
+    `pipeline.run_review` makes a future re-divergence fail loudly instead of
+    quietly under-reporting.
+    """
+    import acceptance.benchmark.coverage as benchmark_coverage
+    import acceptance.cli as cli_module
+
+    calls: list[str] = []
+    real_run_review = benchmark_coverage.run_review
+
+    def tracking_run_review(**kwargs):
+        calls.append("called")
+        return real_run_review(**kwargs)
+
+    monkeypatch.setattr(benchmark_coverage, "run_review", tracking_run_review)
+    monkeypatch.setattr(cli_module, "run_review", tracking_run_review)
+
+    case = build_benchmark_case(ARCHETYPES_DIR / "01-missed-obligation", tmp_path / "repo")
+    classify_case(case, client_finding_nothing())
+    assert len(calls) == 1  # the benchmark path routes through run_review
+
+    task_file = tmp_path / "task.md"
+    task_file.write_text(case.inputs.task_text)
+    run_check(
+        task=str(task_file),
+        base=case.inputs.base_revision,
+        head=case.inputs.head_revision,
+        config=RunConfig(),
+        store=ReviewStore(tmp_path / "reviews"),
+        repo=Path(case.inputs.repo),
+        client=client_finding_nothing(),
+    )
+    assert len(calls) == 2  # ...and so does the CLI path

--- a/tests/benchmark/test_coverage.py
+++ b/tests/benchmark/test_coverage.py
@@ -508,11 +508,14 @@ def test_cli_and_benchmark_share_one_pipeline(tmp_path, monkeypatch):
     import acceptance.cli as cli_module
 
     calls: list[str] = []
+    reviews: list = []
     real_run_review = benchmark_coverage.run_review
 
     def tracking_run_review(**kwargs):
         calls.append("called")
-        return real_run_review(**kwargs)
+        review = real_run_review(**kwargs)
+        reviews.append(review)
+        return review
 
     monkeypatch.setattr(benchmark_coverage, "run_review", tracking_run_review)
     monkeypatch.setattr(cli_module, "run_review", tracking_run_review)
@@ -533,3 +536,75 @@ def test_cli_and_benchmark_share_one_pipeline(tmp_path, monkeypatch):
         client=client_finding_nothing(),
     )
     assert len(calls) == 2  # ...and so does the CLI path
+
+    # Both invocations must run the SAME stages, not merely call the same
+    # helper: a conditional inside run_review that skipped a stage for one
+    # consumer would keep the call count at 2 while silently diverging again.
+    benchmark_review, cli_review = reviews
+    assert benchmark_review.model_dump(exclude={"provenance", "reviewed_revision"}) == (
+        cli_review.model_dump(exclude={"provenance", "reviewed_revision"})
+    )
+
+
+def test_the_shared_pipeline_runs_every_stage(tmp_path):
+    """The divergence guard proves the two consumers AGREE; it cannot prove the
+    shared pipeline is COMPLETE — a stage dropped from run_review would vanish
+    from both callers identically and still compare equal.
+
+    So assert the assembled Review carries an artifact from each stage, using a
+    client that returns non-empty responses for every schema. A pipeline that
+    silently stopped running mapping, strength classification, coverage,
+    recommendations or the verdict would leave its artifact empty here.
+    """
+    case = build_benchmark_case(ARCHETYPES_DIR / "01-missed-obligation", tmp_path / "repo")
+    change_set = extract_change_set(
+        Path(case.inputs.repo), case.inputs.base_revision, case.inputs.head_revision
+    )
+    receipt = next(f.path for f in change_set.files if f.path.endswith("receipt.py"))
+    test_file = next(f.path for f in change_set.files if f.path.endswith("test_receipt.py"))
+    test_id = f"{test_file}::test_positive_line"
+
+    client = _client_dispatching({
+        "_Decomposition": _decomposition_response([{
+            "id": "show-fields",
+            "description": "Show the item name, quantity, and unit price",
+            "type": "functional",
+            "source_quote": "Show the item name, the quantity, and the unit price.",
+        }]),
+        "_Mappings": {"mappings": [
+            {"test_id": test_id, "obligation_ids": ["show-fields"], "rationale": "."},
+        ]},
+        "_Discrimination": {"obligations": [
+            {"obligation_id": "show-fields", "defects": [
+                {"description": "omits a field", "would_be_caught": False, "reason": "."},
+            ]},
+        ]},
+        "_Coverage": _classification_response([
+            {"obligation_id": "show-fields", "status": "addressed",
+             "diff_refs": [f"{receipt}#0"]},
+        ]),
+        "_Detections": {"unrequested_changes": []},
+        "_Judgments": {"resolutions": []},
+        "_Recommendations": {"recommendations": [{
+            "obligation_id": "show-fields",
+            "required_inputs": "a receipt line",
+            "boundary_conditions": "none",
+            "expected_output": "all three fields",
+            "required_assertions": ["assert name in line"],
+            "plausible_defect": "omits a field",
+            "repo_conventions": "test_receipt.py",
+        }]},
+        "_Mismatches": {"mismatches": []},
+    })
+
+    review = classify_case(case, client).reviewer_output
+    obligation = review.obligation_map[0]
+
+    assert obligation.description  # decomposition ran
+    assert obligation.test_evidence == [test_id]  # test discovery + mapping ran
+    assert obligation.evidence_class is not None  # discrimination + strength ran
+    assert obligation.achieved_evidence_tier is not None  # strength applied a tier
+    assert obligation.coverage_status == "addressed"  # coverage classification ran
+    assert obligation.coverage_refs  # coverage refs were carried through
+    assert review.recommendations  # recommendation generation ran
+    assert review.completion is not None  # the verdict was derived

--- a/tests/benchmark/test_labels.py
+++ b/tests/benchmark/test_labels.py
@@ -23,6 +23,7 @@ from acceptance.benchmark.runner import run_case
 from acceptance.benchmark.scoring import score_case_set
 from acceptance.config import RunConfig
 from acceptance.review_store import ReviewStore
+from tests.support import client_finding_nothing
 
 ARCHETYPES_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "archetypes"
 FIXTURE_DIRS = sorted(p for p in ARCHETYPES_DIR.iterdir() if p.is_dir())
@@ -137,6 +138,7 @@ def test_full_loop_scores_the_noop_checker_as_all_miss(tmp_path):
                 case,
                 config=RunConfig(),
                 review_store=ReviewStore(tmp_path / f"reviews-{i}"),
+                client=client_finding_nothing(),
             )
         )
 

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -9,6 +9,7 @@ from acceptance.benchmark.case import (
 from acceptance.benchmark.runner import run_case
 from acceptance.config import RunConfig
 from acceptance.review_store import ReviewStore
+from tests.support import client_finding_nothing
 
 
 def _labels() -> GroundTruthLabels:
@@ -53,6 +54,7 @@ def test_running_the_empty_skeleton_over_an_archetype_case_yields_an_all_miss_sc
         case,
         config=RunConfig(),
         review_store=ReviewStore(tmp_path / "reviews"),
+        client=client_finding_nothing(),
     )
 
     assert result.reviewer_output is not None
@@ -75,7 +77,10 @@ def test_run_case_does_not_mutate_the_input_case(git_repo_elsewhere, tmp_path):
         ground_truth=_labels(),
     )
 
-    run_case(case, config=RunConfig(), review_store=ReviewStore(tmp_path / "reviews"))
+    run_case(
+        case, config=RunConfig(), review_store=ReviewStore(tmp_path / "reviews"),
+        client=client_finding_nothing(),
+    )
 
     assert case.reviewer_output is None
     assert case.score is None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,3 +51,18 @@ def git_repo_elsewhere(tmp_path):
 @pytest.fixture
 def fixture_task_path():
     return str(Path(__file__).parent / "fixtures" / "tasks" / "minimal_task.md")
+
+
+@pytest.fixture
+def stub_model(monkeypatch):
+    """Make `main()`'s internally-built client a no-op stub.
+
+    Since M7.4 `acceptance check` runs the real shared pipeline, so CLI tests
+    that exercise plumbing (provenance, persistence, determinism, the §16
+    shell) rather than model judgment must not issue live calls. Patching
+    RunConfig.build_client keeps `main()`'s own argument parsing under test.
+    """
+    from acceptance.config import RunConfig
+    from tests.support import client_finding_nothing
+
+    monkeypatch.setattr(RunConfig, "build_client", lambda self, completion_fn=None: client_finding_nothing())

--- a/tests/support.py
+++ b/tests/support.py
@@ -68,3 +68,27 @@ def client_dispatching(responses_by_schema: dict, model: str = _DEFAULT_MODEL) -
         store=TranscriptStore(tempfile.mkdtemp()),
         completion_fn=completion_fn,
     )
+
+
+# An empty result per pipeline response schema (schemas are strict, so each
+# needs exactly its own field). A client returning these finds nothing at every
+# step — the "no-op checker" stand-in for tests that exercise the harness loop
+# (fixture -> case -> run -> score) or CLI plumbing rather than any model
+# judgment. Since M7.4's shared pipeline, `run_check` makes real model calls, so
+# these tests must inject a client instead of relying on an empty skeleton.
+_EMPTY_BY_SCHEMA = {
+    "_Decomposition": {"obligations": [], "open_questions": []},
+    "_Mappings": {"mappings": []},
+    "_Discrimination": {"discriminations": []},
+    "_Coverage": {"classifications": []},
+    "_Detections": {"unrequested_changes": []},
+    "_Judgments": {"resolutions": []},
+    "_Recommendations": {"recommendations": []},
+    "_Mismatches": {"mismatches": []},
+}
+
+
+def client_finding_nothing(model: str = _DEFAULT_MODEL) -> ModelClient:
+    """A client whose every pipeline call returns an empty result — the
+    checker runs end to end and reports nothing found."""
+    return client_dispatching(_EMPTY_BY_SCHEMA, model=model)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,12 +103,11 @@ def test_report_shell_renders_all_sections_present_and_empty(git_repo, fixture_t
     out = capsys.readouterr().out
     # Every §16 section present...
     assert "Task completion: UNABLE-TO-DETERMINE" in out  # the real M7.2 verdict
-    assert "Obligation coverage:" in out
-    assert "Test evidence:" in out
+    assert "Obligations:" in out
     assert "Unrequested changes:" in out
     assert "Recommended next instruction: (none)" in out
     # ...and empty when the checker finds nothing.
-    assert out.count("(none)") == 4  # 3 list sections + the next-instruction line
+    assert out.count("(none)") == 3  # 2 list sections + the next-instruction line
 
 
 def test_check_persists_the_review_to_the_store(git_repo, fixture_task_path, stub_model):
@@ -424,3 +423,59 @@ def test_render_change_set_omits_ignored_section_when_empty():
 
     rendered = render_change_set(change_set)
     assert "Ignored" not in rendered
+
+
+
+# --- check: the M7.4 additions (optional declaration + working-tree review) ---
+
+
+def test_check_threads_an_optional_declaration_into_the_review(
+    git_repo, fixture_task_path, tmp_path, capsys, stub_model
+):
+    """--declaration must actually reach the pipeline: with one supplied, the
+    declaration is parsed onto the Review and §7.4's "absent" minor finding is
+    NOT raised. Guards a flag that parses but silently drops its value."""
+    declaration = tmp_path / "declaration.md"
+    declaration.write_text(
+        "# Builder Declaration\n## Mandate as understood\nAdd the thing.\n"
+    )
+
+    assert main([
+        "check", "--json", "--task", fixture_task_path,
+        "--base", git_repo["base"], "--head", git_repo["head"],
+        "--declaration", str(declaration),
+    ]) == 0
+
+    with_declaration = json.loads(capsys.readouterr().out)
+    assert with_declaration["declaration"] is not None
+    assert with_declaration["declaration"]["mandate_as_understood"] == "Add the thing."
+    assert "declaration_absent" not in {f["type"] for f in with_declaration["findings"]}
+
+    # ...and the same invocation WITHOUT it succeeds too, differing only in the
+    # §7.4 absent finding. Pairing both runs in one test means a --declaration
+    # that parses but is ignored cannot pass: the two outputs would be identical.
+    assert main([
+        "check", "--json", "--task", fixture_task_path,
+        "--base", git_repo["base"], "--head", git_repo["head"],
+    ]) == 0
+    without = json.loads(capsys.readouterr().out)
+    assert without["declaration"] is None
+    assert "declaration_absent" in {f["type"] for f in without["findings"]}
+
+
+def test_check_without_a_head_reviews_the_working_tree(
+    git_repo, fixture_task_path, capsys, stub_model
+):
+    """Omitting --head reviews the working tree (§5.1), so a check can run
+    before a commit exists. The uncommitted file must appear in the change set
+    — a fixture whose tree matched HEAD would pass either way."""
+    (git_repo["path"] / "uncommitted.py").write_text("def added_after_head():\n    return 1\n")
+
+    assert main([
+        "check", "--json", "--task", fixture_task_path, "--base", git_repo["base"],
+    ]) == 0
+
+    review = json.loads(capsys.readouterr().out)
+    assert review["reviewed_revision"] == "<working-tree>"
+    changed = {f["path"] for f in review["change_set"]["files"]}
+    assert "uncommitted.py" in changed  # the working tree, not the HEAD commit

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,9 +5,12 @@ import pytest
 from acceptance.cli import main, run_check
 from acceptance.config import RunConfig
 from acceptance.review_store import ReviewStore
+from tests.support import client_finding_nothing
 
 
-def test_check_json_emits_empty_structured_review(git_repo, fixture_task_path, capsys):
+def test_check_json_emits_a_structured_review(git_repo, fixture_task_path, capsys, stub_model):
+    """--json emits the full structured Review. With a checker that finds
+    nothing, the analysis fields are empty but the shape is complete."""
     exit_code = main(
         ["check", "--json", "--task", fixture_task_path, "--base", git_repo["base"], "--head", git_repo["head"]]
     )
@@ -17,18 +20,18 @@ def test_check_json_emits_empty_structured_review(git_repo, fixture_task_path, c
     assert review["mode"] == "local"
     assert review["reviewed_revision"] == git_repo["head"]
     assert review["mandate"] is None
-    assert review["declaration"] is None
-    # Diff endpoints are ingested; file-level diffing is still M2.
     assert review["change_set"]["base_revision"] == git_repo["base"]
     assert review["change_set"]["head_revision"] == git_repo["head"]
-    assert review["change_set"]["files"] == []
     assert review["obligation_map"] == []
-    assert review["findings"] == []
-    assert review["limitations"] == []
     assert review["recommendation"] is None
+    # No declaration was supplied, so §7.4's minor finding is recorded (M6.1)
+    # and the verdict is honestly unable-to-determine with nothing analyzed.
+    assert review["declaration"] is None
+    assert [f["type"] for f in review["findings"]] == ["declaration_absent"]
+    assert review["completion"]["verdict"] == "unable_to_determine"
 
 
-def test_check_defaults_to_replay_mode_provenance(git_repo, fixture_task_path, capsys):
+def test_check_defaults_to_replay_mode_provenance(git_repo, fixture_task_path, capsys, stub_model):
     exit_code = main(
         ["check", "--json", "--task", fixture_task_path, "--base", git_repo["base"], "--head", git_repo["head"]]
     )
@@ -41,7 +44,7 @@ def test_check_defaults_to_replay_mode_provenance(git_repo, fixture_task_path, c
     assert review["provenance"]["seed"] is None
 
 
-def test_check_records_determinism_flags_in_provenance(git_repo, fixture_task_path, capsys):
+def test_check_records_determinism_flags_in_provenance(git_repo, fixture_task_path, capsys, stub_model):
     exit_code = main(
         [
             "check", "--json",
@@ -78,7 +81,7 @@ def test_check_rejects_unknown_mode(git_repo, fixture_task_path):
         )
 
 
-def test_two_runs_over_the_same_input_are_byte_identical(git_repo, fixture_task_path, capsys):
+def test_two_runs_over_the_same_input_are_byte_identical(git_repo, fixture_task_path, capsys, stub_model):
     args = [
         "check", "--task", fixture_task_path, "--base", git_repo["base"], "--head", git_repo["head"]
     ]
@@ -91,7 +94,7 @@ def test_two_runs_over_the_same_input_are_byte_identical(git_repo, fixture_task_
     assert first == second
 
 
-def test_report_shell_renders_all_sections_present_and_empty(git_repo, fixture_task_path, capsys):
+def test_report_shell_renders_all_sections_present_and_empty(git_repo, fixture_task_path, capsys, stub_model):
     exit_code = main(
         ["check", "--task", fixture_task_path, "--base", git_repo["base"], "--head", git_repo["head"]]
     )
@@ -99,16 +102,16 @@ def test_report_shell_renders_all_sections_present_and_empty(git_repo, fixture_t
     assert exit_code == 0
     out = capsys.readouterr().out
     # Every §16 section present...
-    assert "Task completion: INDETERMINATE" in out
+    assert "Task completion: UNABLE-TO-DETERMINE" in out  # the real M7.2 verdict
     assert "Obligation coverage:" in out
     assert "Test evidence:" in out
     assert "Unrequested changes:" in out
     assert "Recommended next instruction: (none)" in out
-    # ...and empty in the walking skeleton.
+    # ...and empty when the checker finds nothing.
     assert out.count("(none)") == 4  # 3 list sections + the next-instruction line
 
 
-def test_check_persists_the_review_to_the_store(git_repo, fixture_task_path):
+def test_check_persists_the_review_to_the_store(git_repo, fixture_task_path, stub_model):
     from acceptance.review_store import ReviewStore
 
     assert main(
@@ -156,6 +159,7 @@ def test_run_check_accepts_an_explicit_repo_independent_of_cwd(
         config=RunConfig(),
         store=ReviewStore(tmp_path / "reviews"),
         repo=git_repo_elsewhere["path"],
+        client=client_finding_nothing(),
     )
 
     assert review.reviewed_revision == git_repo_elsewhere["head"]

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -26,10 +26,7 @@ def test_empty_review_renders_the_full_shell():
     assert report == (
         "Task completion: INDETERMINATE\n"
         "\n"
-        "Obligation coverage:\n"
-        "  (none)\n"
-        "\n"
-        "Test evidence:\n"
+        "Obligations:\n"
         "  (none)\n"
         "\n"
         "Unrequested changes:\n"
@@ -39,7 +36,13 @@ def test_empty_review_renders_the_full_shell():
     )
 
 
-def _obligation(description: str, coverage: str | None, evidence: str | None) -> Obligation:
+def _obligation(
+    description: str,
+    coverage: str | None,
+    evidence: str | None,
+    coverage_refs: list[str] | None = None,
+    tests: list[str] | None = None,
+) -> Obligation:
     return Obligation(
         id=description.lower().replace(" ", "-")[:20],
         description=description,
@@ -48,19 +51,24 @@ def _obligation(description: str, coverage: str | None, evidence: str | None) ->
         explicit=True,
         observable_behavior="...",
         coverage_status=coverage,
+        coverage_refs=coverage_refs or [],
         evidence_class=evidence,
+        test_evidence=tests or [],
         achieved_evidence_tier=EvidenceTier.STATIC if evidence else None,
     )
 
 
-def test_report_renders_both_axes_with_tiers_and_the_verdict():
+def test_report_renders_each_obligation_with_both_axes_numbered():
     review = Review(
         mode="local",
         reviewed_revision="abc",
         obligation_map=[
-            _obligation("CSV generation implemented", "addressed", "strongly_supported"),
+            _obligation(
+                "CSV generation implemented", "addressed", "strongly_supported",
+                coverage_refs=["export.py#@@ -1 +9 @@"],
+                tests=["tests/test_export.py::test_generates_csv"],
+            ),
             _obligation("Active filters applied", "not_addressed", "unsupported"),
-            _obligation("Column order preserved", "unclear", "indeterminate"),
         ],
         findings=[
             Finding(
@@ -83,20 +91,41 @@ def test_report_renders_both_axes_with_tiers_and_the_verdict():
 
     report = render_report(review)
 
-    # The §16 headline is the real computed verdict.
     assert "Task completion: INCOMPLETE" in report
-    assert "1 obligation(s) not fully implemented." in report
-    # Implementation-coverage axis: ✓ addressed, ✗ not, ? uncertain.
-    assert "  ✓ CSV generation implemented" in report
-    assert "  ✗ Active filters applied" in report
-    assert "  ? Column order preserved" in report
-    # Test-evidence axis: every line carries its class AND its evidence tier.
-    assert "  ✓ CSV generation implemented  [strongly supported; tier: static]" in report
-    assert "  ✗ Active filters applied  [unsupported; tier: static]" in report
-    # Unrequested changes are advisory, with their disposition shown (M7.6 spirit).
-    assert "  ! [separable] Export filename behavior changed" in report
+    # Obligations are numbered, with both axes nested beneath each.
+    assert "  1. CSV generation implemented" in report
+    assert "  2. Active filters applied" in report
+    assert "       code evidence: addressed" in report
+    assert "       test evidence: strongly supported  [tier: static]" in report
+    assert "       code evidence: not addressed" in report
+    # Evidence items are numbered <obligation>.<item>, continuously across axes.
+    assert "         1.1  export.py#@@ -1 +9 @@" in report
+    assert "         1.2  tests/test_export.py::test_generates_csv" in report
+    # An obligation with neither axis satisfied says so explicitly.
+    assert "(no corresponding change)" in report
+    assert "(no mapped test)" in report
+    # Unrequested changes are advisory, numbered, with their disposition.
+    assert "  1. [separable] Export filename behavior changed" in report
     assert "Evidence limitations:" in report
     assert "Recommended next instruction: .acceptance/next-instruction.md" in report
+
+
+def test_status_is_stated_in_words_not_symbols():
+    review = Review(
+        mode="local",
+        reviewed_revision="abc",
+        obligation_map=[
+            _obligation("A", "addressed", "strongly_supported"),
+            _obligation("B", "not_addressed", "unsupported"),
+            _obligation("C", "unclear", "indeterminate"),
+        ],
+    )
+
+    report = render_report(review)
+
+    assert "\u2713" not in report and "\u2717" not in report
+    for word in ("addressed", "not addressed", "unclear", "strongly supported", "unsupported"):
+        assert word in report
 
 
 def test_every_test_evidence_line_shows_a_tier():
@@ -111,14 +140,31 @@ def test_every_test_evidence_line_shows_a_tier():
         ],
     )
 
-    evidence_section = render_report(review).split("Test evidence:")[1].split("Unrequested")[0]
-    lines = [line for line in evidence_section.splitlines() if line.strip()]
+    report = render_report(review)
+    evidence_lines = [ln for ln in report.splitlines() if "test evidence:" in ln]
 
-    assert len(lines) == 3
-    assert all("tier: " in line for line in lines)
+    assert len(evidence_lines) == 3
+    assert all("tier: " in line for line in evidence_lines)
 
 
-def test_unclassified_obligation_renders_as_uncertain():
+def test_test_citations_name_the_test_not_just_the_file():
+    review = Review(
+        mode="local",
+        reviewed_revision="abc",
+        obligation_map=[
+            _obligation(
+                "A", "addressed", "strongly_supported",
+                tests=["tests/test_billing.py::test_half_of_a_month"],
+            )
+        ],
+    )
+
+    report = render_report(review)
+
+    assert "tests/test_billing.py::test_half_of_a_month" in report
+
+
+def test_unclassified_obligation_renders_as_unclassified():
     review = Review(
         mode="local",
         reviewed_revision="abc",
@@ -127,11 +173,12 @@ def test_unclassified_obligation_renders_as_uncertain():
 
     report = render_report(review)
 
-    assert "  ? Not yet analyzed" in report
-    assert "[unclassified; tier: none]" in report
+    assert "  1. Not yet analyzed" in report
+    assert "code evidence: unclassified" in report
+    assert "test evidence: unclassified  [tier: none]" in report
 
 
-def test_open_questions_and_recommendations_are_rendered():
+def test_open_questions_and_recommendations_are_numbered():
     review = Review(
         mode="local",
         reviewed_revision="abc",
@@ -156,8 +203,64 @@ def test_open_questions_and_recommendations_are_rendered():
 
     report = render_report(review)
 
-    assert "  [open] Minus sign or parentheses?" in report
-    assert "  [resolved] Tax inclusive?" in report
-    assert "Recommended tests:" in report
-    assert "  - Daily rate uses days_in_month" in report
+    assert "  1. [open] Minus sign or parentheses?" in report
+    assert "  2. [resolved] Tax inclusive?" in report
+    assert "  1. Daily rate uses days_in_month" in report
     assert "detects: hard-codes /30" in report
+
+
+def test_tier_label_comes_from_the_recorded_tier_not_a_hardcoded_string():
+    """Every other fixture uses STATIC, so a hardcoded "tier: static" would
+    pass. Use a higher tier to prove the label is read from the obligation."""
+    obligation = _obligation("Executed behavior", "addressed", "strongly_supported")
+    review = Review(
+        mode="local",
+        reviewed_revision="abc",
+        obligation_map=[
+            obligation.model_copy(update={"achieved_evidence_tier": EvidenceTier.DEFECT_KILLED})
+        ],
+    )
+
+    report = render_report(review)
+
+    assert "[tier: defect-killed]" in report
+    assert "tier: static" not in report
+
+
+def test_multi_word_verdict_renders_as_the_16_headline():
+    """NO_MATERIAL_GAPS is the multi-word case: underscores become hyphens and
+    the whole verdict is upper-cased. Other tests only cover INCOMPLETE."""
+    review = Review(
+        mode="local",
+        reviewed_revision="abc",
+        obligation_map=[_obligation("A", "addressed", "strongly_supported")],
+        completion=CompletionResult(
+            verdict=CompletionVerdict.NO_MATERIAL_GAPS,
+            rationale="Every obligation is addressed and strongly supported.",
+            limitations=["No material gaps found at the achievable evidence tier."],
+        ),
+    )
+
+    report = render_report(review)
+
+    assert "Task completion: NO-MATERIAL-GAPS" in report
+    # §3.7: a positive verdict must carry its bounding caveat.
+    assert "achievable evidence tier" in report
+
+
+def test_the_two_axes_render_independently_for_the_same_obligation():
+    """The load-bearing case: code that responds (coverage `addressed`) whose
+    tests do NOT discriminate (`nominally_supported`). A renderer that
+    collapsed the two axes into one label would show this as fine on both."""
+    review = Review(
+        mode="local",
+        reviewed_revision="abc",
+        obligation_map=[
+            _obligation("Daily rate uses days_in_month", "addressed", "nominally_supported")
+        ],
+    )
+
+    report = render_report(review)
+
+    assert "code evidence: addressed" in report
+    assert "test evidence: nominally supported" in report

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,13 +1,23 @@
-from acceptance.report import render_report
+"""M7.4 acceptance: the rendered §16 report shows obligation coverage, test
+evidence with a per-line evidence tier, advisory unrequested changes, and the
+computed verdict."""
+
 from acceptance.review_state import (
+    UNREQUESTED_CHANGE,
+    CompletionResult,
+    CompletionVerdict,
     Component,
     EvidenceTier,
     Finding,
     Link,
     Obligation,
     ObligationType,
+    OpenQuestion,
     Review,
+    TestRecommendation,
+    UnrequestedChangeDisposition,
 )
+from acceptance.report import render_report
 
 
 def test_empty_review_renders_the_full_shell():
@@ -29,36 +39,125 @@ def test_empty_review_renders_the_full_shell():
     )
 
 
-def test_populated_review_lists_obligations_and_findings():
+def _obligation(description: str, coverage: str | None, evidence: str | None) -> Obligation:
+    return Obligation(
+        id=description.lower().replace(" ", "-")[:20],
+        description=description,
+        type=ObligationType.FUNCTIONAL,
+        importance="critical",
+        explicit=True,
+        observable_behavior="...",
+        coverage_status=coverage,
+        evidence_class=evidence,
+        achieved_evidence_tier=EvidenceTier.STATIC if evidence else None,
+    )
+
+
+def test_report_renders_both_axes_with_tiers_and_the_verdict():
     review = Review(
         mode="local",
         reviewed_revision="abc",
         obligation_map=[
-            Obligation(
-                id="coupons-use-spread",
-                description="Coupons use index + spread.",
-                type=ObligationType.FUNCTIONAL,
-                importance="critical",
-                explicit=True,
-                observable_behavior="...",
-            )
+            _obligation("CSV generation implemented", "addressed", "strongly_supported"),
+            _obligation("Active filters applied", "not_addressed", "unsupported"),
+            _obligation("Column order preserved", "unclear", "indeterminate"),
         ],
         findings=[
             Finding(
-                type="weak_test_evidence",
-                severity="high",
-                description="Filter behavior unsupported",
+                type=UNREQUESTED_CHANGE,
+                severity="medium",
+                description="Export filename behavior changed",
                 evidence_tier=EvidenceTier.STATIC,
                 produced_by=Component.STATIC_ANALYZER,
-                links=[Link(kind="test", ref="tests/t.py:1")],
-                related_obligation="Active filters are applied",
+                links=[Link(kind="code", ref="export.py#@@ -1 +1 @@")],
+                disposition=UnrequestedChangeDisposition.SEPARABLE,
             )
         ],
+        completion=CompletionResult(
+            verdict=CompletionVerdict.INCOMPLETE,
+            rationale="1 obligation(s) not fully implemented.",
+            limitations=["Judgments are static inferences unless a higher tier is recorded."],
+        ),
         recommendation=".acceptance/next-instruction.md",
     )
 
     report = render_report(review)
 
-    assert "  ? Coupons use index + spread." in report
-    assert "  - Filter behavior unsupported [static]" in report
+    # The §16 headline is the real computed verdict.
+    assert "Task completion: INCOMPLETE" in report
+    assert "1 obligation(s) not fully implemented." in report
+    # Implementation-coverage axis: ✓ addressed, ✗ not, ? uncertain.
+    assert "  ✓ CSV generation implemented" in report
+    assert "  ✗ Active filters applied" in report
+    assert "  ? Column order preserved" in report
+    # Test-evidence axis: every line carries its class AND its evidence tier.
+    assert "  ✓ CSV generation implemented  [strongly supported; tier: static]" in report
+    assert "  ✗ Active filters applied  [unsupported; tier: static]" in report
+    # Unrequested changes are advisory, with their disposition shown (M7.6 spirit).
+    assert "  ! [separable] Export filename behavior changed" in report
+    assert "Evidence limitations:" in report
     assert "Recommended next instruction: .acceptance/next-instruction.md" in report
+
+
+def test_every_test_evidence_line_shows_a_tier():
+    # M7.4 acceptance: "every test-evidence line shows its evidence tier."
+    review = Review(
+        mode="local",
+        reviewed_revision="abc",
+        obligation_map=[
+            _obligation("A", "addressed", "strongly_supported"),
+            _obligation("B", "addressed", "partially_supported"),
+            _obligation("C", "addressed", None),  # unclassified -> tier: none
+        ],
+    )
+
+    evidence_section = render_report(review).split("Test evidence:")[1].split("Unrequested")[0]
+    lines = [line for line in evidence_section.splitlines() if line.strip()]
+
+    assert len(lines) == 3
+    assert all("tier: " in line for line in lines)
+
+
+def test_unclassified_obligation_renders_as_uncertain():
+    review = Review(
+        mode="local",
+        reviewed_revision="abc",
+        obligation_map=[_obligation("Not yet analyzed", None, None)],
+    )
+
+    report = render_report(review)
+
+    assert "  ? Not yet analyzed" in report
+    assert "[unclassified; tier: none]" in report
+
+
+def test_open_questions_and_recommendations_are_rendered():
+    review = Review(
+        mode="local",
+        reviewed_revision="abc",
+        obligation_map=[_obligation("A", "addressed", "nominally_supported")],
+        open_questions=[
+            OpenQuestion(id="q-1", question="Minus sign or parentheses?"),
+            OpenQuestion(id="q-2", question="Tax inclusive?", resolved=True),
+        ],
+        recommendations=[
+            TestRecommendation(
+                obligation_id="a",
+                criterion="Daily rate uses days_in_month",
+                required_inputs="A non-30-day month",
+                boundary_conditions="0 days",
+                expected_output="price/28*days",
+                required_assertions=["assert prorate(280, 14, 28) == 140.0"],
+                plausible_defect="hard-codes /30",
+                repo_conventions="test_billing.py",
+            )
+        ],
+    )
+
+    report = render_report(review)
+
+    assert "  [open] Minus sign or parentheses?" in report
+    assert "  [resolved] Tax inclusive?" in report
+    assert "Recommended tests:" in report
+    assert "  - Daily rate uses days_in_month" in report
+    assert "detects: hard-codes /30" in report


### PR DESCRIPTION
## Summary
M7.4 — the §16 CLI report, plus the pipeline unification it depends on.

**The problem this fixes:** the CLI and the benchmark had drifted. Every capability from M4 onward — test discovery/mapping, evidence extraction, discrimination, strength, declaration comparison, recommendations, verdict — was wired only into `classify_case`. So `acceptance check`/`classify`, the commands used to **dogfood the tool against its own changes**, still ran the M3-era chain and could not show test evidence or a verdict at all. Dogfooding was exercising far less than the benchmark measured, and the gap was invisible.

- **`pipeline.py::run_review`** is now the single assembled pipeline. `classify_case` is a thin benchmark adapter around it; `run_check` calls it directly. The two consumers are identical **by construction**, not by keeping copies in step.
- **A regression guard** (`test_cli_and_benchmark_share_one_pipeline`) asserts both paths route through `run_review`, so a future re-divergence fails loudly instead of quietly under-reporting. *(This test came directly from the tool's own recommendation on this diff — see below.)*
- **`report.py`** renders the real §16 layout: the computed M7.2 verdict as headline; implementation coverage and test evidence as **separate axes** (§9.2 "does the code respond" vs §9.3 "do the tests discriminate"); **every test-evidence line tagged with its §9.3 class and §8.1 tier**, so a static inference is never presented as execution-confirmed; advisory unrequested changes with dispositions; plus open questions, recommendations, and evidence limitations.
- `Obligation` gains `coverage_status` so the coverage axis renders faithfully rather than being inferred from which findings exist (lossy — an `addressed` obligation produces none, and so does an unanalyzed one).
- `check` gains `--declaration` (§7.4, optional) and working-tree review when `--head` is omitted (§5.1), matching `classify`.

## Dogfood
`acceptance check` on this PR's own diff now shows **test evidence with tiers** for the first time:
```
Test evidence:
  ✗ The CLI and the benchmark use one shared review pipeline function...  [partially supported; tier: static]
  ✗ Every test-evidence line includes its evidence tier tag.              [partially supported; tier: static]
Unrequested changes:
  ! [in_service] The new `coverage_status` field on `Obligation`...
```
All 10 obligations `[✓ addressed]` on the coverage axis; verdict `INCOMPLETE` because evidence is `partially_supported` throughout — an honest assessment, not a bug (decision A from M7.2: present-but-not-fully-discriminating evidence blocks a positive).

**Acting on its own finding:** the tool recommended a test detecting *"the benchmark adapter accidentally omits one stage from `run_review` while the CLI uses the full pipeline"* — precisely the defect this PR fixes, which had **no** regression guard. I added exactly that test. The tool caught the gap in its own fix.

Remaining flags investigated: one `[separable]` on the test-support plumbing (`client_finding_nothing`/`stub_model`) is the same false-positive class as **#139** — those edits are load-bearing (without them tests issue live calls). Two `[risky]` findings (the `LLMError` catch, expanded report tests) are in-service.

## Test plan
- [x] `pytest -q` — 415 passed
- [x] `ruff check src tests` — clean
- [x] New: pipeline-divergence regression guard; §16 report tests (both axes, tier on every evidence line, unclassified rendering, open questions/recommendations)
- [x] Skeleton-era tests updated to inject a stub client — intent (harness loop, provenance, persistence, determinism, §16 shell) unchanged

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)
