### PR TITLE
Fix the removability litmus instead of adding a fourth special case

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,18 +1,16 @@
 # Task
-Produce the §16 CLI output — a per-obligation report where each obligation carries its own code evidence and test evidence, plus unrequested changes and a recommended-next-instruction pointer. The `check` command must run the full assembled review pipeline so the report reflects everything the checker computes.
+The disposition classifier mislabels test-fixture updates that a source change in the same diff requires as `separable`, recommending they be split into their own PR. Wiring a capability into the shared pipeline forces existing tests to add fixture and dispatch entries; removing those entries breaks the suite, so they are load-bearing, not separable. Fix the removability litmus rather than adding another special case.
 
 ## Constraints
-- One shared pipeline function serves both the CLI and the benchmark. Previously every capability from test discovery onward reached only the benchmark path, so the command used to dogfood the tool ran an older, shorter chain and could not show test evidence or a verdict at all; sharing one function keeps the two consumers identical by construction.
-- The report is organized by obligation: each obligation is a block carrying both of its evidence axes beneath it, rather than two separate lists the reader must join by eye. Code evidence answers whether the code responds to the obligation; test evidence answers whether the tests discriminate.
-- Every test-evidence line shows its evidence tier, so a static inference is never presented as execution-confirmed.
-- Status is stated in words rather than symbols, and obligations, evidence items, findings, questions and recommendations are numbered so a reader can refer to any one of them precisely.
-- A test citation names the specific test, not merely the file that contains it. A code citation names the specific changed region.
-- An obligation records the code regions that satisfy it whatever its status, so the report can say where an obligation was satisfied and not merely that it was.
-- The headline verdict is the computed completion result; a review with no computed verdict renders as indeterminate rather than assumed good.
-- Unrequested changes render as advisory, each showing its disposition.
+- The litmus must ask both whether every obligation would still be satisfied if the change were removed and whether the rest of the diff would still work — tests still passing, imports still resolving. Asking only about obligations is what let this class of misclassification recur three times.
+- A change confined to test files that adds no new test function and accompanies a source change is test scaffolding the existing tests need; classify it as in service, structurally, with no model call.
+- Adding a new test function is the discriminator: that may be genuinely distinct test work, so it escalates to model judgment instead of being swept into in service.
+- A diff containing only test changes is ordinary test work and must still be judged rather than assumed to be scaffolding for something else.
+- Classifying a change as separable must not require it to be large enough to justify its own pull request. A small opportunistic edit is still unrequested scope the reviewer should see; size governs the recommendation, not the classification.
 
 ## Completion expectations
 - Implementation
-- Rendered output matches the §16 layout, with every test-evidence line showing its evidence tier.
-- The benchmark and the CLI produce their reviews from the same pipeline function.
-- `check` accepts an optional builder declaration and reviews the working tree when no head revision is given.
+- A source change accompanied by the test-fixture edits it requires classifies those edits as in service without a model call.
+- A change that adds a new test function still escalates to model judgment.
+- A test-only diff still escalates to model judgment.
+- A small opportunistic edit to an unrelated function is still classified separable.

--- a/src/acceptance/coverage/disposition.py
+++ b/src/acceptance/coverage/disposition.py
@@ -31,6 +31,27 @@ The classifier is a **hybrid** (chosen deliberately, not for cheapness):
      file's changes (#126). This is direct structural evidence sitting in the
      diff itself (the import statement), not something requiring semantic
      judgment — reverting the change would break the file that imports it.
+   - a change confined to test files that adds no new `def test_...` but
+     accompanies a source change → test fixtures/helpers/harness updates the
+     EXISTING tests need to keep passing → **in_service** (#139). Adding a new
+     test function is the discriminator: that may be distinct test work, so it
+     escalates instead.
+
+The three cases above are one principle, not three exceptions. The litmus is
+"delete only this change, keep the rest of the diff": a change is `separable`
+only if every obligation is still satisfied AND the rest of the diff still
+WORKS (imports resolve, tests pass). Supporting scaffolding for THIS diff —
+docs describing it, tests exercising it, fixtures those tests need — fails the
+second test and is in_service. Earlier revisions asked only about obligations,
+which is why this class of misclassification recurred (#122, #126, #139).
+
+Deliberately NOT part of the litmus: whether the change is big enough to
+deserve its own PR. A one-line opportunistic edit (a stray comment, a
+defensive check on an unrelated function) is still unrequested scope the
+reviewer should see, so it is `separable` even though "split this into its own
+PR" would be silly advice for it. Size governs the RECOMMENDATION, not the
+classification — the taxonomy currently has no home for "unrequested but too
+small to split", which is an open question against DR-081 (#145).
    - a pure new-file addition that no obligation's coverage claims → new,
      self-contained work → **separable**.
 2. Everything else — edits to existing code with no clean coverage attribution —
@@ -91,23 +112,41 @@ class DispositionedChange(PersistableModel):
 
 _SYSTEM_PROMPT = """\
 You classify one UNREQUESTED code change — a change no listed obligation called
-for — into exactly one disposition, using the removability litmus:
+for — into exactly one disposition.
 
-  Would EVERY obligation still be satisfied if this change were removed?
+Apply the removability litmus. Delete ONLY this change, keep the rest of the
+diff, and ask BOTH questions:
 
-- in_service: NO — some obligation depends on this change (e.g. a refactor or
-  helper the requested feature needs), even though nothing requested it
-  directly. Removing it would leave an obligation incomplete. A comment or
-  docstring update that describes an in-service code edit in the SAME file is
-  itself in_service — it is not distinct work, and it should never be
-  recommended for splitting into its own PR. A symbol this change defines or
-  renames that is imported and used by ANOTHER file changed in this SAME diff
-  is also in_service for that usage — removing it would break the file that
-  imports it.
-- separable: YES, and it is coherent, self-contained work — valuable but a
-  DISTINCT unit that belongs in its own PR / backlog item.
-- risky: YES, but it edits existing public interface, dependencies, or adjacent
-  behavior in a way that could hide a regression. Scrutinize.
+  (a) Would every obligation still be satisfied?
+  (b) Would the rest of the diff still WORK — tests still passing, imports
+      still resolving, the delivered change still coherent and self-consistent?
+
+A change is `separable` when BOTH answers are YES. If either answer is NO, it
+is `in_service`. Do not also require the change to be large enough to justify
+its own PR — a tiny opportunistic edit is still separable.
+
+- in_service: the delivered change DEPENDS on this, or this is an artifact OF
+  the delivered change rather than distinct work. Two ways that happens:
+  * Something else in this diff would break without it — a helper or symbol
+    another changed file imports, a test fixture/helper/harness update the
+    existing tests need to keep passing, a signature change its callers
+    require. Answer (b) is NO.
+  * It exists only to describe or exercise this change — a docstring or comment
+    documenting the code being changed, tests covering the new behavior,
+    fixtures supporting those tests. It is not a DISTINCT unit of work, so it
+    should never be recommended for splitting into its own PR, even when the
+    code would technically still run without it.
+- separable: removable per (a) and (b) — work that stands apart from the
+  mandate rather than supporting it. This covers BOTH a substantial unit that
+  belongs in its own PR AND a small opportunistic edit someone made in passing
+  (a stray comment, a defensive check on an unrelated function): both are
+  unrequested scope the reviewer should see. Do NOT require a change to be big
+  enough to justify its own PR before calling it separable — size governs the
+  RECOMMENDATION, not the classification. Supporting scaffolding for THIS diff
+  is never separable; it is in_service.
+- risky: removable per (a) and (b), but it edits existing public interface,
+  dependencies, or adjacent behavior in a way that could hide a regression.
+  Scrutinize.
 
 Policy knob: under a STRICT scope-expansion policy, treat an edit to existing
 adjacent behavior as `risky`; under a LOOSE policy, treat it as merely
@@ -285,6 +324,39 @@ def _is_load_bearing_via_cross_file_import(
     return False
 
 
+_TEST_DEF_RE = re.compile(r"^\+\s*(?:async\s+)?def\s+test_")
+
+
+def _is_test_support_for_a_source_change(
+    change: UnrequestedChange, change_set: ChangeSet
+) -> bool:
+    """Test scaffolding a source change in the SAME diff requires (#139).
+
+    Confined to test files, adds no new test function, and accompanies a source
+    change — i.e. fixtures, helpers, or harness updates the EXISTING tests need
+    to keep passing once the source changed. Removing it breaks the suite, so
+    the removability litmus says in_service; it is also not a distinct unit of
+    work (nobody ships "add a fixture" as its own PR).
+
+    Adding a new `def test_...` is the discriminator: that is plausibly new,
+    independent test work, so it escalates to the model rather than being
+    swept up here."""
+    if not change.diff_refs:
+        return False
+    category_by_path = {f.path: f.category for f in change_set.files}
+    if not all(category_by_path.get(ref.file) == "test" for ref in change.diff_refs):
+        return False
+    # Must accompany a real source change — test-only diffs are ordinary test work.
+    if not any(f.category == "source" for f in change_set.files):
+        return False
+
+    for ref in change.diff_refs:
+        content = _hunk_content(ref, change_set)
+        if content and any(_TEST_DEF_RE.match(line) for line in content.splitlines()):
+            return False  # new test functions: possibly distinct work, let the model judge
+    return True
+
+
 def _is_pure_addition(change: UnrequestedChange, change_set: ChangeSet) -> bool:
     if not change.diff_refs:
         return False
@@ -398,6 +470,17 @@ def classify_dispositions(
                     "A symbol this change defines or renames is imported by another "
                     "file changed in the same diff; reverting it would break that "
                     "file's changes.",
+                    decided_by="structural",
+                )
+            )
+        elif _is_test_support_for_a_source_change(change, change_set):
+            results.append(
+                _dispositioned(
+                    change,
+                    UnrequestedChangeDisposition.IN_SERVICE,
+                    "Test fixtures/helpers the existing tests need to keep passing "
+                    "under this diff's source change; removing it would break the "
+                    "suite, and it is not a distinct unit of work.",
                     decided_by="structural",
                 )
             )

--- a/tests/benchmark/test_fixtures.py
+++ b/tests/benchmark/test_fixtures.py
@@ -33,12 +33,15 @@ EXPECTED_NAMES = {
     "09-revision-cycle",
 }
 
-# The three #8 siblings (M3.5.4/DR-081): one archetype per unrequested-change
-# disposition #8 alone doesn't demonstrate.
+# The #8 siblings (M3.5.4/DR-081): one archetype per unrequested-change
+# disposition #8 alone doesn't demonstrate. `-test-support` (#139) covers the
+# case that recurred across #122/#126/#139 — test scaffolding a source change
+# in the same diff requires, which is in_service rather than separable.
 EXPECTED_SIBLING_NAMES = {
     "08-unrequested-change-in-service",
     "08-unrequested-change-separable",
     "08-unrequested-change-risky-adjacent",
+    "08-unrequested-change-test-support",
 }
 
 

--- a/tests/coverage/test_disposition.py
+++ b/tests/coverage/test_disposition.py
@@ -322,3 +322,157 @@ def test_dispositioned_change_round_trips():
     )[0]
 
     assert DispositionedChange.from_dict(result.to_dict()) == result
+
+
+def test_test_fixture_updates_required_by_a_source_change_are_in_service():
+    """#139: wiring a capability into a shared pipeline forces existing tests to
+    add fixture/dispatch entries. Removing them breaks the suite, so the
+    removability litmus says in_service -- and nobody ships "add a fixture" as
+    its own PR. This recurred across #122/#126/#139, so it is caught
+    structurally, with no model call."""
+    source_hunk = _hunk(header="@@ -10,3 +10,4 @@")
+    fixture_hunk = DiffHunk(
+        header="@@ -20,2 +20,3 @@", old_start=20, old_lines=2, new_start=20, new_lines=3,
+        content='+            "_Recommendations": {"recommendations": []},',
+    )
+    change_set = ChangeSet(base_revision="a", head_revision="b", files=[
+        FileChange(path="src/pkg/pipeline.py", status="modified", category="source",
+                   hunks=[source_hunk]),
+        FileChange(path="tests/test_pipeline.py", status="modified", category="test",
+                   hunks=[fixture_hunk]),
+    ])
+    changes = [_change("tests/test_pipeline.py", header=fixture_hunk.header,
+                       kind=UnrequestedChangeKind.OTHER)]
+
+    result = classify_dispositions(
+        changes, [_obligation("ob-1")], [], change_set,
+        ScopeExpansionPolicy.STRICT, _exploding_client(),
+    )
+
+    assert result[0].disposition is UnrequestedChangeDisposition.IN_SERVICE
+    assert result[0].decided_by == "structural"
+    assert result[0].recommendation is None
+
+
+def test_new_test_functions_still_escalate_to_the_model():
+    """The discriminator: adding a `def test_...` may be genuinely distinct test
+    work, so it must NOT be swept into in_service by the fixture fast-path."""
+    source_hunk = _hunk(header="@@ -10,3 +10,4 @@")
+    new_test_hunk = DiffHunk(
+        header="@@ -30,1 +30,4 @@", old_start=30, old_lines=1, new_start=30, new_lines=4,
+        content="+def test_an_unrelated_new_behavior():\n+    assert compute() == 3",
+    )
+    change_set = ChangeSet(base_revision="a", head_revision="b", files=[
+        FileChange(path="src/pkg/pipeline.py", status="modified", category="source",
+                   hunks=[source_hunk]),
+        FileChange(path="tests/test_pipeline.py", status="modified", category="test",
+                   hunks=[new_test_hunk]),
+    ])
+    changes = [_change("tests/test_pipeline.py", header=new_test_hunk.header,
+                       kind=UnrequestedChangeKind.OTHER)]
+    client = client_dispatching({"_DispositionJudgment": {
+        "disposition": "separable", "rationale": "an unrelated new test",
+    }})
+
+    result = classify_dispositions(
+        changes, [_obligation("ob-1")], [], change_set,
+        ScopeExpansionPolicy.STRICT, client,
+    )
+
+    assert result[0].decided_by == "model"
+
+
+def test_test_only_diff_is_not_swept_into_in_service():
+    """With no source change in the diff, test edits are ordinary test work and
+    must still be judged, not assumed to be scaffolding for something else."""
+    test_hunk = DiffHunk(
+        header="@@ -20,2 +20,3 @@", old_start=20, old_lines=2, new_start=20, new_lines=3,
+        content="+    helper_value = 3",
+    )
+    change_set = ChangeSet(base_revision="a", head_revision="b", files=[
+        FileChange(path="tests/test_pipeline.py", status="modified", category="test",
+                   hunks=[test_hunk]),
+    ])
+    changes = [_change("tests/test_pipeline.py", header=test_hunk.header,
+                       kind=UnrequestedChangeKind.OTHER)]
+    client = client_dispatching({"_DispositionJudgment": {
+        "disposition": "separable", "rationale": "standalone test refactor",
+    }})
+
+    result = classify_dispositions(
+        changes, [_obligation("ob-1")], [], change_set,
+        ScopeExpansionPolicy.STRICT, client,
+    )
+
+    assert result[0].decided_by == "model"
+
+
+def test_a_small_opportunistic_edit_is_still_separable():
+    """A drive-by comment or safeguard on an unrelated function is unrequested
+    scope the reviewer should see. It is NOT in_service (nothing in the diff
+    depends on it), so it must not be swept there just because it is too small
+    to warrant its own PR — size governs the recommendation, not the
+    classification. Guards against re-tightening `separable` to mean
+    "PR-worthy" (the taxonomy gap tracked in #145)."""
+    source_hunk = _hunk(header="@@ -10,3 +10,4 @@")
+    drive_by_hunk = DiffHunk(
+        header="@@ -80,2 +80,4 @@", old_start=80, old_lines=2, new_start=80, new_lines=4,
+        content="+    # guard against a negative balance while we're in here\n+    if balance < 0:\n+        raise ValueError(balance)",
+    )
+    change_set = ChangeSet(base_revision="a", head_revision="b", files=[
+        FileChange(path="src/pkg/pipeline.py", status="modified", category="source",
+                   hunks=[source_hunk]),
+        FileChange(path="src/pkg/unrelated.py", status="modified", category="source",
+                   hunks=[drive_by_hunk]),
+    ])
+    changes = [_change("src/pkg/unrelated.py", header=drive_by_hunk.header,
+                       kind=UnrequestedChangeKind.OTHER)]
+    client = client_dispatching({"_DispositionJudgment": {
+        "disposition": "separable",
+        "rationale": "an unrelated safeguard added in passing; nothing here depends on it",
+    }})
+
+    result = classify_dispositions(
+        changes, [_obligation("ob-1")], [], change_set,
+        ScopeExpansionPolicy.STRICT, client,
+    )
+
+    assert result[0].disposition is UnrequestedChangeDisposition.SEPARABLE
+    assert result[0].decided_by == "model"
+
+
+def test_the_escalation_prompt_asks_both_limbs_of_the_litmus():
+    """The fast-paths above cover the structural half of the litmus; this
+    guards the other half — the prompt used for ambiguous cases.
+
+    Asking only "would every obligation still be satisfied?" and never "would
+    the rest of the diff still work?" is precisely what let #122, #126 and #139
+    recur, so limb (b) must not silently disappear from the prompt.
+
+    Limitation, stated plainly: this asserts the model SEES both limbs, not
+    that it OBEYS them — the weakness tracked in #138. Real behavioural
+    evidence needs a recorded model response (#146); the archetype
+    `08-unrequested-change-test-support` carries the ground truth for it.
+    """
+    change_set = ChangeSet(base_revision="a", head_revision="b", files=[
+        FileChange(path="mod.py", status="modified", category="source", hunks=[_hunk()]),
+    ])
+    changes = [_change("mod.py")]
+    seen = {}
+
+    def capture(**kwargs):
+        seen["system"] = kwargs["messages"][0]["content"]
+        content = json.dumps({"disposition": "separable", "rationale": "."})
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+
+    client = ModelClient(model="x", mode=Mode.RECORD,
+                         store=TranscriptStore(tempfile.mkdtemp()), completion_fn=capture)
+
+    classify_dispositions(changes, [_obligation("ob-1")], [], change_set,
+                          ScopeExpansionPolicy.STRICT, client)
+
+    assert "Would every obligation still be satisfied" in seen["system"]  # limb (a)
+    assert "Would the rest of the diff still WORK" in seen["system"]  # limb (b)

--- a/tests/fixtures/archetypes/08-unrequested-change-test-support/base/pricing.py
+++ b/tests/fixtures/archetypes/08-unrequested-change-test-support/base/pricing.py
@@ -1,0 +1,2 @@
+def line_total(item):
+    return item["qty"] * item["price"]

--- a/tests/fixtures/archetypes/08-unrequested-change-test-support/base/test_pricing.py
+++ b/tests/fixtures/archetypes/08-unrequested-change-test-support/base/test_pricing.py
@@ -1,0 +1,13 @@
+from pricing import line_total
+
+
+def _item(qty, price):
+    return {"qty": qty, "price": price}
+
+
+def test_line_total_multiplies_quantity_by_price():
+    assert line_total(_item(2, 5.0)) == 10.0
+
+
+def test_line_total_of_a_single_item():
+    assert line_total(_item(1, 3.25)) == 3.25

--- a/tests/fixtures/archetypes/08-unrequested-change-test-support/head/pricing.py
+++ b/tests/fixtures/archetypes/08-unrequested-change-test-support/head/pricing.py
@@ -1,0 +1,3 @@
+def line_total(item):
+    subtotal = item["qty"] * item["price"]
+    return round(subtotal * (1 - item["discount"] / 100), 2)

--- a/tests/fixtures/archetypes/08-unrequested-change-test-support/head/test_pricing.py
+++ b/tests/fixtures/archetypes/08-unrequested-change-test-support/head/test_pricing.py
@@ -1,0 +1,17 @@
+from pricing import line_total
+
+
+def _item(qty, price, discount=0):
+    return {"qty": qty, "price": price, "discount": discount}
+
+
+def test_line_total_multiplies_quantity_by_price():
+    assert line_total(_item(2, 5.0)) == 10.0
+
+
+def test_line_total_of_a_single_item():
+    assert line_total(_item(1, 3.25)) == 3.25
+
+
+def test_line_total_applies_the_item_discount():
+    assert line_total(_item(2, 5.0, discount=10)) == 9.0

--- a/tests/fixtures/archetypes/08-unrequested-change-test-support/labels.json
+++ b/tests/fixtures/archetypes/08-unrequested-change-test-support/labels.json
@@ -1,0 +1,36 @@
+{
+  "obligations": [
+    {
+      "id": "apply-item-discount",
+      "description": "Apply the item's discount percentage to the line subtotal",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "test_line_total_applies_the_item_discount asserts a 10% discount turns 10.0 into 9.0; an implementation that ignored the discount would return 10.0 and fail.",
+      "candidate_tests": ["test_pricing.py::test_line_total_applies_the_item_discount"]
+    },
+    {
+      "id": "round-to-two-decimals",
+      "description": "Round the discounted line total to two decimals",
+      "explicit": true,
+      "evidence_class": "nominally_supported",
+      "evidence_rationale": "Every asserted result (10.0, 3.25, 9.0) is already exact at two decimals, so a mutant that dropped the rounding would still pass. A present, relevant test that kills zero mapped mutants for this rule.",
+      "candidate_tests": ["test_pricing.py::test_line_total_applies_the_item_discount"]
+    }
+  ],
+  "gaps": [
+    {
+      "id": "gap-rounding-never-exercised",
+      "description": "No input produces a value needing rounding, so the two-decimal rule is never exercised; an implementation that omitted round() would pass every test",
+      "obligation_id": "round-to-two-decimals",
+      "severity": "low"
+    }
+  ],
+  "unrequested_changes": [
+    {
+      "id": "test-support-item-helper-widening",
+      "description": "The _item() test helper gained a discount key/parameter. The task never asked for the test helper to change, but line_total now reads item['discount'], so without it every pre-existing test raises KeyError. Removing this change breaks the suite, and 'split the fixture update into its own PR' is not coherent advice -- it is in service of the requested change, not separable work.",
+      "file": "test_pricing.py",
+      "disposition": "in_service"
+    }
+  ]
+}

--- a/tests/fixtures/archetypes/08-unrequested-change-test-support/meta.json
+++ b/tests/fixtures/archetypes/08-unrequested-change-test-support/meta.json
@@ -1,0 +1,6 @@
+{
+  "scenario": 8,
+  "name": "unrequested-change-test-support",
+  "intended_pytest": "pass",
+  "summary": "Delivering the per-item discount changes the shape line_total expects, so the existing tests' _item() helper must gain a discount key or every pre-existing test raises KeyError. The task never asked for the test helper to change, but removing that change breaks the suite -- it is in service of the requested obligation, not separable work anyone would split into its own PR."
+}

--- a/tests/fixtures/archetypes/08-unrequested-change-test-support/task.md
+++ b/tests/fixtures/archetypes/08-unrequested-change-test-support/task.md
@@ -1,0 +1,4 @@
+# Task: Apply a per-item discount
+
+Update `line_total(item)` in `pricing.py` so it applies the item's
+`discount` percentage to the line subtotal, rounded to two decimals.


### PR DESCRIPTION
## Summary
Fixes #139 — test-fixture updates that a source change in the same diff requires were classified `separable`, recommending they be split into their own PR. That's absurd advice: deleting them breaks the suite.

This is the **fourth recurrence of one defect class** (#122 docstrings, #126 imports, #139 fixtures, plus a fifth sighting on M7.4). So rather than bolt on another exception, the fix is the litmus itself.

**The litmus now asks both questions:**
- (a) would every obligation still be satisfied without this change?
- (b) would the rest of the diff still **work** — tests passing, imports resolving, the delivered change self-consistent?

`separable` requires both YES. Earlier revisions asked only (a), which is exactly why the class kept recurring: nothing ever considered whether the *delivered change* still functioned. The three previously-bolted-on special cases are now one principle.

**Deterministic fast-path:** a change confined to test files that adds no new `def test_...` and accompanies a source change is scaffolding the existing tests need → `in_service`, no model call. Adding a test function is the discriminator (possibly distinct work, so it escalates); a test-only diff is ordinary test work and still escalates.

## Course-correction during review
The first draft over-tightened `separable` to mean *"work someone could ship as its own PR."* That left a small opportunistic change — a stray comment, a defensive check on an unrelated function someone remembered while in the file — with nowhere to go: not `in_service` (nothing depends on it), not `separable` (too small to split). Size now governs the **recommendation**, not the classification, pinned by a test so it can't silently re-tighten.

That gap is real and bigger than this PR, so it's filed as **#145**, which also carries the observation that `risky` may not belong in this enum at all — `in_service`/`separable` answer *"what is this change's relationship to the mandate?"* while `risky` answers *"how much scrutiny?"*. Those are orthogonal, and today a refactor that's both load-bearing **and** alters a public signature can only be recorded as one of them.

## Evidence for the prompt half of the litmus
The tool's own `check` flagged this honestly: the litmus obligation came back `test evidence: unsupported (no mapped test)`, because half the litmus lives in `_SYSTEM_PROMPT` and nothing tested it.

- Added a guard asserting the escalation prompt carries **both** limbs. Its docstring states the limitation plainly: it proves the model *sees* both limbs, not that it *obeys* them — the weakness tracked in **#138**.
- Added archetype **`08-unrequested-change-test-support`** with ground-truth `disposition: in_service`, so this becomes *measurable* rather than merely asserted once **#146** lands. Its base tests were verified to fail against head source (`KeyError: 'discount'`) — empirical proof the `in_service` label is correct, not just claimed.

That untestable-prompt gap prompted **#146**: commit transcripts, replay when prompts are unchanged, live-call and re-verify when they change. The cache key already hashes the system prompt, so a prompt edit *is* a cache miss — the detection mechanism exists; the transcripts just aren't committed.

## Dogfood
`acceptance check` on this diff: **NO-MATERIAL-GAPS**, all 5 obligations addressed with strongly-supported evidence.

The single unrequested change is the new archetype file set, correctly `[in_service]` — notable because it's a pure new-file addition, which the old `_is_pure_addition` fast-path would have labelled `separable` with a split recommendation.

Honest caveat: obligation 1 rates `strongly supported` on the strength of a prompt-containment test, which the tool cannot distinguish from real behavioural evidence. That's #138 in miniature, and every line reads `[tier: static]` for the same reason.

## Test plan
- [x] `pytest -q` — 437 passed
- [x] `ruff check src tests` — clean
- [x] Each new test verified to **discriminate** by injecting its specific defect and confirming failure (§8.2): fast-path disabled; limb (b) deleted from the prompt
- [x] New archetype verified: head passes, base passes, base-against-head fails with `KeyError`

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)
