### PR TITLE
Generate the §10.1 next instruction when a review has gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ htmlcov/
 
 # Recorded model transcripts / local run artifacts (plan M0.4/M0.5)
 .acceptance/cache/
+# The checker's own output when dogfooding this repo (M7.3) — a per-run
+# artifact regenerated from the current review, not a source file to commit.
+.acceptance/next-instruction.md
+.acceptance/reviews/
 *.local
 
 # OS / editor

--- a/current-task.md
+++ b/current-task.md
@@ -1,16 +1,17 @@
 # Task
-The disposition classifier mislabels test-fixture updates that a source change in the same diff requires as `separable`, recommending they be split into their own PR. Wiring a capability into the shared pipeline forces existing tests to add fixture and dispatch entries; removing those entries breaks the suite, so they are load-bearing, not separable. Fix the removability litmus rather than adding another special case.
+Produce a `.acceptance/next-instruction.md` that tells the coding agent what to implement and which discriminating tests to add, so a review with gaps hands back an actionable next step rather than stopping at a findings report.
 
 ## Constraints
-- The litmus must ask both whether every obligation would still be satisfied if the change were removed and whether the rest of the diff would still work — tests still passing, imports still resolving. Asking only about obligations is what let this class of misclassification recur three times.
-- A change confined to test files that adds no new test function and accompanies a source change is test scaffolding the existing tests need; classify it as in service, structurally, with no model call.
-- Adding a new test function is the discriminator: that may be genuinely distinct test work, so it escalates to model judgment instead of being swept into in service.
-- A diff containing only test changes is ordinary test work and must still be judged rather than assumed to be scaffolding for something else.
-- Classifying a change as separable must not require it to be large enough to justify its own pull request. A small opportunistic edit is still unrequested scope the reviewer should see; size governs the recommendation, not the classification.
+- Produce the instruction only when gaps exist. A review with no material gaps has nothing to instruct and must write no file.
+- Derive the instruction entirely from findings and recommendations the review already produced; make no new judgment and no additional model call, so every line traces to something already established.
+- Key the decision to produce an instruction off the computed completion verdict rather than re-deriving what counts as a material gap, so there is only one definition of materiality.
+- Select rather than restate: the instruction is addressed to the coding agent, so it omits satisfied obligations, advisory unrequested changes, and evidence limitations, which belong in the human-facing report.
+- Writing the file is a command-line side effect, not part of the shared review pipeline, so that scoring the same review over fixture repositories never writes into them.
+- Unresolved open questions come first, because a review blocked on an ambiguity cannot be closed by writing code.
 
 ## Completion expectations
 - Implementation
-- A source change accompanied by the test-fixture edits it requires classifies those edits as in service without a model call.
-- A change that adds a new test function still escalates to model judgment.
-- A test-only diff still escalates to model judgment.
-- A small opportunistic edit to an unrelated function is still classified separable.
+- On a review with several gaps, the instruction names each gap and the discriminating test that closes it, including the plausible defect that test must fail on.
+- The instruction closes by asking for the builder declaration to be updated.
+- A review with no material gaps produces no instruction and no file.
+- The rendered report points at the written instruction file instead of reporting none.

--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -28,7 +28,7 @@ from acceptance.coverage.open_questions import apply_open_question_resolutions, 
 from acceptance.coverage.unrequested import detect_unrequested_changes
 from acceptance.llm import LLMError, Mode, ModelClient
 from acceptance.pipeline import run_review
-from acceptance.report import render_report
+from acceptance.report import render_next_instruction, render_report
 from acceptance.requirement.obligations import Decomposition, Obligation, decompose
 from acceptance.requirement.task_file import parse_task_file
 from acceptance.review_state import ChangeSet, OpenQuestion, Review
@@ -148,8 +148,26 @@ def run_check(
         policy=config.scope_expansion_policy,
         provenance=config.provenance(),
     )
+    # §10.1 step 12: when gaps exist, hand the agent a next instruction. The
+    # file is a CLI side effect, not part of the pipeline — the benchmark runs
+    # the same review over fixture repos and must not write into them.
+    instruction_path = _write_next_instruction(review, repo_path)
+    if instruction_path is not None:
+        review = review.model_copy(update={"recommendation": str(instruction_path)})
     store.write(review)
     return review
+
+
+def _write_next_instruction(review: Review, repo: Path) -> Path | None:
+    """Write `.acceptance/next-instruction.md` when the review has gaps to
+    close; return its path, or None when there is nothing to instruct."""
+    instruction = render_next_instruction(review)
+    if instruction is None:
+        return None
+    path = repo / ".acceptance" / "next-instruction.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(instruction + "\n", encoding="utf-8")
+    return path.relative_to(repo) if path.is_relative_to(repo) else path
 
 
 def run_decompose(task: str, config: RunConfig) -> Decomposition:

--- a/src/acceptance/report.py
+++ b/src/acceptance/report.py
@@ -16,7 +16,12 @@ Status is stated in words, not symbols, and every evidence line carries its
 
 from __future__ import annotations
 
-from acceptance.review_state import UNREQUESTED_CHANGE, Obligation, Review
+from acceptance.review_state import (
+    UNREQUESTED_CHANGE,
+    CompletionVerdict,
+    Obligation,
+    Review,
+)
 
 _EMPTY = "  (none)"
 _NO_CODE = "(no corresponding change)"
@@ -77,6 +82,72 @@ def render_report(review: Review) -> str:
 
     lines.append(f"Recommended next instruction: {review.recommendation or '(none)'}")
 
+    return "\n".join(lines)
+
+
+def render_next_instruction(review: Review) -> str | None:
+    """The §10.1 step-12 next instruction, or None when there is nothing to do.
+
+    A deliberately thin projection of the same Review `render_report` renders —
+    no new judgment, no model call, every line traced to a finding, an M7.1
+    recommendation, or an unresolved open question. What it adds over the §16
+    report is SELECTION and mood: the report says "here is everything I found,
+    you judge"; this says "here is what to do next", addressed to the coding
+    agent rather than the human reviewer. So it drops satisfied obligations,
+    advisory unrequested changes, and evidence limitations.
+
+    Kept beside `render_report` rather than in its own module because both are
+    the same concern (render a Review for a consumer) — and kept a SEPARATE
+    function because the two audiences diverge: terminal styling (M7.6) must
+    never reach a file on disk, and reviewer-facing explanations (#143) are
+    noise in an agent handoff.
+
+    Produced only when gaps exist (§10.1 step 12), keyed off M7.2's verdict so
+    there is no second definition of what counts as material.
+    """
+    if review.completion is not None and review.completion.verdict is CompletionVerdict.NO_MATERIAL_GAPS:
+        return None
+
+    gaps = [
+        f.related_obligation
+        for f in review.findings
+        if f.type == "coverage_gap" and f.related_obligation is not None
+    ]
+    unresolved = [q.question for q in review.open_questions if not q.resolved]
+    if not gaps and not review.recommendations and not unresolved:
+        return None
+
+    lines = ["# Next instruction", ""]
+    if review.completion is not None:
+        lines += [f"Review verdict: **{review.completion.verdict.value}**.", ""]
+
+    if unresolved:
+        lines.append("## Answer these first")
+        lines += [f"{i}. {q}" for i, q in enumerate(unresolved, start=1)]
+        lines += ["", "These are unresolved ambiguities in the task; the work cannot be "
+                  "judged complete until they are settled.", ""]
+
+    if gaps:
+        lines.append("## Implement")
+        lines += [f"{i}. {g}" for i, g in enumerate(gaps, start=1)]
+        lines.append("")
+
+    if review.recommendations:
+        lines.append("## Add these tests")
+        for i, rec in enumerate(review.recommendations, start=1):
+            lines.append(f"{i}. **{rec.criterion}**")
+            lines.append(f"   - Inputs: {rec.required_inputs}")
+            if rec.boundary_conditions:
+                lines.append(f"   - Boundaries: {rec.boundary_conditions}")
+            lines.append(f"   - Expected: {rec.expected_output}")
+            for assertion in rec.required_assertions:
+                lines.append(f"   - Assert: {assertion}")
+            lines.append(f"   - Must fail if: {rec.plausible_defect}")
+            if rec.repo_conventions:
+                lines.append(f"   - Conventions: {rec.repo_conventions}")
+        lines.append("")
+
+    lines.append("Update the builder declaration after the changes.")
     return "\n".join(lines)
 
 

--- a/tests/benchmark/test_coverage.py
+++ b/tests/benchmark/test_coverage.py
@@ -608,3 +608,72 @@ def test_the_shared_pipeline_runs_every_stage(tmp_path):
     assert obligation.coverage_refs  # coverage refs were carried through
     assert review.recommendations  # recommendation generation ran
     assert review.completion is not None  # the verdict was derived
+
+
+def test_the_shared_pipeline_writes_nothing_into_the_reviewed_repo(tmp_path):
+    """The next-instruction file (M7.3) is a CLI side effect, deliberately NOT
+    part of `run_review`. The benchmark runs the same review over fixture
+    repos, so a write inside the pipeline would mutate the very fixtures the
+    scores are computed from.
+
+    Asserts BOTH halves of that boundary in one test: the pipeline writes
+    nothing, AND the CLI over the same repo does write. Checking only the
+    first half would pass just as well if the feature were broken and nothing
+    ever wrote anywhere -- isolation that is trivially true proves nothing.
+    """
+    case = build_benchmark_case(ARCHETYPES_DIR / "01-missed-obligation", tmp_path / "repo")
+    repo = Path(case.inputs.repo)
+    instruction = repo / ".acceptance" / "next-instruction.md"
+
+    def snapshot() -> set:
+        return {p.relative_to(repo) for p in repo.rglob("*") if ".git" not in p.parts}
+
+    # The pipeline leaves the reviewed repo untouched...
+    before = snapshot()
+    classify_case(case, client_finding_nothing())
+    assert snapshot() == before
+    assert not instruction.exists()
+
+    # ...while the CLI, over that same repo and a review with a real gap,
+    # does write the instruction. The boundary is real, not vacuous.
+    task_file = tmp_path / "task.md"
+    task_file.write_text(case.inputs.task_text)
+    run_check(
+        task=str(task_file),
+        base=case.inputs.base_revision,
+        head=case.inputs.head_revision,
+        config=RunConfig(),
+        store=ReviewStore(tmp_path / "reviews"),
+        repo=repo,
+        client=_client_dispatching({
+            "_Decomposition": _decomposition_response([{
+                "id": "gap-ob", "description": "Handle the empty case",
+                "type": "functional", "source_quote": "Show the item name",
+            }]),
+            "_Mappings": {"mappings": []},
+            "_Discrimination": {"discriminations": []},
+            "_Coverage": _classification_response([
+                {"obligation_id": "gap-ob", "status": "not_addressed"},
+            ]),
+            "_Detections": {"unrequested_changes": []},
+            "_Judgments": {"resolutions": []},
+            "_Recommendations": {"recommendations": []},
+            "_Mismatches": {"mismatches": []},
+        }),
+    )
+    assert instruction.is_file()
+
+    # ...and SKIPS that branch when the review has nothing to instruct, over
+    # the same repo. Without this, a CLI that wrote unconditionally would pass:
+    # the write would be a side effect, just not a conditional one.
+    instruction.unlink()
+    run_check(
+        task=str(task_file),
+        base=case.inputs.base_revision,
+        head=case.inputs.head_revision,
+        config=RunConfig(),
+        store=ReviewStore(tmp_path / "reviews-2"),
+        repo=repo,
+        client=client_finding_nothing(),
+    )
+    assert not instruction.exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -479,3 +479,73 @@ def test_check_without_a_head_reviews_the_working_tree(
     assert review["reviewed_revision"] == "<working-tree>"
     changed = {f["path"] for f in review["change_set"]["files"]}
     assert "uncommitted.py" in changed  # the working tree, not the HEAD commit
+
+
+# --- M7.3: the next-instruction file ---
+
+
+def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+    git_repo, fixture_task_path, capsys, monkeypatch
+):
+    """§10.1 step 12: when the review has gaps, `check` writes
+    .acceptance/next-instruction.md and the §16 report points at it instead of
+    printing "(none)"."""
+    from acceptance.config import RunConfig
+    from tests.support import client_dispatching
+
+    # A checker that finds one obligation, leaves it uncovered, and recommends
+    # a discriminating test for it — i.e. a review with real gaps.
+    monkeypatch.setattr(RunConfig, "build_client", lambda self, completion_fn=None: client_dispatching({
+        "_Decomposition": {"obligations": [{
+            "id": "gap-ob", "description": "Handle the empty case",
+            "type": "functional", "importance": "critical", "explicit": True,
+            "observable_behavior": "...", "source_quote": "Do the thing.",
+        }], "open_questions": []},
+        "_Mappings": {"mappings": []},
+        "_Discrimination": {"discriminations": []},
+        "_Coverage": {"classifications": [{
+            "obligation_id": "gap-ob", "status": "not_addressed",
+            "rationale": "no code handles the empty case", "diff_refs": [],
+        }]},
+        "_Detections": {"unrequested_changes": []},
+        "_Judgments": {"resolutions": []},
+        "_Recommendations": {"recommendations": [{
+            "obligation_id": "gap-ob",
+            "required_inputs": "an empty collection",
+            "boundary_conditions": "zero elements",
+            "expected_output": "an empty result, not an error",
+            "required_assertions": ["assert handle([]) == []"],
+            "plausible_defect": "raises IndexError on an empty input",
+            "repo_conventions": "tests/test_thing.py",
+        }]},
+        "_Mismatches": {"mismatches": []},
+    }))
+
+    assert main([
+        "check", "--task", fixture_task_path,
+        "--base", git_repo["base"], "--head", git_repo["head"],
+    ]) == 0
+
+    instruction_file = git_repo["path"] / ".acceptance" / "next-instruction.md"
+    assert instruction_file.is_file()
+    written = instruction_file.read_text()
+    assert "Handle the empty case" in written  # the gap
+    assert "Must fail if: raises IndexError on an empty input" in written  # its test
+    assert "Update the builder declaration after the changes." in written
+    # The §16 report's pointer now names the file rather than "(none)".
+    out = capsys.readouterr().out
+    assert ".acceptance/next-instruction.md" in out
+
+
+def test_check_writes_no_instruction_file_when_nothing_is_wrong(
+    git_repo, fixture_task_path, capsys, stub_model
+):
+    """A checker that finds nothing has nothing to instruct, so no file is
+    written and the report still reads "(none)"."""
+    assert main([
+        "check", "--task", fixture_task_path,
+        "--base", git_repo["base"], "--head", git_repo["head"],
+    ]) == 0
+
+    assert not (git_repo["path"] / ".acceptance" / "next-instruction.md").exists()
+    assert "Recommended next instruction: (none)" in capsys.readouterr().out

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -17,7 +17,9 @@ from acceptance.review_state import (
     TestRecommendation,
     UnrequestedChangeDisposition,
 )
-from acceptance.report import render_report
+import re
+
+from acceptance.report import render_next_instruction, render_report
 
 
 def test_empty_review_renders_the_full_shell():
@@ -264,3 +266,189 @@ def test_the_two_axes_render_independently_for_the_same_obligation():
 
     assert "code evidence: addressed" in report
     assert "test evidence: nominally supported" in report
+
+
+# --- M7.3: the §10.1 step-12 next instruction ---
+
+
+def _gap_finding(obligation_description: str) -> Finding:
+    return Finding(
+        type="coverage_gap", severity="high", description="missing",
+        evidence_tier=EvidenceTier.STATIC, produced_by=Component.STATIC_ANALYZER,
+        links=[Link(kind="requirement", ref="x", text="x")],
+        related_obligation=obligation_description,
+    )
+
+
+def _recommendation(criterion: str, defect: str) -> TestRecommendation:
+    return TestRecommendation(
+        obligation_id=criterion.lower().replace(" ", "-")[:20],
+        criterion=criterion,
+        required_inputs="a non-30-day month",
+        boundary_conditions="0 days used, a full month",
+        expected_output="price/days_in_month * days, rounded",
+        required_assertions=["assert prorate(280, 14, 28) == 140.0"],
+        plausible_defect=defect,
+        repo_conventions="test_billing.py",
+    )
+
+
+def test_multi_gap_review_names_each_gap_and_its_distinguishing_test():
+    """M7.3 acceptance: on a multi-gap review the instruction names each gap
+    and the discriminating test that closes it (§10.1 style)."""
+    review = Review(
+        mode="local",
+        reviewed_revision="abc",
+        obligation_map=[_obligation("Daily rate", "not_addressed", "unsupported")],
+        findings=[
+            _gap_finding("Daily rate is monthly_price divided by days_in_month"),
+            _gap_finding("Round the result to two decimals"),
+        ],
+        recommendations=[
+            _recommendation("Daily rate uses days_in_month", "hard-codes price/30"),
+            _recommendation("Rounding to two decimals", "drops the round() call"),
+        ],
+        completion=CompletionResult(
+            verdict=CompletionVerdict.INCOMPLETE, rationale="2 gaps.",
+        ),
+    )
+
+    instruction = render_next_instruction(review)
+
+    # Each gap is named...
+    assert "Daily rate is monthly_price divided by days_in_month" in instruction
+    assert "Round the result to two decimals" in instruction
+    # ...and each distinguishing test, with the defect it must catch.
+    assert "Daily rate uses days_in_month" in instruction
+    assert "Must fail if: hard-codes price/30" in instruction
+    assert "Must fail if: drops the round() call" in instruction
+    assert "assert prorate(280, 14, 28) == 140.0" in instruction
+    # §10.1 closes by asking for the declaration to be refreshed.
+    assert "Update the builder declaration after the changes." in instruction
+
+
+def test_no_instruction_when_there_are_no_material_gaps():
+    """§10.1 step 12 produces an instruction only WHEN GAPS EXIST.
+
+    Carries leftover recommendations deliberately: with an empty review the
+    "nothing actionable" guard would return None on its own and the verdict
+    gate would never be exercised. Recommendations present + a positive
+    verdict isolates the gate as the only thing that can suppress output.
+    """
+    review = Review(
+        mode="local",
+        reviewed_revision="abc",
+        obligation_map=[_obligation("A", "addressed", "strongly_supported")],
+        recommendations=[_recommendation("Some criterion", "some defect")],
+        completion=CompletionResult(
+            verdict=CompletionVerdict.NO_MATERIAL_GAPS, rationale="all good",
+        ),
+    )
+
+    assert render_next_instruction(review) is None
+
+
+def test_unresolved_open_questions_lead_the_instruction():
+    """A needs-clarification review can't be closed by writing code, so the
+    questions come first (#113)."""
+    review = Review(
+        mode="local",
+        reviewed_revision="abc",
+        open_questions=[
+            OpenQuestion(id="q-1", question="Minus sign or parentheses?"),
+            OpenQuestion(id="q-2", question="Already answered", resolved=True),
+        ],
+        completion=CompletionResult(
+            verdict=CompletionVerdict.NEEDS_CLARIFICATION, rationale="1 open question.",
+        ),
+    )
+
+    instruction = render_next_instruction(review)
+
+    assert "Answer these first" in instruction
+    assert "Minus sign or parentheses?" in instruction
+    assert "Already answered" not in instruction  # resolved questions are not asked again
+
+
+def test_no_instruction_when_a_non_positive_verdict_has_nothing_actionable():
+    """unable-to-determine with no gaps, recommendations or open questions has
+    nothing to instruct — better silence than an empty template."""
+    review = Review(
+        mode="local",
+        reviewed_revision="abc",
+        completion=CompletionResult(
+            verdict=CompletionVerdict.UNABLE_TO_DETERMINE, rationale="nothing analyzed",
+        ),
+    )
+
+    assert render_next_instruction(review) is None
+
+
+def test_instruction_contains_only_review_content_and_invents_nothing():
+    """Obligation 4's real test: the instruction is a PROJECTION, so it must
+    contain exactly the review's own gaps and recommendations and nothing more.
+
+    Compares the FULL SET of rendered items against the review's own content.
+    An earlier version enumerated expected prefixes ("1. ", "2. ") and so
+    missed an injected "0. " line -- a superset check that could not detect a
+    superset. Set equality is what actually closes that."""
+    review = Review(
+        mode="local",
+        reviewed_revision="abc",
+        findings=[_gap_finding("Only gap A")],
+        recommendations=[_recommendation("Only criterion A", "defect A")],
+        completion=CompletionResult(
+            verdict=CompletionVerdict.INCOMPLETE, rationale="1 gap.",
+        ),
+    )
+
+    instruction = render_next_instruction(review)
+
+    def numbered_items(section: str) -> set[str]:
+        """Every `<n>. <text>` item in a section, regardless of its number."""
+        return {
+            re.sub(r"\*\*", "", m.group(1)).strip()
+            for m in (re.match(r"^\d+\.\s+(.*)$", ln) for ln in section.splitlines())
+            if m
+        }
+
+    implement = instruction.split("## Implement")[1].split("## ")[0]
+    tests_section = instruction.split("## Add these tests")[1]
+
+    # EXACTLY the review's own content -- nothing invented, nothing dropped.
+    assert numbered_items(implement) == {"Only gap A"}
+    assert numbered_items(tests_section) == {"Only criterion A"}
+
+
+def test_instruction_omits_satisfied_obligations_and_advisory_items():
+    """Obligation 6: the instruction SELECTS. A review deliberately mixing an
+    actionable gap with a satisfied obligation, an advisory unrequested change
+    and an evidence limitation must surface only the gap."""
+    review = Review(
+        mode="local",
+        reviewed_revision="abc",
+        obligation_map=[
+            _obligation("A satisfied obligation", "addressed", "strongly_supported"),
+        ],
+        findings=[
+            _gap_finding("A real remaining gap"),
+            Finding(
+                type=UNREQUESTED_CHANGE, severity="medium",
+                description="An advisory unrequested change",
+                evidence_tier=EvidenceTier.STATIC, produced_by=Component.STATIC_ANALYZER,
+                links=[Link(kind="code", ref="x.py#@@ -1 +1 @@")],
+                disposition=UnrequestedChangeDisposition.SEPARABLE,
+            ),
+        ],
+        completion=CompletionResult(
+            verdict=CompletionVerdict.INCOMPLETE, rationale="1 gap.",
+            limitations=["An evidence limitation note"],
+        ),
+    )
+
+    instruction = render_next_instruction(review)
+
+    assert "A real remaining gap" in instruction
+    assert "A satisfied obligation" not in instruction
+    assert "An advisory unrequested change" not in instruction
+    assert "An evidence limitation note" not in instruction


### PR DESCRIPTION
## Summary
M7.3 — `render_next_instruction` writes `.acceptance/next-instruction.md` when a review has something to act on, closing the loop archetype #9 needs: a review that finds gaps now hands the coding agent an actionable next step instead of stopping at a findings report. The §16 report's pointer, which always read `(none)`, now names the file.

**Deliberately a thin projection.** Deterministic, no model call — every line traces to a coverage-gap finding, an M7.1 recommendation, or an unresolved open question. What it adds over the report is *selection and mood*: satisfied obligations, advisory unrequested changes and evidence limitations are dropped, because the audience is the agent deciding what to do, not the human deciding whether to accept.

Scope kept small per review: no new module (it sits beside `render_report`), no new data-model fields, no second definition of materiality (it keys off M7.2's verdict). Kept a *separate* function on purpose — M7.6's terminal colour must never reach a file on disk, and #143's reviewer-facing explanations would be noise in an agent handoff. The write is a CLI side effect, never part of `run_review`, so the benchmark scoring the same review over fixture repos cannot mutate them.

## Acting on the tool's own findings
The first `check` run rated three obligations weakly evidenced. All three were right, and each is now properly tested — every fix verified by injecting the specific defect it claims to catch:

- **Pipeline isolation** asserted in all three directions (pipeline writes nothing; CLI *does* write on gaps; CLI skips when there are none). My first version proved only "nothing writes" — which would have passed with the feature entirely disabled.
- **Projection completeness** compared as a **set**, so an invented *or* dropped item is caught. An earlier version enumerated `"1. "`/`"2. "` prefixes and missed an injected `0. ` line — a superset check that couldn't see a superset.
- **Selection** verified against a review deliberately mixing a real gap with a satisfied obligation, an advisory unrequested change, and an evidence limitation.

`.acceptance/next-instruction.md` is now gitignored — it's the checker's own per-run output, regenerated from the current review, not a source file.

## Merging at INCOMPLETE, deliberately
The final run still reports `INCOMPLETE` on one obligation (pipeline isolation, `unsupported`). **This is tool instability, not missing evidence** — and it is the most interesting result of the task:

| Run | Test contents | Mapped? | Rating |
|---|---|---|---|
| 3 | isolation + CLI-writes | yes | `partially_supported` |
| 4 | isolation + CLI-writes + **CLI-skips** | **no** | `unsupported` |

The test only *gained* coverage between runs, and each assertion is injection-verified. The mapper simply stopped associating it with the obligation. Discovery isn't the culprit — run 4 still cites that file's hunk as *code* evidence for the same obligation while dropping it as *test* evidence, which narrows it to M4.2.

Filed as **#150**, because a verdict that moves without the code moving isn't a defensible acceptance record, and because *strengthening a test appeared to worsen the rating* — which would push a developer toward reverting a real improvement.

## Follow-ups filed
- **#148** — design/approach obligations need a code-evident tier. Demanding test evidence for "use library X" can't work (a hand-rolled equivalent passes every behavioural test) and actively pushes toward tautological tests, the #138 pattern.
- **#149** — intermediate judgments are computed then discarded, so a wrong conclusion can't be traced to the stage that caused it. Surfaced when "why is this `partially_supported`?" proved unanswerable from the tool's own output.
- **#150** — mapping instability (above).

## Test plan
- [x] `pytest -q` — 446 passed
- [x] `ruff check src tests` — clean
- [x] Every new test verified to **discriminate** by injecting its specific defect (§8.2): pipeline writes; CLI never writes; CLI writes unconditionally; instruction invents content; instruction drops content; satisfied obligations leak in; gap-gating removed

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)
