### PR TITLE
Report the determinism controls actually in force, not the ones configured (#160)

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,26 +1,46 @@
 # Task
-Make the model harness genuinely provider-agnostic. Calls route through LiteLLM
-so the model can be swapped to compare quality and cost, but a run against a
-non-OpenAI model currently fails before it reaches the model, and the schema the
-harness sends hides its enum values behind a reference, which changes the
-answers the model gives. Have LiteLLM perform the per-provider translation,
-send schemas with their values inline, record which determinism controls the
-provider actually honoured, and hold the whole claim to recorded evidence
-rather than a hand-run experiment.
+Make a review's own provenance tell the truth about the determinism controls
+that were in force. The harness records which controls a provider actually
+honoured, but a review still reports the controls that were *configured*, so on
+a provider that discards them the review claims a reproducibility it does not
+have. Source provenance from the client that made the calls rather than from
+configuration, distinguish a control that held from one the provider ignored and
+from one nothing was ever observed about, and stop the store from keeping a
+transcript whose response failed validation.
 
 ## Constraints
-- A completion function injected by a caller must not pull in the provider stack, so capability tests keep running with no provider dependency.
-- The schema sent to the provider must also be the schema inside the hashed request, so a change to how schemas are rendered invalidates recordings instead of replaying judgments made under a different schema.
+- Building provenance must not pull in the provider stack, because provenance is
+  assembled during replay runs that have no provider dependency and no API key.
+- A control the provider discarded must never be reported as the value that was
+  requested.
 
 ## Scope exclusions
-- Carrying the provider-honoured determinism controls through into the review's own provenance is deferred to a follow-up; this change records them in the transcript only.
+- Rendering provenance in the human-readable report is presentation work owned
+  by M7.6; this change corrects the persisted review state and the benchmark's
+  determinism disclosure that reads it.
+- Sampling a provider repeatedly to quantify variance where controls were
+  discarded belongs to the benchmark harness (M-B0.4).
 
 ## Completion expectations
 - Implementation
-- A live call against a provider that rejects a configured determinism control still reaches the model instead of raising first.
-- The structured-output request is expressed through LiteLLM's own response-format interface, so LiteLLM translates it into each provider's native mechanism instead of the harness targeting one provider's API directly.
-- The schema sent to the provider carries its enum values inline, with no `$defs` or `$ref` indirection, because that indirection changes the model's answer.
-- Every recorded transcript states which determinism controls actually applied, and a control the provider discarded reads as not in force rather than as the value requested.
-- The recorded corpus holds transcripts from more than one provider, drawn from a declared set of approved models, so provider-agnosticism rests on recorded evidence like every other capability.
-- A requirement span locates its text exactly, so `source[start:end]` equals the span's own text even when a bullet wraps across lines.
-- The model the tool runs by default is pinned by a guard, so that swapping it becomes a deliberate and visible edit rather than a silent drift that invalidates the recorded corpus.
+- A review's provenance reports the determinism controls the provider actually
+  honoured, separately from the controls that were requested.
+- A control the provider discarded is reported as not in force rather than as
+  the requested value, so a run against a provider that rejects a seed does not
+  claim that seed.
+- A review whose run made no model call at all reports its determinism as
+  indeterminate rather than claiming the configured controls held.
+- Provenance is built from the client that issued the calls, so one builder
+  serves both the CLI pipeline and the benchmark hooks instead of two that can
+  disagree.
+- A replayed run reports the controls recorded in the transcripts it replayed,
+  so replaying a recording made against a provider that discarded a control does
+  not report that control as in force.
+- A transcript recorded from a response that fails schema validation is not left
+  in the store, so a recording session cannot poison the corpus with a response
+  the harness itself rejected.
+- The default model named by the test doubles is the model the tool actually
+  defaults to, so test support does not assert a default that is not real.
+- A run started from the command line carries the configured default seed, so
+  the fixed-seed half of the determinism strategy is in force on the path users
+  actually invoke, with an explicit way to opt out of seeding.

--- a/src/acceptance/benchmark/coverage.py
+++ b/src/acceptance/benchmark/coverage.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from acceptance.benchmark.case import BenchmarkCase
-from acceptance.benchmark.hooks import provenance_from, scored_copy
+from acceptance.benchmark.hooks import scored_copy
 from acceptance.change.diff import extract_change_set
 from acceptance.config import ScopeExpansionPolicy
 from acceptance.llm import ModelClient
@@ -51,6 +51,5 @@ def classify_case(
         reviewed_revision=case.inputs.head_revision,
         declaration_text=case.inputs.declaration_text,
         policy=policy,
-        provenance=provenance_from(client),
     )
     return scored_copy(case, review)

--- a/src/acceptance/benchmark/decomposition.py
+++ b/src/acceptance/benchmark/decomposition.py
@@ -11,7 +11,8 @@ resulting obligation_map, ready for score_case/score_case_set.
 from __future__ import annotations
 
 from acceptance.benchmark.case import BenchmarkCase
-from acceptance.benchmark.hooks import provenance_from, scored_copy
+from acceptance.benchmark.hooks import scored_copy
+from acceptance.config import provenance_for
 from acceptance.llm import ModelClient
 from acceptance.requirement.obligations import decompose
 from acceptance.requirement.task_file import parse_task_file
@@ -26,7 +27,9 @@ def decompose_case(case: BenchmarkCase, client: ModelClient) -> BenchmarkCase:
     review = Review(
         mode="local",
         reviewed_revision=case.inputs.head_revision,
-        provenance=provenance_from(client),
+        # Stamped after `decompose` has run, so the honoured controls it reports
+        # reflect calls that actually happened (#160).
+        provenance=provenance_for(client),
         obligation_map=result.obligations,
     )
     return scored_copy(case, review)

--- a/src/acceptance/benchmark/hooks.py
+++ b/src/acceptance/benchmark/hooks.py
@@ -3,26 +3,16 @@
 Every hook that wires a capability's output into `score_case` (M1.4's
 `decompose_case`, M3.3's `classify_case`, and the M4/M5 hooks still to come)
 follows the same shape: stamp a `ReviewProvenance` from the `ModelClient` that
-produced the output, build a `Review`, then copy it onto the case and attach
-its score. Factored out once decomposition.py and coverage.py built the same
-two steps identically.
+produced the output (`config.provenance_for`), build a `Review`, then copy it
+onto the case and attach its score. Factored out once decomposition.py and
+coverage.py built the same two steps identically.
 """
 
 from __future__ import annotations
 
 from acceptance.benchmark.case import BenchmarkCase
 from acceptance.benchmark.scoring import score_case
-from acceptance.llm import ModelClient
-from acceptance.review_state import Review, ReviewProvenance
-
-
-def provenance_from(client: ModelClient) -> ReviewProvenance:
-    return ReviewProvenance(
-        determinism_mode=client.mode.value,
-        model=client.model,
-        temperature=client.temperature,
-        seed=client.seed,
-    )
+from acceptance.review_state import Review
 
 
 def scored_copy(case: BenchmarkCase, review: Review) -> BenchmarkCase:

--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -21,7 +21,7 @@ import sys
 from pathlib import Path
 
 from acceptance.change.diff import extract_change_set, extract_working_tree_change_set
-from acceptance.config import DEFAULT_MODEL, RunConfig
+from acceptance.config import DEFAULT_MODEL, DEFAULT_SEED, RunConfig
 from acceptance.coverage.classify import ImplementationCoverage, classify_coverage
 from acceptance.coverage.disposition import DispositionedChange, classify_dispositions
 from acceptance.coverage.open_questions import apply_open_question_resolutions, resolve_open_questions
@@ -146,7 +146,6 @@ def run_check(
         reviewed_revision=reviewed_revision,
         declaration_text=declaration_text,
         policy=config.scope_expansion_policy,
-        provenance=config.provenance(),
     )
     # §10.1 step 12: when gaps exist, hand the agent a next instruction. The
     # file is a CLI side effect, not part of the pipeline — the benchmark runs
@@ -329,10 +328,30 @@ def _add_model_flags(parser: argparse.ArgumentParser, default_mode: str) -> None
         default=default_mode,
         help="record (live call on cache miss) or replay (transcripts only).",
     )
-    parser.add_argument("--seed", type=int, default=None, help="Model seed (determinism).")
+    # Defaulted to the configured seed, not to None. argparse always supplies a
+    # value and every command passes it straight into RunConfig, so a `None`
+    # default here silently overrode DEFAULT_SEED and left every CLI run
+    # unseeded — half the determinism strategy #154 wired up was dead on the
+    # only path users invoke (#160).
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=DEFAULT_SEED,
+        help=f"Model seed (determinism; default: {DEFAULT_SEED}).",
+    )
+    parser.add_argument(
+        "--no-seed",
+        action="store_true",
+        help="Send no seed, letting the provider sample freely (variance runs).",
+    )
     parser.add_argument(
         "--temperature", type=float, default=0.0, help="Model temperature (default: 0.0)."
     )
+
+
+def _seed_from(args: argparse.Namespace) -> int | None:
+    """`--no-seed` is the deliberate way to run unpinned; absence means pinned."""
+    return None if args.no_seed else args.seed
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -417,7 +436,7 @@ def main(argv: list[str] | None = None) -> int:
         config = RunConfig(
             model=args.model,
             mode=Mode(args.mode),
-            seed=args.seed,
+            seed=_seed_from(args),
             temperature=args.temperature,
         )
         try:
@@ -441,7 +460,7 @@ def main(argv: list[str] | None = None) -> int:
         config = RunConfig(
             model=args.model,
             mode=Mode(args.mode),
-            seed=args.seed,
+            seed=_seed_from(args),
             temperature=args.temperature,
         )
         try:
@@ -474,7 +493,7 @@ def main(argv: list[str] | None = None) -> int:
         config = RunConfig(
             model=args.model,
             mode=Mode(args.mode),
-            seed=args.seed,
+            seed=_seed_from(args),
             temperature=args.temperature,
         )
         try:

--- a/src/acceptance/config.py
+++ b/src/acceptance/config.py
@@ -22,7 +22,7 @@ from typing import Any, Callable
 from pydantic import BaseModel, ConfigDict, Field
 
 from acceptance.llm import DEFAULT_TRANSCRIPT_ROOT, Mode, ModelClient, TranscriptStore
-from acceptance.review_state import ReviewProvenance
+from acceptance.review_state import DeterminismControls, ReviewProvenance
 
 # LiteLLM model string. Provider-agnostic: swap freely via --model / RunConfig.
 DEFAULT_MODEL = "openai/gpt-5.4-mini"
@@ -63,7 +63,7 @@ class RunConfig(BaseModel):
     transcript_root: Path = Field(default=DEFAULT_TRANSCRIPT_ROOT)
     # A review-interpretation knob (consumed by the M3.5.3 separability
     # classifier), not a determinism control — so it deliberately does not
-    # feed build_client() or provenance(). If we later want it recorded for
+    # feed build_client() or provenance_for(). If we later want it recorded for
     # traceability, that is a deliberate addition to ReviewProvenance.
     scope_expansion_policy: ScopeExpansionPolicy = ScopeExpansionPolicy.STRICT
 
@@ -77,10 +77,27 @@ class RunConfig(BaseModel):
             completion_fn=completion_fn,
         )
 
-    def provenance(self) -> ReviewProvenance:
-        return ReviewProvenance(
-            determinism_mode=self.mode.value,
-            model=self.model,
-            temperature=self.temperature,
-            seed=self.seed,
-        )
+
+def provenance_for(client: ModelClient) -> ReviewProvenance:
+    """Stamp provenance from the client that issued the calls.
+
+    Sourced from the client, not from `RunConfig`, because only the client knows
+    which determinism controls the provider actually honoured — configuration
+    knows what was asked for, and on a provider that discards controls those are
+    different (#160). This is the single builder: the CLI pipeline and the
+    benchmark hooks previously each had their own, which could disagree.
+
+    No provider import: the client reads honoured controls off the transcripts
+    it recorded or replayed, so a replay run stays free of the provider stack.
+    """
+    in_force = client.controls_in_force
+    return ReviewProvenance(
+        determinism_mode=client.mode.value,
+        model=client.model,
+        controls_requested=DeterminismControls(
+            temperature=client.temperature, seed=client.seed
+        ),
+        controls_in_force=(
+            None if in_force is None else DeterminismControls(**in_force)
+        ),
+    )

--- a/src/acceptance/llm.py
+++ b/src/acceptance/llm.py
@@ -232,6 +232,11 @@ class ModelClient:
         self.temperature = temperature
         self.seed = seed
         self._completion_fn = completion_fn or _default_completion_fn
+        # One entry per completed call: the controls that call ran under, or
+        # None if nothing is known about them. Accumulated so a review's
+        # provenance can report the controls actually in force rather than the
+        # ones configured (#160) — see `controls_in_force`.
+        self._observed_controls: list[dict | None] = []
 
     def build_request(
         self, messages: list[dict], response_model: type[BaseModel]
@@ -276,11 +281,55 @@ class ModelClient:
                     "Recording makes live calls AND runs the assertions, so a prompt "
                     "that degrades quality fails rather than silently re-recording."
                 )
-            record = self._record_live_call(key, request)
+            record = self._persist_live_call(key, request, response_model)
 
+        # Observed on both paths: a replayed run's reproducibility is exactly
+        # that of the recording it replays, so a transcript recorded against a
+        # provider that discarded a control must not replay as pinned.
+        self._observed_controls.append(record.get("controls_applied"))
         return self._validate(record["response"], response_model)
 
-    def _record_live_call(self, key: str, request: dict) -> dict:
+    @property
+    def controls_in_force(self) -> dict[str, Any] | None:
+        """The determinism controls observed in force across this client's calls.
+
+        `None` means indeterminate: either no call was made, or no call reported
+        anything about its controls (a transcript recorded before this was
+        tracked). That is distinct from a control being *absent*, which is the
+        positive claim that the provider ignored it.
+
+        Otherwise a control counts as in force only if every call agrees on its
+        value. Disagreement, or a call that reported nothing, yields `None` for
+        that control: a run is only as pinned as its least-pinned call, and
+        overstating in the negative direction never claims reproducibility the
+        run does not have (§3.7).
+        """
+        if not any(observed is not None for observed in self._observed_controls):
+            return None
+        per_call = [observed or {} for observed in self._observed_controls]
+        in_force: dict[str, Any] = {}
+        for name in ("temperature", "seed"):
+            values = [call.get(name) for call in per_call]
+            in_force[name] = values[0] if all(v == values[0] for v in values) else None
+        return in_force
+
+    def _persist_live_call(
+        self, key: str, request: dict, response_model: type[BaseModel]
+    ) -> dict:
+        """Make the call, validate the reply, and only then keep the transcript.
+
+        Validating first matters because structured output is best-effort on some
+        providers: Anthropic omitted a required field in 2 of 4 probes of a real
+        response schema. Persisting before validating let one of those replies
+        into the corpus, where replay would serve it forever (#160). A response
+        the harness rejects is not evidence and must not be stored.
+        """
+        record = self._live_call(key, request)
+        self._validate(record["response"], response_model)
+        self.store.write(key, record)
+        return record
+
+    def _live_call(self, key: str, request: dict) -> dict:
         requested = {"temperature": request["temperature"]}
         if "seed" in request:
             requested["seed"] = request["seed"]
@@ -320,7 +369,6 @@ class ModelClient:
             # which have no provider to drop anything.
             "controls_applied": self._effective_controls(request["model"], requested),
         }
-        self.store.write(key, record)
         return record
 
     def _effective_controls(self, model: str, requested: dict) -> dict:

--- a/src/acceptance/pipeline.py
+++ b/src/acceptance/pipeline.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from acceptance.config import ScopeExpansionPolicy
+from acceptance.config import ScopeExpansionPolicy, provenance_for
 from acceptance.coverage.classify import CoverageStatus, ImplementationCoverage, classify_coverage
 from acceptance.coverage.declaration_comparison import (
     compare_declaration,
@@ -47,7 +47,6 @@ from acceptance.review_state import (
     Link,
     Obligation,
     Review,
-    ReviewProvenance,
     UnrequestedChangeDisposition,
 )
 from acceptance.verdict import derive_verdict
@@ -146,7 +145,6 @@ def run_review(
     reviewed_revision: str,
     declaration_text: str | None = None,
     policy: ScopeExpansionPolicy = ScopeExpansionPolicy.STRICT,
-    provenance: ReviewProvenance | None = None,
 ) -> Review:
     """Run the full static review pipeline and return the assembled Review."""
     parsed = parse_task_file(task_text)
@@ -199,7 +197,10 @@ def run_review(
     return Review(
         mode="local",
         reviewed_revision=reviewed_revision,
-        provenance=provenance,
+        # Stamped here, at the end, rather than accepted from the caller: only
+        # after the calls have run does the client know which determinism
+        # controls the provider honoured (#160).
+        provenance=provenance_for(client),
         obligation_map=obligations,
         open_questions=open_questions,
         change_set=change_set,

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -49,6 +49,7 @@ __all__ = [
     "TestRecommendation",
     "CompletionVerdict",
     "CompletionResult",
+    "DeterminismControls",
     "ReviewProvenance",
     "Review",
 ]
@@ -409,18 +410,61 @@ class CompletionResult(_Model):
     escalation_candidates: list[str] = Field(default_factory=list)
 
 
+class DeterminismControls(_Model):
+    """A seed/temperature pair.
+
+    `None` means the control is **not in force**. For requested controls that is
+    "we asked for nothing"; for honoured controls it is the stronger statement
+    that the provider ignored the control and ran at its own default. Both are
+    real: Anthropic rejects `seed` outright and `claude-sonnet-5` accepts only
+    `temperature=1`, so a run there honours neither control (#158).
+    """
+
+    temperature: float | None = None
+    seed: int | None = None
+
+
 class ReviewProvenance(_Model):
     """How a review was produced (§13.6 trustworthiness). Stored so a reader
     can tell what determinism controls were in force — a fixed-seed replay is
     reproducible in a way a live sampled run is not, and M-B0.4's variance
     disclosure reads this. Mode is stored as its string value, not the harness
     `Mode` enum, so the data model stays independent of the LLM harness.
+
+    Requested and honoured controls are separate fields because they diverge.
+    The harness sends determinism controls through LiteLLM with `drop_params`,
+    which lets a provider that rejects a control run anyway rather than failing
+    the review — so what we asked for is intent, and only `controls_in_force`
+    describes the run that actually happened (#160). Reporting a single set
+    would have provenance claim a seed the provider never received.
     """
 
     determinism_mode: Literal["record", "replay"]
     model: str
-    temperature: float
-    seed: int | None = None
+    controls_requested: DeterminismControls
+    # None until some model call is observed. A review can legitimately make no
+    # model call at all, and such a run must not inherit a claim that the
+    # configured controls held — see `determinism`.
+    controls_in_force: DeterminismControls | None = None
+
+    def determinism(self) -> Literal["pinned", "unpinned", "indeterminate"]:
+        """Whether this run is reproducible, derived rather than stored.
+
+        Derived for the same reason as `Review.evidence_tier_summary`: a stored
+        copy alongside the controls it summarizes is a second source of truth
+        that can drift. `indeterminate` is a real answer, not a fallback — with
+        no observed call there is no evidence either way, and the uncertainty is
+        first-class (§9.3).
+        """
+        if self.controls_in_force is None:
+            return "indeterminate"
+        requested = self.controls_requested
+        honoured = self.controls_in_force
+        for name in ("temperature", "seed"):
+            asked = getattr(requested, name)
+            if asked is not None and getattr(honoured, name) != asked:
+                return "unpinned"
+        return "pinned"
 
 
 class Review(_Model):

--- a/tests/benchmark/test_alignment.py
+++ b/tests/benchmark/test_alignment.py
@@ -18,6 +18,7 @@ from acceptance.benchmark.case import (
 from acceptance.benchmark.scoring import score_case
 from acceptance.evidence_tier import Component, EvidenceTier
 from acceptance.review_state import (
+    DeterminismControls,
     Finding,
     Link,
     Obligation,
@@ -99,7 +100,10 @@ def _case_with_reworded_reviewer_output() -> BenchmarkCase:
     )
     reviewer = Review(
         mode="local", reviewed_revision="def456",
-        provenance=ReviewProvenance(determinism_mode="replay", model="m", temperature=0.0),
+        provenance=ReviewProvenance(
+            determinism_mode="replay", model="m",
+            controls_requested=DeterminismControls(temperature=0.0),
+        ),
         obligation_map=[
             # Same criterion, different wording, AND its mapped test.
             _reviewer_obligation("Use monthly_price / days_in_month as the daily rate").model_copy(

--- a/tests/benchmark/test_labels.py
+++ b/tests/benchmark/test_labels.py
@@ -150,4 +150,8 @@ def test_full_loop_scores_the_noop_checker_as_all_miss(tmp_path):
     assert report.decomposition_accuracy == 0.0  # obligations labeled everywhere; none found
     assert report.mapping_accuracy == 0.0  # coverage edges labeled; none found
     assert report.evidence_agreement == 0.0
-    assert report.determinism_mode == "replay"
+    # The mode of the client that actually ran, not of the config that was
+    # requested: the injected no-op stub records. Provenance describing the run
+    # rather than the intent is the point of #160 — before it, a record-mode
+    # stub could produce a review that claimed "replay".
+    assert report.determinism_mode == "record"

--- a/tests/benchmark/test_scoring_report.py
+++ b/tests/benchmark/test_scoring_report.py
@@ -50,6 +50,7 @@ from acceptance.benchmark.case import (
 from acceptance.benchmark.scoring import score_case_set
 from acceptance.evidence_tier import Component, EvidenceTier
 from acceptance.review_state import (
+    DeterminismControls,
     Finding,
     Link,
     Obligation,
@@ -70,7 +71,9 @@ def _inputs() -> BenchmarkCaseInputs:
 
 def _provenance() -> ReviewProvenance:
     return ReviewProvenance(
-        determinism_mode="replay", model="anthropic/claude-sonnet-5", temperature=0.0
+        determinism_mode="replay",
+        model="anthropic/claude-sonnet-5",
+        controls_requested=DeterminismControls(temperature=0.0),
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,8 +61,20 @@ def stub_model(monkeypatch):
     that exercise plumbing (provenance, persistence, determinism, the §16
     shell) rather than model judgment must not issue live calls. Patching
     RunConfig.build_client keeps `main()`'s own argument parsing under test.
+
+    The stub stands in for the *network*, not for the configuration: it carries
+    the config's own model and determinism controls, so a CLI test can still
+    assert that a flag reaches the review's provenance (#160 sources provenance
+    from the client, so a stub that ignored the config would silently break that
+    link). Its mode is necessarily RECORD — see `client_dispatching`.
     """
     from acceptance.config import RunConfig
     from tests.support import client_finding_nothing
 
-    monkeypatch.setattr(RunConfig, "build_client", lambda self, completion_fn=None: client_finding_nothing())
+    monkeypatch.setattr(
+        RunConfig,
+        "build_client",
+        lambda self, completion_fn=None: client_finding_nothing(
+            model=self.model, temperature=self.temperature, seed=self.seed
+        ),
+    )

--- a/tests/support.py
+++ b/tests/support.py
@@ -16,10 +16,14 @@ import pathlib
 import tempfile
 from types import SimpleNamespace
 
+from acceptance.config import DEFAULT_MODEL
 from acceptance.llm import Mode, ModelClient, TranscriptStore
 from acceptance.review_state import Obligation, ObligationType
 
-_DEFAULT_MODEL = "anthropic/claude-sonnet-5"
+# Sourced from the tool's own default rather than restated, so a double never
+# stands in for a model the tool does not actually run. It had drifted to a
+# hardcoded Anthropic string while the real default was OpenAI.
+_DEFAULT_MODEL = DEFAULT_MODEL
 
 
 def _fake_response(content: str) -> SimpleNamespace:
@@ -56,9 +60,19 @@ def make_obligation(obligation_id: str, description: str, typ: ObligationType) -
     )
 
 
-def client_dispatching(responses_by_schema: dict, model: str = _DEFAULT_MODEL) -> ModelClient:
+def client_dispatching(
+    responses_by_schema: dict,
+    model: str = _DEFAULT_MODEL,
+    temperature: float = 0.0,
+    seed: int | None = None,
+) -> ModelClient:
     """A client for multi-call hooks: each call returns the response keyed by
-    its response schema's class name (e.g. `_Decomposition`, `_Coverage`)."""
+    its response schema's class name (e.g. `_Decomposition`, `_Coverage`).
+
+    Determinism controls are settable because a review's provenance now reports
+    the client that made the calls (#160): a double that hardcoded them would
+    make provenance describe the double instead of the run under test.
+    """
 
     def completion_fn(**kwargs):
         schema_name = kwargs["response_format"]["json_schema"]["name"]
@@ -66,8 +80,12 @@ def client_dispatching(responses_by_schema: dict, model: str = _DEFAULT_MODEL) -
 
     return ModelClient(
         model=model,
+        # RECORD, always: an injected completion_fn is only ever reached on the
+        # live path, so a REPLAY double would find an empty store and raise.
         mode=Mode.RECORD,
         store=TranscriptStore(tempfile.mkdtemp()),
+        temperature=temperature,
+        seed=seed,
         completion_fn=completion_fn,
     )
 
@@ -90,10 +108,16 @@ _EMPTY_BY_SCHEMA = {
 }
 
 
-def client_finding_nothing(model: str = _DEFAULT_MODEL) -> ModelClient:
+def client_finding_nothing(
+    model: str = _DEFAULT_MODEL,
+    temperature: float = 0.0,
+    seed: int | None = None,
+) -> ModelClient:
     """A client whose every pipeline call returns an empty result — the
     checker runs end to end and reports nothing found."""
-    return client_dispatching(_EMPTY_BY_SCHEMA, model=model)
+    return client_dispatching(
+        _EMPTY_BY_SCHEMA, model=model, temperature=temperature, seed=seed
+    )
 
 
 # --- Recorded prompt-quality corpus (#146) ---------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from acceptance.cli import main, run_check
-from acceptance.config import RunConfig
+from acceptance.config import DEFAULT_SEED, RunConfig
 from acceptance.review_store import ReviewStore
 from tests.support import client_finding_nothing
 
@@ -31,17 +31,43 @@ def test_check_json_emits_a_structured_review(git_repo, fixture_task_path, capsy
     assert review["completion"]["verdict"] == "unable_to_determine"
 
 
-def test_check_defaults_to_replay_mode_provenance(git_repo, fixture_task_path, capsys, stub_model):
+def test_a_default_cli_run_is_seeded(git_repo, fixture_task_path, capsys, stub_model):
+    """A plain `acceptance check` must carry the configured seed.
+
+    `--seed` defaulted to None and every command passed it straight into
+    RunConfig, so argparse silently overrode DEFAULT_SEED and no CLI run was
+    ever seeded — the fixed-seed half of the determinism strategy was dead on
+    the only path a user invokes. The previous version of this test asserted
+    `seed is None`, which locked the defect in (#160).
+    """
     exit_code = main(
         ["check", "--json", "--task", fixture_task_path, "--base", git_repo["base"], "--head", git_repo["head"]]
     )
 
     assert exit_code == 0
     review = json.loads(capsys.readouterr().out)
-    # Default mode is replay so the CLI never issues a live call unbidden.
-    assert review["provenance"]["determinism_mode"] == "replay"
-    assert review["provenance"]["temperature"] == 0.0
-    assert review["provenance"]["seed"] is None
+    assert review["provenance"]["controls_requested"] == {"temperature": 0.0, "seed": DEFAULT_SEED}
+    # What actually held. The stub has no provider to discard anything, so the
+    # two agree here; against a real provider they need not.
+    assert review["provenance"]["controls_in_force"] == {"temperature": 0.0, "seed": DEFAULT_SEED}
+
+
+def test_no_seed_is_the_deliberate_way_to_run_unpinned(git_repo, fixture_task_path, capsys, stub_model):
+    """Seeding by default must still leave a way out: M-B0.4 samples a provider
+    repeatedly to disclose variance, which a fixed seed would suppress."""
+    exit_code = main(
+        [
+            "check", "--json", "--task", fixture_task_path,
+            "--base", git_repo["base"], "--head", git_repo["head"], "--no-seed",
+        ]
+    )
+
+    assert exit_code == 0
+    provenance = json.loads(capsys.readouterr().out)["provenance"]
+    assert provenance["controls_requested"]["seed"] is None
+    # Nothing was asked for, so nothing was dropped: the run is honestly pinned
+    # on temperature and simply unseeded.
+    assert provenance["controls_in_force"]["seed"] is None
 
 
 def test_check_records_determinism_flags_in_provenance(git_repo, fixture_task_path, capsys, stub_model):
@@ -63,8 +89,8 @@ def test_check_records_determinism_flags_in_provenance(git_repo, fixture_task_pa
     assert provenance == {
         "determinism_mode": "record",
         "model": "openai/gpt-5",
-        "temperature": 0.4,
-        "seed": 7,
+        "controls_requested": {"temperature": 0.4, "seed": 7},
+        "controls_in_force": {"temperature": 0.4, "seed": 7},
     }
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 """RunConfig controls, incl. the M3.5.2 scope-expansion policy (DR-081)."""
 
-from acceptance.config import RunConfig, ScopeExpansionPolicy
+from acceptance.config import RunConfig, ScopeExpansionPolicy, provenance_for
 
 
 def test_scope_expansion_policy_defaults_to_strict():
@@ -25,8 +25,8 @@ def test_scope_expansion_policy_is_not_a_determinism_control():
     # M-B0.4 variance) — two configs differing only in policy are provenance-equal.
     strict = RunConfig(scope_expansion_policy=ScopeExpansionPolicy.STRICT)
     loose = RunConfig(scope_expansion_policy=ScopeExpansionPolicy.LOOSE)
-    assert strict.provenance() == loose.provenance()
-    assert "scope_expansion" not in strict.provenance().model_dump()
+    assert provenance_for(strict.build_client()) == provenance_for(loose.build_client())
+    assert "scope_expansion" not in provenance_for(strict.build_client()).model_dump()
 
 
 # --- determinism: the seed half of "fixed seed/temperature" (#154) ---
@@ -52,7 +52,7 @@ def test_the_default_seed_reaches_both_the_model_call_and_the_provenance():
     config = RunConfig()
 
     assert config.build_client().seed == DEFAULT_SEED
-    assert config.provenance().seed == DEFAULT_SEED
+    assert provenance_for(config.build_client()).controls_requested.seed == DEFAULT_SEED
 
 
 def test_the_seed_is_part_of_the_request_so_changing_it_invalidates_transcripts():
@@ -80,3 +80,92 @@ def test_the_default_model_is_pinned_so_changing_it_is_deliberate():
     """
     assert RunConfig().model == "openai/gpt-5.4-mini"
     assert RunConfig().build_client().model == "openai/gpt-5.4-mini"
+
+
+# --- provenance: what held, not what was asked for (#160) -------------------
+
+
+def _dropping_client(model: str = "anthropic/claude-sonnet-5"):
+    """A client whose provider discards every determinism control, as Anthropic
+    does: it rejects `seed` outright and takes only `temperature=1`."""
+    from tests.support import client_finding_nothing
+
+    client = client_finding_nothing(model=model, temperature=0.0, seed=0)
+    client._completion_fn.effective_controls = lambda model, **requested: {
+        name: None for name in requested
+    }
+    return client
+
+
+def test_provenance_reports_the_controls_the_provider_honoured():
+    """A review that ran against a provider which threw our seed away must not
+    report that seed as in force — that overstates its reproducibility (§13.6),
+    and M-B0.4's variance disclosure reads exactly this field."""
+    from acceptance.requirement.obligations import _Decomposition
+
+    client = _dropping_client()
+    client.complete([{"role": "user", "content": "decompose"}], _Decomposition)
+
+    provenance = provenance_for(client)
+
+    assert provenance.controls_requested.seed == 0
+    assert provenance.controls_in_force.seed is None
+    assert provenance.controls_in_force.temperature is None
+    assert provenance.determinism() == "unpinned"
+
+
+def test_provenance_of_a_run_that_made_no_model_call_is_indeterminate():
+    """Not "the configured controls held". With no call there is no evidence
+    either way, and an indeterminate answer is a valid result (§9.3)."""
+    provenance = provenance_for(RunConfig().build_client())
+
+    assert provenance.controls_in_force is None
+    assert provenance.determinism() == "indeterminate"
+
+
+def test_one_builder_serves_both_the_cli_pipeline_and_the_benchmark():
+    """The CLI and the benchmark each had their own provenance builder, so the
+    benchmark could disagree with the tool it measures about how a review was
+    produced. There is now one, and no config-sourced builder to drift back to."""
+    from acceptance.benchmark import decomposition
+
+    assert decomposition.provenance_for is provenance_for
+    assert not hasattr(RunConfig, "provenance")
+
+
+def test_the_benchmark_hooks_also_report_honoured_controls():
+    """The behavioural half of the above: a benchmark hook's review carries the
+    dropped controls, not the requested ones."""
+    from acceptance.benchmark.case import (
+        BenchmarkCase,
+        BenchmarkCaseInputs,
+        BenchmarkCaseSource,
+        GroundTruthLabels,
+        GroundTruthObligation,
+    )
+    from acceptance.benchmark.decomposition import decompose_case
+
+    case = BenchmarkCase(
+        case_id="provenance-probe",
+        source=BenchmarkCaseSource(kind="archetype", identifier="provenance-probe"),
+        inputs=BenchmarkCaseInputs(
+            repo=".", base_revision="HEAD", head_revision="HEAD", task_text="# Task\nDo a thing.\n"
+        ),
+        ground_truth=GroundTruthLabels(
+            obligations=[
+                GroundTruthObligation(
+                    id="do-a-thing",
+                    description="Do a thing",
+                    explicit=True,
+                    evidence_class="unsupported",
+                    evidence_rationale="Nothing exercises it.",
+                    candidate_tests=[],
+                )
+            ]
+        ),
+    )
+
+    scored = decompose_case(case, _dropping_client())
+
+    assert scored.reviewer_output.provenance.determinism() == "unpinned"
+    assert scored.reviewer_output.provenance.controls_in_force.seed is None

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -13,7 +13,7 @@ from types import SimpleNamespace
 
 from pydantic import BaseModel
 
-from acceptance.config import RunConfig
+from acceptance.config import RunConfig, provenance_for
 from acceptance.llm import Mode
 from acceptance.review_state import Component, EvidenceTier, Finding, Link, Review
 
@@ -61,7 +61,8 @@ def _produce_review(config: RunConfig, completion_fn) -> Review:
     return Review(
         mode="local",
         reviewed_revision="deadbeef",
-        provenance=config.provenance(),
+        # After the call, so the honoured controls it reports are observed.
+        provenance=provenance_for(client),
         findings=[finding],
     )
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -385,3 +385,120 @@ def test_a_transcript_records_which_determinism_controls_actually_applied(store)
     key = request_key(client.build_request(MESSAGES, Verdict))
     record = json.loads(store.path_for(key).read_text())
     assert record["controls_applied"] == {"temperature": 0.0, "seed": 0}
+
+
+def _dropping_completion_fn(content: str):
+    """A completion_fn standing in for a provider that discards our controls.
+
+    Anthropic is the real case: it rejects `seed` outright and `claude-sonnet-5`
+    accepts only `temperature=1`, so LiteLLM's `drop_params` sends neither.
+    """
+    fn = _recorder(content)
+    fn.effective_controls = lambda model, **requested: {
+        name: None for name in requested
+    }
+    return fn
+
+
+def test_a_client_reports_the_controls_the_provider_honoured(store):
+    """Provenance is only worth reading if it describes the run that happened.
+    A client asked for a seed the provider throws away must report the run as
+    unseeded rather than echoing the request back (#160)."""
+    client = ModelClient(
+        model="anthropic/claude-sonnet-5",
+        mode=Mode.RECORD,
+        store=store,
+        temperature=0.0,
+        seed=0,
+        completion_fn=_dropping_completion_fn('{"supported": true, "rationale": "ok"}'),
+    )
+
+    client.complete(MESSAGES, Verdict)
+
+    assert client.controls_in_force == {"temperature": None, "seed": None}
+
+
+def test_a_client_that_made_no_call_reports_nothing_in_force(store):
+    """Indeterminate, not "the configured controls held". A review can make no
+    model call at all, and such a run has no evidence either way (§9.3)."""
+    client = ModelClient(
+        model="openai/gpt-5.4-mini", mode=Mode.RECORD, store=store, temperature=0.0, seed=0
+    )
+
+    assert client.controls_in_force is None
+
+
+def test_a_replayed_run_reports_the_controls_its_transcript_recorded(store):
+    """A replay is exactly as reproducible as the recording it replays. Replaying
+    a transcript recorded against a provider that discarded a control must not
+    report that control as in force."""
+    recorder = ModelClient(
+        model="anthropic/claude-sonnet-5",
+        mode=Mode.RECORD,
+        store=store,
+        temperature=0.0,
+        seed=0,
+        completion_fn=_dropping_completion_fn('{"supported": true, "rationale": "ok"}'),
+    )
+    recorder.complete(MESSAGES, Verdict)
+
+    replayer = ModelClient(
+        model="anthropic/claude-sonnet-5",
+        mode=Mode.REPLAY,
+        store=store,
+        temperature=0.0,
+        seed=0,
+        completion_fn=_exploding_completion_fn,
+    )
+    replayer.complete(MESSAGES, Verdict)
+
+    assert replayer.controls_in_force == {"temperature": None, "seed": None}
+
+
+def test_a_run_is_only_as_pinned_as_its_least_pinned_call(store):
+    """A review makes many calls. If one ran unpinned the run is unpinned, so
+    disagreement collapses to "not in force" — overstating in the negative
+    direction never claims reproducibility the run lacks (§3.7)."""
+    completion_fn = _recorder('{"supported": true, "rationale": "ok"}')
+    # Honoured on the first call, dropped on the second.
+    honoured = [True, False]
+    completion_fn.effective_controls = lambda model, **requested: (
+        dict(requested) if honoured.pop(0) else {name: None for name in requested}
+    )
+    client = ModelClient(
+        model="openai/gpt-5.4-mini",
+        mode=Mode.RECORD,
+        store=store,
+        temperature=0.0,
+        seed=0,
+        completion_fn=completion_fn,
+    )
+
+    client.complete(MESSAGES, Verdict)
+    assert client.controls_in_force == {"temperature": 0.0, "seed": 0}
+
+    client.complete([{"role": "user", "content": "another question"}], Verdict)
+
+    assert client.controls_in_force == {"temperature": None, "seed": None}
+
+
+def test_a_response_that_fails_validation_is_not_left_in_the_store(store):
+    """Structured output is best-effort on some providers — Anthropic omitted a
+    required field in 2 of 4 probes of a real schema. Persisting before
+    validating let such a reply into the corpus, where replay would serve it
+    forever. A response the harness rejects is not evidence (#160)."""
+    client = ModelClient(
+        model="anthropic/claude-sonnet-5",
+        mode=Mode.RECORD,
+        store=store,
+        # `rationale` is required and missing — exactly the observed failure.
+        completion_fn=_recorder('{"supported": true}'),
+    )
+
+    with pytest.raises(SchemaValidationError):
+        client.complete(MESSAGES, Verdict)
+
+    key = request_key(client.build_request(MESSAGES, Verdict))
+    assert not store.path_for(key).exists()
+    # And it contributes no observation: a call that failed is not a data point.
+    assert client.controls_in_force is None

--- a/tests/test_review_state.py
+++ b/tests/test_review_state.py
@@ -7,6 +7,7 @@ from acceptance.review_state import (
     BuilderDeclaration,
     ChangeSet,
     Component,
+    DeterminismControls,
     DiffHunk,
     EvidenceTier,
     ExecutionEvidence,
@@ -18,6 +19,7 @@ from acceptance.review_state import (
     ObligationType,
     Project,
     Review,
+    ReviewProvenance,
     TaskSource,
     TestEvidence,
     TextSpan,
@@ -369,3 +371,60 @@ def test_review_evidence_tier_summary_is_derived_not_stored():
 
     assert review.evidence_tier_summary() == {"COVERAGE_CONFIRMED": 1, "STATIC": 1}
     assert "evidence_tiers" not in review.to_dict()
+
+
+# --- determinism verdict derived from provenance (#160) ----------------------
+
+
+def _provenance(requested: dict, in_force: dict | None) -> ReviewProvenance:
+    return ReviewProvenance(
+        determinism_mode="record",
+        model="anthropic/claude-sonnet-5",
+        controls_requested=DeterminismControls(**requested),
+        controls_in_force=None if in_force is None else DeterminismControls(**in_force),
+    )
+
+
+def test_a_run_whose_controls_all_held_is_pinned():
+    provenance = _provenance({"temperature": 0.0, "seed": 0}, {"temperature": 0.0, "seed": 0})
+
+    assert provenance.determinism() == "pinned"
+
+
+def test_a_run_whose_provider_dropped_a_control_is_unpinned():
+    """The Anthropic case: `seed` is rejected outright, so the run is not
+    reproducible however it was configured."""
+    provenance = _provenance({"temperature": 0.0, "seed": 0}, {"temperature": 0.0, "seed": None})
+
+    assert provenance.determinism() == "unpinned"
+
+
+def test_a_control_honoured_at_a_different_value_is_unpinned():
+    """`claude-sonnet-5` accepts only `temperature=1`. Asking for 0.0 and getting
+    1 is not a dropped control but it is not the requested run either."""
+    provenance = _provenance({"temperature": 0.0, "seed": None}, {"temperature": 1.0, "seed": None})
+
+    assert provenance.determinism() == "unpinned"
+
+
+def test_asking_for_nothing_and_getting_nothing_is_pinned():
+    """`--no-seed` is a deliberate choice, not a broken promise: nothing was
+    requested, so nothing was dropped."""
+    provenance = _provenance({"temperature": 0.0, "seed": None}, {"temperature": 0.0, "seed": None})
+
+    assert provenance.determinism() == "pinned"
+
+
+def test_a_run_with_nothing_observed_is_indeterminate():
+    provenance = _provenance({"temperature": 0.0, "seed": 0}, None)
+
+    assert provenance.determinism() == "indeterminate"
+
+
+def test_the_determinism_verdict_is_derived_rather_than_stored():
+    """A stored copy alongside the controls it summarizes is a second source of
+    truth that can drift — same rule as `evidence_tier_summary`."""
+    provenance = _provenance({"temperature": 0.0, "seed": 0}, {"temperature": 0.0, "seed": 0})
+
+    assert "determinism" not in provenance.to_dict()
+    assert "pinned" not in json.dumps(provenance.to_dict())


### PR DESCRIPTION
Closes #160.

## What was wrong

`ReviewProvenance` reported the determinism controls that were **configured**.
Since #158 the harness sends them through LiteLLM with `drop_params`, so a
provider that rejects a control runs anyway rather than failing the review — and
on Anthropic (rejects `seed` outright, `claude-sonnet-5` takes only
`temperature=1`) a review claimed a reproducibility it did not have. §13.6 makes
provenance the thing a reader consults to decide how much to trust a review, and
`scoring.py::_case_determinism_mode` reads it for M-B0.4's variance disclosure.

Two structural facts shaped the fix:

1. **There were two provenance builders**, both configuration-sourced —
   `RunConfig.provenance()` (CLI, built *before* any call happened) and
   `provenance_from(client)` (benchmark hooks). They could disagree about how a
   review was produced.
2. **`temperature` was a non-optional `float`**, so the schema could not express
   "the provider ignored temperature and ran at its own default" — the exact
   Anthropic case. This was not only plumbing; the data model lacked the
   vocabulary.

## What changed

- **`ReviewProvenance` carries `controls_requested` and `controls_in_force`** as
  separate `DeterminismControls` pairs, plus a derived
  `determinism() -> pinned | unpinned | indeterminate`. Derived, not stored, for
  the same reason as `evidence_tier_summary`: a stored summary beside the data it
  summarizes is a second source of truth that can drift.
- **`indeterminate` when no model call was observed.** A review can legitimately
  make no call, and such a run must not inherit a claim that the configured
  controls held. Uncertainty is first-class (§9.3).
- **`ModelClient` accumulates the controls each call ran under** — on the record
  path *and* the replay path. A replay is exactly as reproducible as the
  recording it replays, so replaying a transcript recorded against a dropping
  provider must not report the control as in force. A run is only as pinned as
  its least-pinned call; disagreement collapses to "not in force", which
  overstates in the safe direction (§3.7).
- **One builder, `config.provenance_for(client)`**, sourced from the client that
  issued the calls and stamped at the *end* of `run_review` — only then are the
  honoured controls known. No provider import: the client reads them off the
  transcripts it recorded or replayed, so `test_harness_does_not_import_the_provider_stack`
  still holds.
- **A response that fails schema validation is no longer persisted.** Anthropic
  omitted a required field in 2 of 4 probes of a real schema, and one such reply
  reached the corpus this way during #158.

## Two defects found while wiring it up

**`--seed` was dead on the CLI.** It defaulted to `None` and all three commands
passed `seed=args.seed` straight into `RunConfig`, so argparse silently overrode
`DEFAULT_SEED` and **no CLI run was ever seeded** — the fixed-seed half of the
determinism strategy #154 wired up did not reach the only path a user invokes.
`--no-seed` is now the deliberate way to run unpinned (M-B0.4 needs it for
variance sampling). The previous CLI test asserted `seed is None`, which locked
the defect in; it is now `test_a_default_cli_run_is_seeded`.

**The `stub_model` fixture stood in for the configuration, not just the network.**
It fabricated a client unrelated to the config, so once provenance became
client-sourced the CLI's flag-plumbing guarantee silently detached. It now
carries the config's own model and controls. Its mode is necessarily RECORD — an
injected `completion_fn` is only reachable on the live path — which is why
`test_labels.py` now expects `determinism_mode == "record"`: the mode of the
client that actually ran, not of the config that was requested. Before this
change a record-mode stub could produce a review claiming "replay", which is the
same class of lie as the seed.

Also fixed the `tests/support.py` default-model drift flagged in #159 review: the
doubles named `anthropic/claude-sonnet-5` while the real default was
`openai/gpt-5.4-mini`. It now sources `config.DEFAULT_MODEL`.

## Verification

- 494 tests pass (478 on `main`); `ruff check` clean.
- **Defect injection, after committing** so `git checkout HEAD --` is an exact
  undo. Seven injections, each red then restored:
  | injected defect | test that caught it |
  |---|---|
  | provenance echoes requested controls | `test_provenance_reports_the_controls_the_provider_honoured` |
  | skip observation on the replay path | `test_a_replayed_run_reports_the_controls_its_transcript_recorded` |
  | persist before validating | `test_a_response_that_fails_validation_is_not_left_in_the_store` |
  | `--seed` default back to `None` | `test_a_default_cli_run_is_seeded` |
  | reduction takes the first value | `test_a_run_is_only_as_pinned_as_its_least_pinned_call` |
  | `determinism()` never indeterminate | `test_a_run_with_nothing_observed_is_indeterminate` |
  | default model drifts | `test_the_default_model_is_pinned_so_changing_it_is_deliberate` |
- **The change is visible in the review this PR's own dogfood run wrote:**
  ```json
  {
    "controls_in_force": {"seed": 0, "temperature": 0.0},
    "controls_requested": {"seed": 0, "temperature": 0.0},
    "determinism_mode": "record",
    "model": "openai/gpt-5.4-mini"
  }
  ```
  `determinism()` -> `pinned`. Those in-force values came from LiteLLM's real
  reporter, not a stub — the run made live calls.

## Out of scope (stated in the task file)

- Rendering provenance in the human-readable report: presentation work owned by
  M7.6. Today the §16 report does not display provenance at all; the consumers
  are the persisted review state and the benchmark's determinism disclosure.
- Repeated sampling to quantify variance where controls were discarded: M-B0.4.

## Dogfood run

`acceptance check --task current-task.md --base main --mode record`

```
Task completion: NO-MATERIAL-GAPS

Every obligation is addressed and strongly supported by discriminating tests.

Obligations:

  1. A review's provenance reports the determinism controls the provider actually honoured, separately from the controls that were requested.
       code evidence: addressed
         1.1  src/acceptance/config.py#@@ -22,7 +22,7 @@ from typing import Any, Callable
         1.2  src/acceptance/config.py#@@ -77,10 +77,27 @@ class RunConfig(BaseModel):
         1.3  src/acceptance/llm.py#@@ -232,6 +232,11 @@ class ModelClient:
         1.4  src/acceptance/llm.py#@@ -276,11 +281,55 @@ class ModelClient:
         1.5  src/acceptance/review_state.py#@@ -409,18 +410,61 @@ class CompletionResult(_Model):
         1.6  src/acceptance/pipeline.py#@@ -199,7 +197,10 @@ def run_review(
         1.7  src/acceptance/benchmark/decomposition.py#@@ -26,7 +27,9 @@ def decompose_case(case: BenchmarkCase, client: ModelClient) -> BenchmarkCase:
         1.8  src/acceptance/benchmark/coverage.py#@@ -51,6 +51,5 @@ def classify_case(
       test evidence: strongly supported  [tier: static]
         1.9  tests/test_cli.py::test_check_records_determinism_flags_in_provenance
         1.10  tests/test_config.py::test_provenance_reports_the_controls_the_provider_honoured
         1.11  tests/test_config.py::test_the_benchmark_hooks_also_report_honoured_controls
         1.12  tests/test_config.py::test_the_default_seed_reaches_both_the_model_call_and_the_provenance
         1.13  tests/test_llm.py::test_a_client_reports_the_controls_the_provider_honoured
         1.14  tests/test_llm.py::test_a_transcript_records_which_determinism_controls_actually_applied
         1.15  tests/test_review_state.py::test_a_control_honoured_at_a_different_value_is_unpinned
         1.16  tests/test_review_state.py::test_a_run_whose_controls_all_held_is_pinned
         1.17  tests/test_review_state.py::test_the_determinism_verdict_is_derived_rather_than_stored

  2. A control the provider discarded is reported as not in force rather than as the requested value.
       code evidence: addressed
         2.1  src/acceptance/config.py#@@ -77,10 +77,27 @@ class RunConfig(BaseModel):
         2.2  src/acceptance/llm.py#@@ -276,11 +281,55 @@ class ModelClient:
         2.3  src/acceptance/review_state.py#@@ -409,18 +410,61 @@ class CompletionResult(_Model):
         2.4  tests/test_review_state.py#@@ -7,6 +7,7 @@ from acceptance.review_state import (
       test evidence: strongly supported  [tier: static]
         2.5  tests/test_config.py::test_provenance_reports_the_controls_the_provider_honoured
         2.6  tests/test_config.py::test_the_benchmark_hooks_also_report_honoured_controls
         2.7  tests/test_llm.py::test_a_client_reports_the_controls_the_provider_honoured
         2.8  tests/test_llm.py::test_a_replayed_run_reports_the_controls_its_transcript_recorded
         2.9  tests/test_llm.py::test_controls_a_provider_discards_are_recorded_as_absent_not_as_requested
         2.10  tests/test_review_state.py::test_a_run_whose_provider_dropped_a_control_is_unpinned

  3. A review whose run made no model call at all reports its determinism as indeterminate.
       code evidence: addressed
         3.1  src/acceptance/llm.py#@@ -232,6 +232,11 @@ class ModelClient:
         3.2  src/acceptance/llm.py#@@ -276,11 +281,55 @@ class ModelClient:
         3.3  src/acceptance/review_state.py#@@ -409,18 +410,61 @@ class CompletionResult(_Model):
       test evidence: strongly supported  [tier: static]
         3.4  tests/test_config.py::test_provenance_of_a_run_that_made_no_model_call_is_indeterminate
         3.5  tests/test_llm.py::test_a_client_that_made_no_call_reports_nothing_in_force
         3.6  tests/test_review_state.py::test_a_run_with_nothing_observed_is_indeterminate

  4. Provenance is built from the client that issued the calls, so one builder serves both the CLI pipeline and the benchmark hooks.
       code evidence: addressed
         4.1  src/acceptance/config.py#@@ -77,10 +77,27 @@ class RunConfig(BaseModel):
         4.2  src/acceptance/pipeline.py#@@ -199,7 +197,10 @@ def run_review(
         4.3  src/acceptance/benchmark/decomposition.py#@@ -26,7 +27,9 @@ def decompose_case(case: BenchmarkCase, client: ModelClient) -> BenchmarkCase:
         4.4  src/acceptance/benchmark/coverage.py#@@ -51,6 +51,5 @@ def classify_case(
         4.5  src/acceptance/benchmark/hooks.py#@@ -3,26 +3,16 @@
       test evidence: strongly supported  [tier: static]
         4.6  tests/benchmark/test_coverage.py::test_cli_and_benchmark_share_one_pipeline
         4.7  tests/test_config.py::test_one_builder_serves_both_the_cli_pipeline_and_the_benchmark
         4.8  tests/test_config.py::test_the_benchmark_hooks_also_report_honoured_controls

  5. A replayed run reports the controls recorded in the transcripts it replayed.
       code evidence: addressed
         5.1  src/acceptance/llm.py#@@ -276,11 +281,55 @@ class ModelClient:
         5.2  src/acceptance/llm.py#@@ -320,7 +369,6 @@ class ModelClient:
       test evidence: strongly supported  [tier: static]
         5.3  tests/test_determinism.py::test_replay_reproduces_a_recorded_run_with_no_live_call
         5.4  tests/test_llm.py::test_a_replayed_run_reports_the_controls_its_transcript_recorded
         5.5  tests/test_llm.py::test_recorded_transcript_replays_with_zero_live_calls

  6. A transcript recorded from a response that fails schema validation is not left in the store.
       code evidence: addressed
         6.1  src/acceptance/llm.py#@@ -276,11 +281,55 @@ class ModelClient:
         6.2  src/acceptance/llm.py#@@ -320,7 +369,6 @@ class ModelClient:
       test evidence: strongly supported  [tier: static]
         6.3  tests/test_llm.py::test_a_response_that_fails_validation_is_not_left_in_the_store
         6.4  tests/test_llm.py::test_malformed_json_is_rejected_with_a_typed_error
         6.5  tests/test_llm.py::test_non_text_content_is_rejected_with_a_typed_error
         6.6  tests/test_llm.py::test_schema_violating_response_is_rejected_with_a_typed_error

  7. The default model named by the test doubles is the model the tool actually defaults to.
       code evidence: addressed
         7.1  tests/support.py#@@ -16,10 +16,14 @@ import pathlib
       test evidence: strongly supported  [tier: static]
         7.2  tests/test_config.py::test_the_default_model_is_pinned_so_changing_it_is_deliberate

  8. A run started from the command line carries the configured default seed, with an explicit way to opt out of seeding.
       code evidence: addressed
         8.1  src/acceptance/cli.py#@@ -146,7 +146,6 @@ def run_check(
         8.2  src/acceptance/cli.py#@@ -329,12 +328,32 @@ def _add_model_flags(parser: argparse.ArgumentParser, default_mode: str) -> None
         8.3  src/acceptance/cli.py#@@ -417,7 +436,7 @@ def main(argv: list[str] | None = None) -> int:
         8.4  src/acceptance/cli.py#@@ -441,7 +460,7 @@ def main(argv: list[str] | None = None) -> int:
         8.5  src/acceptance/cli.py#@@ -474,7 +493,7 @@ def main(argv: list[str] | None = None) -> int:
         8.6  tests/test_cli.py#@@ -31,17 +31,43 @@ def test_check_json_emits_a_structured_review(git_repo, fixture_task_path, capsy
       test evidence: strongly supported  [tier: static]
         8.7  tests/test_cli.py::test_a_default_cli_run_is_seeded
         8.8  tests/test_cli.py::test_check_records_determinism_flags_in_provenance
         8.9  tests/test_cli.py::test_no_seed_is_the_deliberate_way_to_run_unpinned
         8.10  tests/test_config.py::test_a_seed_is_fixed_by_default
         8.11  tests/test_config.py::test_the_default_seed_reaches_both_the_model_call_and_the_provenance
         8.12  tests/test_config.py::test_the_seed_is_part_of_the_request_so_changing_it_invalidates_transcripts
         8.13  tests/test_review_state.py::test_asking_for_nothing_and_getting_nothing_is_pinned

Unrequested changes:
  1. [in_service] The CLI now defaults `--seed` to `DEFAULT_SEED` and adds `--no-seed`, changing command-line behavior beyond the provenance/reporting obligations. The task required the CLI run to carry the configured default seed with an explicit opt-out, but did not require changing the parser default/help text or introducing a new flag name/semantics.
       src/acceptance/cli.py#@@ -329,12 +328,32 @@ def _add_model_flags(parser: argparse.ArgumentParser, default_mode: str) -> None
       src/acceptance/cli.py#@@ -417,7 +436,7 @@ def main(argv: list[str] | None = None) -> int:
       src/acceptance/cli.py#@@ -441,7 +460,7 @@ def main(argv: list[str] | None = None) -> int:
       src/acceptance/cli.py#@@ -474,7 +493,7 @@ def main(argv: list[str] | None = None) -> int:
       tests/test_cli.py#@@ -31,17 +31,43 @@ def test_check_json_emits_a_structured_review(git_repo, fixture_task_path, capsy
  2. [in_service] `RunConfig.provenance()` was removed and replaced by a free function `provenance_for(client)`, changing the public API used by callers. The obligations require provenance to be built from the client and shared across CLI/benchmark paths, but they do not require removing the existing method or changing its signature/name.
       src/acceptance/config.py#@@ -77,10 +77,27 @@ class RunConfig(BaseModel):
       src/acceptance/pipeline.py#@@ -146,7 +145,6 @@ def run_review(
       src/acceptance/benchmark/coverage.py#@@ -24,7 +24,7 @@ from __future__ import annotations
       src/acceptance/benchmark/decomposition.py#@@ -11,7 +11,8 @@ resulting obligation_map, ready for score_case/score_case_set.
       src/acceptance/benchmark/hooks.py#@@ -3,26 +3,16 @@
       tests/test_config.py#@@ -25,8 +25,8 @@ def test_scope_expansion_policy_is_not_a_determinism_control():
       tests/test_config.py#@@ -52,7 +52,7 @@ def test_the_default_seed_reaches_both_the_model_call_and_the_provenance():
       tests/test_determinism.py#@@ -13,7 +13,7 @@ from types import SimpleNamespace
       tests/test_determinism.py#@@ -61,7 +61,8 @@ def _produce_review(config: RunConfig, completion_fn) -> Review:
  3. [in_service] `ModelClient` now tracks `_observed_controls`, exposes `controls_in_force`, and changes persistence to validate before writing transcripts. The obligations do require invalid transcripts not be stored and provenance to reflect honored controls, but the specific internal observation-tracking API and the new persistence helper are implementation choices not explicitly requested.
       src/acceptance/llm.py#@@ -232,6 +232,11 @@ class ModelClient:
       src/acceptance/llm.py#@@ -276,11 +281,55 @@ class ModelClient:
       src/acceptance/llm.py#@@ -320,7 +369,6 @@ class ModelClient:
       tests/test_llm.py#@@ -385,3 +385,120 @@ def test_a_transcript_records_which_determinism_controls_actually_applied(store)
  4. [in_service] `ReviewProvenance` changed shape from `temperature`/`seed` fields to nested `controls_requested`/`controls_in_force` plus a new `determinism()` method. The obligations require provenance to distinguish requested vs honored controls and to report indeterminate when no model call occurs, but they do not require this exact schema change or the new method to be part of the public model.
       src/acceptance/review_state.py#@@ -49,6 +49,7 @@ __all__ = [
       src/acceptance/review_state.py#@@ -409,18 +410,61 @@ class CompletionResult(_Model):
       tests/benchmark/test_alignment.py#@@ -18,6 +18,7 @@ from acceptance.benchmark.case import (
       tests/benchmark/test_alignment.py#@@ -99,7 +100,10 @@ def _case_with_reworded_reviewer_output() -> BenchmarkCase:
       tests/benchmark/test_scoring_report.py#@@ -50,6 +50,7 @@ from acceptance.benchmark.case import (
       tests/benchmark/test_scoring_report.py#@@ -70,7 +71,9 @@ def _inputs() -> BenchmarkCaseInputs:
       tests/test_cli.py#@@ -31,17 +31,43 @@ def test_check_json_emits_a_structured_review(git_repo, fixture_task_path, capsy
       tests/test_cli.py#@@ -63,8 +89,8 @@ def test_check_records_determinism_flags_in_provenance(git_repo, fixture_task_pa
       tests/test_review_state.py#@@ -7,6 +7,7 @@ from acceptance.review_state import (
       tests/test_review_state.py#@@ -18,6 +19,7 @@ from acceptance.review_state import (
       tests/test_review_state.py#@@ -369,3 +371,60 @@ def test_review_evidence_tier_summary_is_derived_not_stored():
  5. [in_service] The test doubles in `tests/support.py` were changed to source the tool's default model and to accept/pass through temperature and seed. The compatibility obligation asks that the test-double default model match the real default, but it does not require broadening these helpers' signatures or behavior beyond that alignment.
       tests/support.py#@@ -16,10 +16,14 @@ import pathlib
       tests/support.py#@@ -56,9 +60,19 @@ def make_obligation(obligation_id: str, description: str, typ: ObligationType) -
       tests/support.py#@@ -66,8 +80,12 @@ def client_dispatching(responses_by_schema: dict, model: str = _DEFAULT_MODEL) -
       tests/support.py#@@ -90,10 +108,16 @@ _EMPTY_BY_SCHEMA = {
       tests/conftest.py#@@ -61,8 +61,20 @@ def stub_model(monkeypatch):

Open questions:
  1. [resolved] When a response fails schema validation, should the entire recording session be rolled back, or should only the invalid transcript be omitted while other valid transcripts from the same session remain stored?
       The diff changes live-call persistence to validate before writing the transcript, and the new test asserts that a schema-validation failure leaves no file in the store. That makes the behavior clear: invalid transcripts are omitted rather than partially stored, so there is no session rollback mechanism shown or needed in the diff.
  2. [resolved] What is the actual default model value that the test doubles should match?
       The test doubles now import and reuse `acceptance.config.DEFAULT_MODEL` instead of a hardcoded Anthropic string, and the config file still defines `DEFAULT_MODEL = "openai/gpt-5.4-mini"`. The diff therefore makes the source of truth explicit and shows the default model value the doubles should match.
  3. [resolved] What is the explicit command-line mechanism for opting out of the configured default seed?
       The CLI adds an explicit `--no-seed` flag and a `_seed_from` helper that returns `None` when it is set; the help text and tests state this is the deliberate way to run unpinned. That unambiguously answers the opt-out mechanism.

Evidence limitations:
  1. No material gaps found at the achievable evidence tier — not proof of correctness. The full application was not independently executed (§3.7).

Recommended next instruction: (none)

```

All 8 obligations addressed and strongly supported; 5 unrequested changes, all
`[in_service]`; 3 open questions, all resolved by the diff; no recommended tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
