### PR TITLE
Partition the mapping call by tests so it stops shedding work (#164)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,11 @@ cases:
 | **Implementation detail** deliberately left to the coding agent | **No action.** It is a correct observation about a decision that is yours to make; silencing it would be dishonest. |
 | **Wrong question** — answerable from the task file plus the repo | **Stop and tell the human. Do not proceed.** State why it is answerable, and whether you believe the cause is already accounted for in the backlog (e.g. a known decomposition or mapping defect). Never fix it silently, never work around it. |
 
+**Tie-break on rewriting:** rewrite when the tool's response makes you regret
+your wording; otherwise leave it. This is independent of whether to escalate — a
+question can be both worth rewording and worth reporting. Report it either way;
+the rewrite is not the report.
+
 **4. Record in `session-state.md`** that Gate 1 passed, at which SHA, and who
 confirmed the decomposition. That confirmation is a human judgement — unwritten,
 the next session either repeats it or assumes it.
@@ -231,8 +236,11 @@ continuously, reset at the cheap moments.**
 1. `session-state.md` — rolling state of the task in flight.
 2. `current-task.md` — the task itself.
 3. `git log --oneline -10` and `git status`.
-4. `.acceptance/next-instruction.md` if it exists — the checker writes it when a
-   review has gaps, so it is the tool's own account of what to do next.
+
+Do **not** read `.acceptance/next-instruction.md` at startup. It is a single
+fixed path overwritten by whichever `check` run last found gaps, keyed to no task
+and no SHA, and never cleaned up — so it routinely describes a different task on
+a different branch. #167 (M7.3.r1) replaces it with on-demand retrieval.
 
 Then start work. Do **not** "get oriented" by reading the source tree; the
 `src/acceptance/` map above exists so you don't have to.

--- a/current-task.md
+++ b/current-task.md
@@ -1,46 +1,53 @@
 # Task
-Make a review's own provenance tell the truth about the determinism controls
-that were in force. The harness records which controls a provider actually
-honoured, but a review still reports the controls that were *configured*, so on
-a provider that discards them the review claims a reproducibility it does not
-have. Source provenance from the client that made the calls rather than from
-configuration, distinguish a control that held from one the provider ignored and
-from one nothing was ever observed about, and stop the store from keeping a
-transcript whose response failed validation.
+Stop the mapping stage from silently shedding work on a large review. Mapping
+currently asks one model call to judge every candidate test against every
+obligation — on this repo, 96 tests × 17 obligations in a single structured
+response. The response stays schema-valid but arrives with most test entries
+carrying an empty obligation list, so obligations that do have tests are
+reported as having none, and the reviewer's own failure is rendered as the
+user's untested change. Partition that request along the tests axis: a bounded
+number of tests per call with all obligations repeated in each call, and merge
+the per-call results into the mapping the stage produces today.
 
 ## Constraints
-- Building provenance must not pull in the provider stack, because provenance is
-  assembled during replay runs that have no provider dependency and no API key.
-- A control the provider discarded must never be reported as the value that was
-  requested.
+- Every candidate test must still be judged against every obligation, so
+  partitioning changes how the question is asked and never which pairs are
+  considered.
+- Batch composition must be a pure function of the stage's input, so that two
+  runs over the same input issue the same requests and a recorded run replays.
+- The partitioning mechanism is built to be reusable, but applied to the mapping
+  stage only in this change.
 
 ## Scope exclusions
-- Rendering provenance in the human-readable report is presentation work owned
-  by M7.6; this change corrects the persisted review state and the benchmark's
-  determinism disclosure that reads it.
-- Sampling a provider repeatedly to quantify variance where controls were
-  discarded belongs to the benchmark harness (M-B0.4).
+- Constraining id-bearing response fields to the ids supplied in the call is
+  #163, sequenced immediately after this change because both touch the same
+  prompt and schema.
+- Applying partitioning to the coverage, unrequested-change, recommendation or
+  discrimination stages is out of scope and measured as unwanted (DR-164,
+  decision 2).
+- The mapping stage's foreign-id filter is out of scope and is not changed by
+  this task; it keeps its current behaviour.
+- Re-recording the invalidated mapping transcripts is an operational
+  consequence of this change, not part of its deliverable.
 
 ## Completion expectations
 - Implementation
-- A review's provenance reports the determinism controls the provider actually
-  honoured, separately from the controls that were requested.
-- A control the provider discarded is reported as not in force rather than as
-  the requested value, so a run against a provider that rejects a seed does not
-  claim that seed.
-- A review whose run made no model call at all reports its determinism as
-  indeterminate rather than claiming the configured controls held.
-- Provenance is built from the client that issued the calls, so one builder
-  serves both the CLI pipeline and the benchmark hooks instead of two that can
-  disagree.
-- A replayed run reports the controls recorded in the transcripts it replayed,
-  so replaying a recording made against a provider that discarded a control does
-  not report that control as in force.
-- A transcript recorded from a response that fails schema validation is not left
-  in the store, so a recording session cannot poison the corpus with a response
-  the harness itself rejected.
-- The default model named by the test doubles is the model the tool actually
-  defaults to, so test support does not assert a default that is not real.
-- A run started from the command line carries the configured default seed, so
-  the fixed-seed half of the determinism strategy is in force on the path users
-  actually invoke, with an explicit way to opt out of seeding.
+- The mapping stage issues several model calls, each covering a bounded subset
+  of the candidate tests with all obligations repeated, instead of one call
+  covering every test.
+- The mapping the stage returns is the merge of the per-call results, so a test
+  mapped in any call appears in the final mapping and downstream stages see the
+  same shape of mapping they see today.
+- Every candidate test is judged against every obligation across the calls, so
+  no test-obligation pair is dropped by the act of partitioning.
+- The tests are partitioned from a deterministic order, so the same input
+  produces the same batches on every run.
+- Each call is recorded and replayed as its own request, so a partitioned run
+  replays from recorded transcripts without live calls.
+- The number of tests per call is a run control carried with the other
+  determinism controls, so changing it changes request keys the way changing the
+  seed does and a review discloses the value that was in force.
+- The partitioning mechanism is expressed so that a future stage can adopt it
+  without reimplementing batching, while mapping is its only caller here.
+- The documentation states that mapping-accuracy figures are not comparable
+  across this change, so a benchmark reader is not misled into comparing them.

--- a/docs/DR-164-mapping-stage-request-partitioning.md
+++ b/docs/DR-164-mapping-stage-request-partitioning.md
@@ -1,8 +1,8 @@
 # Decision Record 164 — Request partitioning for the mapping stage
 
-*Relates to issue #164 (reframing merged in `08d0862`; implementation still
-open) and issue #163. Status: measurement accepted, partitioning accepted,
-implementation pending. Track: checker. Stage: 1, with one item explicitly
+*Relates to issue #164 (reframing merged in `08d0862`) and issue #163. Status:
+measurement accepted, partitioning accepted, **partitioning implemented** —
+see "As built" below. Track: checker. Stage: 1, with one item explicitly
 deferred.*
 
 ---
@@ -107,6 +107,40 @@ closed; do not reopen it.
 each forces a transcript re-record that makes benchmark accuracy figures
 non-comparable across it. Sequencing them pays that cost once. They were kept as
 separate issues rather than merged.
+
+## As built (decision 1)
+
+`partition.py` holds the generic mechanism; `evidence/mapping.py` is its only
+caller, per decision 2. Three things about it are load-bearing and look
+optional:
+
+- **The batch sorts its own input.** Ordering is not trusted from
+  `discover_tests`, even though that is currently stable: batch composition must
+  be a pure function of the input or request keys churn and replay misses, and
+  an upstream ordering guarantee is one refactor away from being untrue.
+- **Only `size` goes into the hashed request, not `index` or `count`.** `size`
+  must be there — it is a run control, and two different sizes can produce
+  identical batches when the input is smaller than both, so without it changing
+  the control would silently replay the old recordings. `index`/`count` must
+  *not* be: the messages already differ per batch, so they would add no
+  distinguishing power while making an early batch's key depend on how many
+  batches follow it, invalidating an unchanged batch's transcript every time a
+  test was appended.
+- **A batch may only answer for its own tests.** A model that echoes a
+  neighbouring batch's test would otherwise have its duplicate judgment merged
+  alongside the real one, making the merged result depend on which batch
+  answered last. The merged mappings are then sorted by test id for the same
+  reason.
+
+The batch size is `RunConfig.mapping_batch_size` (default 12, `--mapping-batch-size`),
+and provenance reports `request_partition_size` **observed from the calls**, not
+read from configuration — the #160 rule. `None` there means no partitioned call
+was made, which is a different claim from a partition of size one.
+
+**Mapping-accuracy figures are not comparable across this change**, stated at
+`BenchmarkScore`/`BenchmarkReport.mapping_accuracy` where a reader meets the
+number. Figures from before and after measure different questions being asked,
+so they must not be plotted as a trend or cited as a regression.
 
 ## Open
 

--- a/src/acceptance/benchmark/case.py
+++ b/src/acceptance/benchmark/case.py
@@ -175,6 +175,7 @@ class BenchmarkScore(PersistableModel):
     gap_recall: float | None = None
     gap_precision: float | None = None
     decomposition_accuracy: float | None = None
+    # Not comparable across #164 — see BenchmarkReport.mapping_accuracy.
     mapping_accuracy: float | None = None
     evidence_agreement: float | None = None
     unrequested_precision: float | None = None

--- a/src/acceptance/benchmark/coverage.py
+++ b/src/acceptance/benchmark/coverage.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from acceptance.benchmark.case import BenchmarkCase
 from acceptance.benchmark.hooks import scored_copy
 from acceptance.change.diff import extract_change_set
-from acceptance.config import ScopeExpansionPolicy
+from acceptance.config import DEFAULT_MAPPING_BATCH_SIZE, ScopeExpansionPolicy
 from acceptance.llm import ModelClient
 from acceptance.pipeline import run_review
 
@@ -35,6 +35,7 @@ def classify_case(
     case: BenchmarkCase,
     client: ModelClient,
     policy: ScopeExpansionPolicy = ScopeExpansionPolicy.STRICT,
+    mapping_batch_size: int = DEFAULT_MAPPING_BATCH_SIZE,
 ) -> BenchmarkCase:
     """Run the shared review pipeline over a case's diff and return a scored
     copy of `case`. The benchmark's adapter around `run_review` — every
@@ -51,5 +52,6 @@ def classify_case(
         reviewed_revision=case.inputs.head_revision,
         declaration_text=case.inputs.declaration_text,
         policy=policy,
+        mapping_batch_size=mapping_batch_size,
     )
     return scored_copy(case, review)

--- a/src/acceptance/benchmark/scoring.py
+++ b/src/acceptance/benchmark/scoring.py
@@ -233,6 +233,12 @@ class BenchmarkReport(PersistableModel):
     gap_recall: float | None = None
     gap_precision: float | None = None
     decomposition_accuracy: float | None = None
+    # NOT COMPARABLE ACROSS #164. The mapping stage now partitions its request
+    # across several calls instead of asking one call for every test-obligation
+    # judgment (DR-164), which changes the prompts and forced the whole mapping
+    # transcript corpus to be re-recorded. A mapping-accuracy figure from before
+    # that change and one from after measure different questions being asked, so
+    # they must not be plotted as a trend or cited as a regression/improvement.
     mapping_accuracy: float | None = None
     evidence_agreement: float | None = None
     unrequested_precision: float | None = None
@@ -321,6 +327,9 @@ class SampledBenchmarkReport(PersistableModel):
     gap_recall: MetricStats
     gap_precision: MetricStats
     decomposition_accuracy: MetricStats
+    # Not comparable across #164 — see BenchmarkReport.mapping_accuracy. Spread
+    # pooled across that boundary would read as model variance when it is the
+    # partitioning change.
     mapping_accuracy: MetricStats
     evidence_agreement: MetricStats
     unrequested_precision: MetricStats

--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -21,7 +21,12 @@ import sys
 from pathlib import Path
 
 from acceptance.change.diff import extract_change_set, extract_working_tree_change_set
-from acceptance.config import DEFAULT_MODEL, DEFAULT_SEED, RunConfig
+from acceptance.config import (
+    DEFAULT_MAPPING_BATCH_SIZE,
+    DEFAULT_MODEL,
+    DEFAULT_SEED,
+    RunConfig,
+)
 from acceptance.coverage.classify import ImplementationCoverage, classify_coverage
 from acceptance.coverage.disposition import DispositionedChange, classify_dispositions
 from acceptance.coverage.open_questions import apply_open_question_resolutions, resolve_open_questions
@@ -146,6 +151,7 @@ def run_check(
         reviewed_revision=reviewed_revision,
         declaration_text=declaration_text,
         policy=config.scope_expansion_policy,
+        mapping_batch_size=config.mapping_batch_size,
     )
     # §10.1 step 12: when gaps exist, hand the agent a next instruction. The
     # file is a CLI side effect, not part of the pipeline — the benchmark runs
@@ -347,6 +353,16 @@ def _add_model_flags(parser: argparse.ArgumentParser, default_mode: str) -> None
     parser.add_argument(
         "--temperature", type=float, default=0.0, help="Model temperature (default: 0.0)."
     )
+    parser.add_argument(
+        "--mapping-batch-size",
+        type=int,
+        default=DEFAULT_MAPPING_BATCH_SIZE,
+        help=(
+            "Candidate tests per mapping call (determinism; default: "
+            f"{DEFAULT_MAPPING_BATCH_SIZE}). Changing it invalidates recorded "
+            "mapping transcripts."
+        ),
+    )
 
 
 def _seed_from(args: argparse.Namespace) -> int | None:
@@ -438,6 +454,7 @@ def main(argv: list[str] | None = None) -> int:
             mode=Mode(args.mode),
             seed=_seed_from(args),
             temperature=args.temperature,
+            mapping_batch_size=args.mapping_batch_size,
         )
         try:
             review = run_check(
@@ -462,6 +479,7 @@ def main(argv: list[str] | None = None) -> int:
             mode=Mode(args.mode),
             seed=_seed_from(args),
             temperature=args.temperature,
+            mapping_batch_size=args.mapping_batch_size,
         )
         try:
             result = run_decompose(args.task, config)
@@ -495,6 +513,7 @@ def main(argv: list[str] | None = None) -> int:
             mode=Mode(args.mode),
             seed=_seed_from(args),
             temperature=args.temperature,
+            mapping_batch_size=args.mapping_batch_size,
         )
         try:
             obligations, open_questions, coverages, dispositioned = run_classify(

--- a/src/acceptance/config.py
+++ b/src/acceptance/config.py
@@ -35,6 +35,13 @@ DEFAULT_MODEL = "openai/gpt-5.4-mini"
 # correct: a determinism control changed, so recordings must be re-verified.
 DEFAULT_SEED = 0
 
+# Candidate tests per mapping call (DR-164). A determinism control in the same
+# sense as the seed: it changes what is asked of the model, so changing it
+# invalidates every recorded mapping transcript. 12 puts ~200 relevance
+# judgments in a call, an order of magnitude under the ~1,000 at which the
+# stage was measured shedding work, at ~1.5x the total input tokens.
+DEFAULT_MAPPING_BATCH_SIZE = 12
+
 
 class ScopeExpansionPolicy(str, Enum):
     """How tolerant the review is of changes beyond the mandate (DR-081
@@ -61,6 +68,10 @@ class RunConfig(BaseModel):
     temperature: float = 0.0
     seed: int | None = DEFAULT_SEED
     transcript_root: Path = Field(default=DEFAULT_TRANSCRIPT_ROOT)
+    # A determinism control, but a stage-level one: it partitions the request
+    # rather than parameterising the provider call, so it reaches the mapping
+    # stage through the pipeline instead of through build_client().
+    mapping_batch_size: int = Field(default=DEFAULT_MAPPING_BATCH_SIZE, ge=1)
     # A review-interpretation knob (consumed by the M3.5.3 separability
     # classifier), not a determinism control — so it deliberately does not
     # feed build_client() or provenance_for(). If we later want it recorded for
@@ -100,4 +111,5 @@ def provenance_for(client: ModelClient) -> ReviewProvenance:
         controls_in_force=(
             None if in_force is None else DeterminismControls(**in_force)
         ),
+        request_partition_size=client.partition_size_in_force,
     )

--- a/src/acceptance/evidence/mapping.py
+++ b/src/acceptance/evidence/mapping.py
@@ -19,9 +19,11 @@ the field the §11.1 mapping-accuracy metric (scoring.py) already scores.
 
 from __future__ import annotations
 
+from acceptance.config import DEFAULT_MAPPING_BATCH_SIZE
 from acceptance.evidence.discovery import DiscoveredTest
 from acceptance.llm import ModelClient, StrictResponseModel
 from acceptance.model_base import PersistableModel
+from acceptance.partition import partition
 from acceptance.review_state import Obligation
 
 _SYSTEM_PROMPT = """\
@@ -89,36 +91,61 @@ def _render_prompt(obligations: list[Obligation], tests: list[DiscoveredTest]) -
 
 
 def map_tests_to_obligations(
-    obligations: list[Obligation], tests: list[DiscoveredTest], client: ModelClient
+    obligations: list[Obligation],
+    tests: list[DiscoveredTest],
+    client: ModelClient,
+    batch_size: int = DEFAULT_MAPPING_BATCH_SIZE,
 ) -> MappingResult:
-    """Map each candidate test to the obligation(s) it purports to evidence."""
+    """Map each candidate test to the obligation(s) it purports to evidence.
+
+    The tests are partitioned across several calls, with every obligation
+    repeated in each call, because one call asking for tests x obligations
+    judgments sheds work silently past roughly a thousand of them (DR-164).
+    Recall is unaffected: every test is still judged against every obligation,
+    just not all in one response.
+    """
     valid_obligation_ids = {o.id for o in obligations}
     if not tests:
         # No candidates to map — every obligation is unmapped. No model call.
         return MappingResult(mappings=[], unmapped_obligation_ids=sorted(valid_obligation_ids))
 
-    messages = [
-        {"role": "system", "content": _SYSTEM_PROMPT},
-        {"role": "user", "content": _render_prompt(obligations, tests)},
-    ]
-    result = client.complete(messages, _Mappings)
-
-    valid_test_ids = {t.test_id for t in tests}
     mapped_obligation_ids: set[str] = set()
     mappings: list[TestMapping] = []
-    for mapping in result.mappings:
-        if mapping.test_id not in valid_test_ids:
-            continue  # a returned id that isn't a real candidate — drop it
-        obligation_ids = [oid for oid in mapping.obligation_ids if oid in valid_obligation_ids]
-        mapped_obligation_ids.update(obligation_ids)
-        mappings.append(
-            TestMapping(
-                test_id=mapping.test_id,
-                obligation_ids=obligation_ids,
-                rationale=mapping.rationale,
-            )
-        )
+    seen_test_ids: set[str] = set()
 
+    for batch in partition(tests, batch_size, key=lambda test: test.test_id):
+        messages = [
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {"role": "user", "content": _render_prompt(obligations, list(batch.items))},
+        ]
+        result = client.complete(messages, _Mappings, batch.request_partition())
+
+        # A batch may only speak for its own tests. Without this, a model that
+        # echoes tests from a neighbouring batch would have its duplicate
+        # judgment merged in alongside the real one, and the merged mapping
+        # would depend on which batch answered last.
+        batch_test_ids = {test.test_id for test in batch.items}
+        for mapping in result.mappings:
+            if mapping.test_id not in batch_test_ids:
+                continue  # not a candidate in this batch — drop it
+            if mapping.test_id in seen_test_ids:
+                continue  # already judged, in its own batch
+            seen_test_ids.add(mapping.test_id)
+            obligation_ids = [
+                oid for oid in mapping.obligation_ids if oid in valid_obligation_ids
+            ]
+            mapped_obligation_ids.update(obligation_ids)
+            mappings.append(
+                TestMapping(
+                    test_id=mapping.test_id,
+                    obligation_ids=obligation_ids,
+                    rationale=mapping.rationale,
+                )
+            )
+
+    # Sorted, not left in response order, so the merged result depends only on
+    # which judgments came back and not on the order the batches returned them.
+    mappings.sort(key=lambda mapping: mapping.test_id)
     unmapped = sorted(valid_obligation_ids - mapped_obligation_ids)
     return MappingResult(mappings=mappings, unmapped_obligation_ids=unmapped)
 

--- a/src/acceptance/llm.py
+++ b/src/acceptance/llm.py
@@ -237,9 +237,16 @@ class ModelClient:
         # provenance can report the controls actually in force rather than the
         # ones configured (#160) — see `controls_in_force`.
         self._observed_controls: list[dict | None] = []
+        # One entry per partitioned call. Observed rather than configured, for
+        # the same reason as the controls above: provenance should describe the
+        # run that happened, not the run that was asked for (DR-164).
+        self._observed_partitions: list[dict] = []
 
     def build_request(
-        self, messages: list[dict], response_model: type[BaseModel]
+        self,
+        messages: list[dict],
+        response_model: type[BaseModel],
+        partition: dict[str, Any] | None = None,
     ) -> dict:
         """The recorded, hashed description of a call."""
         request: dict[str, Any] = {
@@ -255,13 +262,22 @@ class ModelClient:
         }
         if self.seed is not None:
             request["seed"] = self.seed
+        if partition is not None:
+            # Inside the hash, like the seed, because it is a determinism
+            # control: changing how work is partitioned changes what is asked of
+            # the model, so recordings made under the old partitioning must be
+            # re-verified rather than silently replayed (DR-164).
+            request["partition"] = partition
         return request
 
     def complete(
-        self, messages: list[dict], response_model: type[ResponseModelT]
+        self,
+        messages: list[dict],
+        response_model: type[ResponseModelT],
+        partition: dict[str, Any] | None = None,
     ) -> ResponseModelT:
         """Return a validated `response_model`, from a live call or a transcript."""
-        request = self.build_request(messages, response_model)
+        request = self.build_request(messages, response_model, partition)
         key = request_key(request)
         record = self.store.read(key)
 
@@ -287,6 +303,8 @@ class ModelClient:
         # that of the recording it replays, so a transcript recorded against a
         # provider that discarded a control must not replay as pinned.
         self._observed_controls.append(record.get("controls_applied"))
+        if partition is not None:
+            self._observed_partitions.append(partition)
         return self._validate(record["response"], response_model)
 
     @property
@@ -312,6 +330,21 @@ class ModelClient:
             values = [call.get(name) for call in per_call]
             in_force[name] = values[0] if all(v == values[0] for v in values) else None
         return in_force
+
+    @property
+    def partition_size_in_force(self) -> int | None:
+        """The partition size observed across this client's partitioned calls.
+
+        `None` means no partitioned call was made — an unpartitioned run, which
+        is a different claim from a partition size of one. As with
+        `controls_in_force`, disagreement between calls yields `None` rather than
+        a value that only some calls ran under.
+        """
+        sizes = {partition.get("size") for partition in self._observed_partitions}
+        if len(sizes) != 1:
+            return None
+        size = sizes.pop()
+        return size if isinstance(size, int) else None
 
     def _persist_live_call(
         self, key: str, request: dict, response_model: type[BaseModel]

--- a/src/acceptance/partition.py
+++ b/src/acceptance/partition.py
@@ -1,0 +1,78 @@
+"""Request partitioning — decisions per request (plan §3.2, DR-164).
+
+A schema-constrained call degrades by *shedding work* long before it runs out of
+context. The M4 mapping stage asked one call for tests x obligations relevance
+judgments — 1,632 on a review of this repo — and returned a well-formed entry per
+test with an empty `obligation_ids` list for up to 80 of 96 tests. The response
+stayed schema-valid, so nothing downstream noticed, and the review reported the
+reviewer's own failure as the user's untested change.
+
+Size was measured and is not the binding constraint: the largest prompt used 2.5%
+of the model's context window. What binds is how many independent judgments one
+response is asked to carry. So the fix partitions the *judgments*, not the bytes.
+
+This module is the generic mechanism. It is deliberately not applied everywhere:
+partitioning is cheap only when the repeated context is small relative to the axis
+being split, which measurement says is true of mapping (obligations are 4% of the
+prompt) and false of the diff-dominated stages, where it would cost ~3.8x the
+tokens on stages with no observed failure (DR-164, decision 2).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Generic, Iterable, Sequence, TypeVar
+
+from pydantic import BaseModel, ConfigDict, Field
+
+T = TypeVar("T")
+
+
+class Batch(BaseModel, Generic[T]):
+    """One partition of a stage's input, and the request it describes."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, arbitrary_types_allowed=True)
+
+    items: tuple[T, ...]
+    index: int = Field(ge=0)
+    count: int = Field(ge=1)
+    size: int = Field(ge=1)  # the configured control, not len(items)
+
+    def request_partition(self) -> dict[str, Any]:
+        """The partition descriptor to fold into the hashed request.
+
+        Only `size` is included, and deliberately. It is a run control, so
+        changing it must invalidate every recorded transcript exactly as changing
+        the seed does (#154) — and it would not otherwise, because two batch
+        sizes can produce identical batches when the input is smaller than both.
+
+        `index` and `count` are left out for the opposite reason: the messages
+        already differ between batches, so including them would buy no
+        distinguishing power while making a batch's key depend on how many
+        batches follow it. Appending one test would then invalidate the first
+        batch's transcript even though its content is unchanged.
+        """
+        return {"size": self.size}
+
+
+def partition(
+    items: Iterable[T], size: int, key: Callable[[T], Any]
+) -> list[Batch[T]]:
+    """Split `items` into batches of at most `size`, in a stable order.
+
+    Ordering is imposed here rather than trusted from upstream: batch composition
+    must be a pure function of the input or request keys churn between runs and
+    replay misses, and a caller's ordering guarantee is one refactor away from
+    being untrue. Sorting on `key` makes the guarantee local and testable.
+    """
+    if size < 1:
+        raise ValueError(f"batch size must be at least 1, got {size}")
+
+    ordered: Sequence[T] = sorted(items, key=key)
+    if not ordered:
+        return []
+
+    groups = [ordered[start : start + size] for start in range(0, len(ordered), size)]
+    return [
+        Batch(items=tuple(group), index=index, count=len(groups), size=size)
+        for index, group in enumerate(groups)
+    ]

--- a/src/acceptance/pipeline.py
+++ b/src/acceptance/pipeline.py
@@ -20,7 +20,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from acceptance.config import ScopeExpansionPolicy, provenance_for
+from acceptance.config import (
+    DEFAULT_MAPPING_BATCH_SIZE,
+    ScopeExpansionPolicy,
+    provenance_for,
+)
 from acceptance.coverage.classify import CoverageStatus, ImplementationCoverage, classify_coverage
 from acceptance.coverage.declaration_comparison import (
     compare_declaration,
@@ -145,6 +149,7 @@ def run_review(
     reviewed_revision: str,
     declaration_text: str | None = None,
     policy: ScopeExpansionPolicy = ScopeExpansionPolicy.STRICT,
+    mapping_batch_size: int = DEFAULT_MAPPING_BATCH_SIZE,
 ) -> Review:
     """Run the full static review pipeline and return the assembled Review."""
     parsed = parse_task_file(task_text)
@@ -152,7 +157,9 @@ def run_review(
     obligations = decomposition.obligations
 
     discovered = discover_tests(repo, change_set)
-    mapping = map_tests_to_obligations(obligations, discovered.tests, client)
+    mapping = map_tests_to_obligations(
+        obligations, discovered.tests, client, mapping_batch_size
+    )
     obligations = apply_test_mapping(obligations, mapping)
 
     test_evidence = extract_test_evidence(repo, discovered.tests, change_set, mapping)

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -446,6 +446,11 @@ class ReviewProvenance(_Model):
     # model call at all, and such a run must not inherit a claim that the
     # configured controls held — see `determinism`.
     controls_in_force: DeterminismControls | None = None
+    # How many items one partitioned request covered (DR-164). Observed from the
+    # calls, not read from configuration, so it reports the partitioning that was
+    # actually in force. None means no partitioned call was made — a different
+    # claim from a partition of size one.
+    request_partition_size: int | None = None
 
     def determinism(self) -> Literal["pinned", "unpinned", "indeterminate"]:
         """Whether this run is reproducible, derived rather than stored.

--- a/tests/benchmark/test_coverage.py
+++ b/tests/benchmark/test_coverage.py
@@ -22,16 +22,18 @@ invariant the test client dispatches a fixed, hand-authored response per
 call by its response schema name — no live calls.
 """
 
+import json
 from pathlib import Path
 
 from acceptance.benchmark.coverage import classify_case
 from acceptance.benchmark.fixtures import build_benchmark_case
 from acceptance.change.diff import extract_change_set
 from acceptance.cli import run_check
-from acceptance.config import RunConfig
+from acceptance.config import DEFAULT_MODEL, RunConfig
+from acceptance.llm import Mode, ModelClient, TranscriptStore
 from acceptance.review_store import ReviewStore
 from tests.support import client_dispatching as _client_dispatching
-from tests.support import client_finding_nothing
+from tests.support import _EMPTY_BY_SCHEMA, _fake_response, client_finding_nothing
 
 ARCHETYPES_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "archetypes"
 
@@ -608,6 +610,47 @@ def test_the_shared_pipeline_runs_every_stage(tmp_path):
     assert obligation.coverage_refs  # coverage refs were carried through
     assert review.recommendations  # recommendation generation ran
     assert review.completion is not None  # the verdict was derived
+
+
+def test_the_shared_pipeline_partitions_the_mapping_call(tmp_path):
+    """The batching mechanism has its own unit tests; this pins that the
+    pipeline actually *calls* it, and that the batch-size control reaches it
+    rather than stopping at the signature. A partitioner nothing routes through
+    is the exact shape of hole defect injection keeps finding here.
+    """
+    case = build_benchmark_case(ARCHETYPES_DIR / "01-missed-obligation", tmp_path / "repo")
+    mapping_prompts: list[str] = []
+
+    def completion_fn(**kwargs):
+        schema_name = kwargs["response_format"]["json_schema"]["name"]
+        if schema_name == "_Mappings":
+            mapping_prompts.append(kwargs["messages"][-1]["content"])
+        return _fake_response(json.dumps(_EMPTY_BY_SCHEMA[schema_name]))
+
+    def run(batch_size):
+        mapping_prompts.clear()
+        client = ModelClient(
+            model=DEFAULT_MODEL,
+            mode=Mode.RECORD,
+            store=TranscriptStore(str(tmp_path / f"transcripts-{batch_size}")),
+            completion_fn=completion_fn,
+        )
+        classify_case(case, client, mapping_batch_size=batch_size)
+        return list(mapping_prompts)
+
+    # This fixture discovers more than one candidate test, so a batch size of
+    # one must produce more than one mapping call.
+    one_per_call = run(1)
+    all_at_once = run(50)
+
+    assert len(all_at_once) == 1
+    assert len(one_per_call) > 1
+    # Same tests judged either way — partitioning changes the asking, not the
+    # question. Each single-test call carries exactly one test.
+    assert all(prompt.count("\n### ") == 1 for prompt in one_per_call)
+    assert sum(prompt.count("\n### ") for prompt in one_per_call) == all_at_once[
+        0
+    ].count("\n### ")
 
 
 def test_the_shared_pipeline_writes_nothing_into_the_reviewed_repo(tmp_path):

--- a/tests/benchmark/test_scoring.py
+++ b/tests/benchmark/test_scoring.py
@@ -100,3 +100,50 @@ def test_metrics_are_none_when_their_ground_truth_is_empty():
     assert score.mapping_accuracy is None  # no candidate_tests edges
     assert score.decomposition_accuracy == 0.0  # one obligation, none reported
     assert score.evidence_agreement == 0.0  # one obligation with an evidence class
+
+
+# --- #164: the metric carries its own comparability warning ------------------
+
+
+def _text_around(path, anchor: str, before: int = 8) -> str:
+    """The lines immediately preceding `anchor` in `path` — where a field's
+    explanatory comment lives in this codebase."""
+    import pathlib
+
+    lines = pathlib.Path(path).read_text().splitlines()
+    index = next(i for i, line in enumerate(lines) if anchor in line)
+    return "\n".join(lines[max(0, index - before) : index + 1])
+
+
+def test_mapping_accuracy_is_marked_not_comparable_across_the_partitioning_change():
+    """A mapping-accuracy figure from before #164 and one from after measure
+    different questions being asked of the model, so a reader who plots them as
+    a trend draws a conclusion the data cannot support. The warning has to sit
+    where the number is met, not only in the decision record — this test fails
+    if it is deleted, softened, or drifts away from the field."""
+    import acceptance.benchmark.case as case_module
+    import acceptance.benchmark.scoring as scoring_module
+
+    report = _text_around(scoring_module.__file__, "    mapping_accuracy: float | None = None")
+    score = _text_around(case_module.__file__, "    mapping_accuracy: float | None = None")
+    sampled = _text_around(scoring_module.__file__, "    mapping_accuracy: MetricStats")
+
+    for text in (report, score, sampled):
+        assert "not comparable" in text.lower()
+        assert "#164" in text
+
+    # The strong form: not merely "changed", but "do not compare".
+    assert "must not be plotted as a trend" in report
+    assert "regression" in report
+
+
+def test_the_decision_record_states_the_non_comparability_too():
+    """The DR is where someone reading the *change* lands, as opposed to
+    someone reading the *number*. Both entry points have to carry it."""
+    import pathlib
+
+    dr = pathlib.Path(__file__).resolve().parents[2] / "docs"
+    text = (dr / "DR-164-mapping-stage-request-partitioning.md").read_text()
+
+    assert "not comparable" in text.lower()
+    assert "mapping-accuracy" in text.lower()

--- a/tests/evidence/test_mapping.py
+++ b/tests/evidence/test_mapping.py
@@ -7,6 +7,7 @@ these tests inject the recorded response via completion_fn — no live calls.
 A client that raises proves the no-candidate-tests path takes no model call.
 """
 
+import json
 import tempfile
 from pathlib import Path
 
@@ -17,7 +18,7 @@ from acceptance.evidence.discovery import DiscoveredTest, DiscoveryReason, disco
 from acceptance.evidence.mapping import apply_test_mapping, map_tests_to_obligations
 from acceptance.llm import Mode, ModelClient, TranscriptStore
 from acceptance.review_state import Obligation, ObligationType, Review
-from tests.support import client_returning, make_obligation
+from tests.support import client_answering_per_call, client_returning, make_obligation
 
 ARCHETYPES_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "archetypes"
 
@@ -116,6 +117,181 @@ def test_no_candidate_tests_makes_no_model_call_and_flags_all_unmapped():
 
     assert result.mappings == []
     assert result.unmapped_obligation_ids == ["ob-1", "ob-2"]
+
+
+# --- partitioning the mapping request (DR-164, #164) ---
+
+
+def _mapped(prompt: str, obligation_id: str) -> dict:
+    """Map every test named in `prompt` to `obligation_id` — a stand-in for a
+    model that answers only about the tests it was actually given."""
+    return {
+        "mappings": [
+            {"test_id": test_id, "obligation_ids": [obligation_id], "rationale": "."}
+            for test_id in _test_ids_in(prompt)
+        ]
+    }
+
+
+def _test_ids_in(prompt: str) -> list[str]:
+    return [
+        line.removeprefix("### ").strip()
+        for line in prompt.splitlines()
+        if line.startswith("### ")
+    ]
+
+
+def test_the_tests_are_split_across_several_calls():
+    obligations = [make_obligation("ob-1", "A", ObligationType.FUNCTIONAL)]
+    tests = [_test(f"t.py::test_{n:02d}") for n in range(10)]
+    client, calls = client_answering_per_call(lambda p: _mapped(p, "ob-1"))
+
+    map_tests_to_obligations(obligations, tests, client, batch_size=4)
+
+    assert len(calls) == 3
+    assert [len(_test_ids_in(call["prompt"])) for call in calls] == [4, 4, 2]
+
+
+def test_every_test_is_judged_against_every_obligation_across_the_calls():
+    """Partitioning changes how the question is asked, never which pairs are
+    considered: each call repeats all obligations, and the calls together cover
+    all tests."""
+    obligations = [
+        make_obligation("ob-1", "A", ObligationType.FUNCTIONAL),
+        make_obligation("ob-2", "B", ObligationType.FUNCTIONAL),
+        make_obligation("ob-3", "C", ObligationType.FUNCTIONAL),
+    ]
+    tests = [_test(f"t.py::test_{n:02d}") for n in range(7)]
+    client, calls = client_answering_per_call(lambda p: _mapped(p, "ob-1"))
+
+    map_tests_to_obligations(obligations, tests, client, batch_size=3)
+
+    judged = [test_id for call in calls for test_id in _test_ids_in(call["prompt"])]
+    assert sorted(judged) == sorted(t.test_id for t in tests)
+    assert len(judged) == len(set(judged))  # no test judged twice
+    for call in calls:
+        for obligation in obligations:
+            assert f"id={obligation.id}" in call["prompt"]
+
+
+def test_the_per_call_results_are_merged():
+    """A judgment made in any batch reaches the final mapping — the merge is
+    what makes partitioning invisible downstream."""
+    obligations = [
+        make_obligation("ob-1", "A", ObligationType.FUNCTIONAL),
+        make_obligation("ob-2", "B", ObligationType.FUNCTIONAL),
+    ]
+    tests = [_test("t.py::test_a"), _test("t.py::test_b")]
+
+    def responder(prompt: str) -> dict:
+        # Each batch holds one test; they map to different obligations, so a
+        # result that kept only one call's answer would lose an obligation.
+        test_id = _test_ids_in(prompt)[0]
+        target = "ob-1" if test_id.endswith("_a") else "ob-2"
+        return {"mappings": [
+            {"test_id": test_id, "obligation_ids": [target], "rationale": "."},
+        ]}
+
+    client, calls = client_answering_per_call(responder)
+    result = map_tests_to_obligations(obligations, tests, client, batch_size=1)
+
+    assert len(calls) == 2
+    assert {m.test_id: m.obligation_ids for m in result.mappings} == {
+        "t.py::test_a": ["ob-1"],
+        "t.py::test_b": ["ob-2"],
+    }
+    assert result.unmapped_obligation_ids == []
+
+
+def test_a_batch_may_not_answer_for_a_test_outside_it():
+    """A model that echoes a neighbouring batch's test would otherwise have its
+    duplicate judgment merged alongside the real one, making the result depend
+    on which batch answered last."""
+    obligations = [
+        make_obligation("ob-1", "A", ObligationType.FUNCTIONAL),
+        make_obligation("ob-2", "B", ObligationType.FUNCTIONAL),
+    ]
+    tests = [_test("t.py::test_a"), _test("t.py::test_b")]
+
+    def responder(prompt: str) -> dict:
+        # Every batch claims to have judged BOTH tests, mapping each to whatever
+        # its own batch is about.
+        target = "ob-1" if _test_ids_in(prompt)[0].endswith("_a") else "ob-2"
+        return {"mappings": [
+            {"test_id": "t.py::test_a", "obligation_ids": [target], "rationale": "."},
+            {"test_id": "t.py::test_b", "obligation_ids": [target], "rationale": "."},
+        ]}
+
+    client, _ = client_answering_per_call(responder)
+    result = map_tests_to_obligations(obligations, tests, client, batch_size=1)
+
+    # One entry per test, each carrying its own batch's answer.
+    assert [m.test_id for m in result.mappings] == ["t.py::test_a", "t.py::test_b"]
+    assert result.mappings[0].obligation_ids == ["ob-1"]
+    assert result.mappings[1].obligation_ids == ["ob-2"]
+
+
+def test_the_merged_mapping_does_not_depend_on_the_order_the_tests_arrive_in():
+    obligations = [make_obligation("ob-1", "A", ObligationType.FUNCTIONAL)]
+    tests = [_test(f"t.py::test_{n:02d}") for n in range(6)]
+
+    forward, _ = client_answering_per_call(lambda p: _mapped(p, "ob-1"))
+    reverse, _ = client_answering_per_call(lambda p: _mapped(p, "ob-1"))
+
+    first = map_tests_to_obligations(obligations, tests, forward, batch_size=2)
+    second = map_tests_to_obligations(
+        obligations, list(reversed(tests)), reverse, batch_size=2
+    )
+
+    assert first.model_dump() == second.model_dump()
+
+
+def test_each_batch_is_recorded_as_its_own_request():
+    """Replay depends on it: one transcript per batch, keyed distinctly, and
+    carrying the partition size so changing the control invalidates them."""
+    obligations = [make_obligation("ob-1", "A", ObligationType.FUNCTIONAL)]
+    tests = [_test(f"t.py::test_{n:02d}") for n in range(4)]
+    client, _ = client_answering_per_call(lambda p: _mapped(p, "ob-1"))
+
+    map_tests_to_obligations(obligations, tests, client, batch_size=2)
+
+    keys = list(Path(client.store.root).glob("*.json"))
+    assert len(keys) == 2  # two batches, two distinct transcripts
+    recorded = [json.loads(path.read_text())["request"] for path in keys]
+    assert all(request["partition"] == {"size": 2} for request in recorded)
+
+
+def test_changing_the_batch_size_changes_every_request_key():
+    """The control is hashed like the seed. These inputs make one batch either
+    way, so only the descriptor distinguishes them — without it, a run under a
+    changed control would silently replay the old recordings."""
+    obligations = [make_obligation("ob-1", "A", ObligationType.FUNCTIONAL)]
+    tests = [_test("t.py::test_a")]
+
+    first, _ = client_answering_per_call(lambda p: _mapped(p, "ob-1"))
+    second, _ = client_answering_per_call(lambda p: _mapped(p, "ob-1"))
+    map_tests_to_obligations(obligations, tests, first, batch_size=4)
+    map_tests_to_obligations(obligations, tests, second, batch_size=8)
+
+    def keys(client):
+        return {path.name for path in Path(client.store.root).glob("*.json")}
+
+    assert len(keys(first)) == len(keys(second)) == 1
+    assert keys(first) != keys(second)
+
+
+def test_repeating_a_run_reuses_the_recorded_batches():
+    """The other half of determinism: unchanged input under an unchanged
+    control must hit the same keys, or every re-run would re-record."""
+    obligations = [make_obligation("ob-1", "A", ObligationType.FUNCTIONAL)]
+    tests = [_test(f"t.py::test_{n:02d}") for n in range(4)]
+    client, calls = client_answering_per_call(lambda p: _mapped(p, "ob-1"))
+
+    first = map_tests_to_obligations(obligations, tests, client, batch_size=2)
+    second = map_tests_to_obligations(obligations, tests, client, batch_size=2)
+
+    assert len(calls) == 2  # the second run made no live call: all four batches hit cache
+    assert first.model_dump() == second.model_dump()
 
 
 # --- unit: apply_test_mapping ---

--- a/tests/support.py
+++ b/tests/support.py
@@ -47,6 +47,33 @@ def client_returning(response: dict, model: str = _DEFAULT_MODEL) -> ModelClient
     )
 
 
+def client_answering_per_call(
+    responder, model: str = _DEFAULT_MODEL
+) -> tuple[ModelClient, list[dict]]:
+    """A client that answers each call from the prompt it was given.
+
+    Returns the client and a list that accumulates one entry per call —
+    `{"prompt": ..., "response": ...}` — so a test can assert what was asked as
+    well as what came back. Needed for partitioned stages, where a single fixed
+    response cannot distinguish "every batch was asked" from "one batch was".
+    """
+    calls: list[dict] = []
+
+    def completion_fn(**kwargs):
+        prompt = "\n".join(message["content"] for message in kwargs["messages"])
+        response = responder(prompt)
+        calls.append({"prompt": prompt, "response": response})
+        return _fake_response(json.dumps(response))
+
+    client = ModelClient(
+        model=model,
+        mode=Mode.RECORD,
+        store=TranscriptStore(tempfile.mkdtemp()),
+        completion_fn=completion_fn,
+    )
+    return client, calls
+
+
 def make_obligation(obligation_id: str, description: str, typ: ObligationType) -> Obligation:
     """A minimal but valid Obligation for tests that don't exercise its
     importance/explicitness/observable-behavior fields directly."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,6 +91,10 @@ def test_check_records_determinism_flags_in_provenance(git_repo, fixture_task_pa
         "model": "openai/gpt-5",
         "controls_requested": {"temperature": 0.4, "seed": 7},
         "controls_in_force": {"temperature": 0.4, "seed": 7},
+        # This fixture's diff surfaces no candidate tests, so the mapping stage
+        # makes no call and there is no partitioning to report. None here is
+        # "unpartitioned run", not "partition of size zero".
+        "request_partition_size": None,
     }
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,14 @@
 """RunConfig controls, incl. the M3.5.2 scope-expansion policy (DR-081)."""
 
-from acceptance.config import RunConfig, ScopeExpansionPolicy, provenance_for
+import pytest
+from pydantic import ValidationError
+
+from acceptance.config import (
+    DEFAULT_MAPPING_BATCH_SIZE,
+    RunConfig,
+    ScopeExpansionPolicy,
+    provenance_for,
+)
 
 
 def test_scope_expansion_policy_defaults_to_strict():
@@ -121,6 +129,43 @@ def test_provenance_of_a_run_that_made_no_model_call_is_indeterminate():
 
     assert provenance.controls_in_force is None
     assert provenance.determinism() == "indeterminate"
+
+
+def test_the_mapping_batch_size_is_a_run_control_with_a_fixed_default():
+    assert RunConfig().mapping_batch_size == DEFAULT_MAPPING_BATCH_SIZE
+
+    with pytest.raises(ValidationError):
+        RunConfig(mapping_batch_size=0)  # a batch must hold something
+
+
+def test_provenance_reports_the_partition_size_the_run_actually_used():
+    """Read off the calls, not off configuration — the same rule as the other
+    controls (#160). A review that reported a configured partition size while
+    its calls ran unpartitioned would describe a run that did not happen."""
+    from acceptance.requirement.obligations import _Decomposition
+
+    from tests.support import client_finding_nothing
+
+    client = client_finding_nothing()
+    client.complete(
+        [{"role": "user", "content": "batch 1"}], _Decomposition, {"size": 7}
+    )
+
+    assert provenance_for(client).request_partition_size == 7
+
+
+def test_provenance_of_an_unpartitioned_run_reports_no_partition_size():
+    """None means "no partitioned call was made", which is a different claim
+    from a partition of size one — the same distinction controls_in_force draws
+    between "ignored" and "nothing observed"."""
+    from acceptance.requirement.obligations import _Decomposition
+
+    from tests.support import client_finding_nothing
+
+    client = client_finding_nothing()
+    client.complete([{"role": "user", "content": "unpartitioned"}], _Decomposition)
+
+    assert provenance_for(client).request_partition_size is None
 
 
 def test_one_builder_serves_both_the_cli_pipeline_and_the_benchmark():

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -84,6 +84,50 @@ def test_a_size_below_one_is_rejected():
         partition(["a"], 0, key=str)
 
 
+def test_the_mechanism_works_on_a_payload_that_has_nothing_to_do_with_mapping():
+    """Reusability is the obligation, so exercise it on a shape the mapping
+    stage would never produce. A partitioner that had grown mapping-specific
+    assumptions — a `test_id` attribute, an obligation list — could not run this
+    at all, and the next stage to need batching would have to reimplement it."""
+    changed_files = [
+        {"path": "src/b.py", "hunks": 3},
+        {"path": "src/a.py", "hunks": 1},
+        {"path": "src/c.py", "hunks": 7},
+    ]
+
+    batches = partition(changed_files, 2, key=lambda f: f["path"])
+
+    assert [[f["path"] for f in b.items] for b in batches] == [
+        ["src/a.py", "src/b.py"],
+        ["src/c.py"],
+    ]
+    assert batches[0].request_partition() == {"size": 2}
+
+
+def test_the_mechanism_does_not_depend_on_the_stage_that_uses_it():
+    """The one caller today is mapping (DR-164 decision 2). The module must not
+    import it back: a partitioner that reaches into `evidence/` is reusable only
+    in name, and the coupling would not show up in any behavioural test."""
+    import ast
+    import pathlib
+
+    import acceptance.partition as module
+
+    tree = ast.parse(pathlib.Path(module.__file__).read_text())
+    imported = {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    } | {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+
+    assert not [name for name in imported if name.startswith("acceptance.")]
+
+
 def test_a_batch_is_immutable():
     batch = partition(["a", "b"], 2, key=str)[0]
 

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -1,0 +1,91 @@
+"""Request partitioning (DR-164).
+
+The mechanism is generic, so these are its properties independent of any stage:
+batches cover the input exactly once, composition is a pure function of the
+input, and the descriptor folded into the request key carries the run control
+without carrying the batch's position.
+"""
+
+import pytest
+
+from acceptance.partition import Batch, partition
+
+
+def _ids(batches: list[Batch]) -> list[list[str]]:
+    return [list(batch.items) for batch in batches]
+
+
+def test_batches_cover_every_item_exactly_once():
+    items = [f"t{n:02d}" for n in range(10)]
+
+    batches = partition(items, 4, key=str)
+
+    assert _ids(batches) == [
+        ["t00", "t01", "t02", "t03"],
+        ["t04", "t05", "t06", "t07"],
+        ["t08", "t09"],
+    ]
+    assert [item for batch in batches for item in batch.items] == items
+
+
+def test_batch_composition_is_independent_of_input_order():
+    """Batches must be a pure function of the input: if the order tests arrive
+    in could change the batches, request keys churn between runs and replay
+    misses even though nothing about the review changed."""
+    items = ["c", "a", "e", "b", "d"]
+
+    forward = partition(items, 2, key=str)
+    shuffled = partition(list(reversed(items)), 2, key=str)
+
+    assert _ids(forward) == [["a", "b"], ["c", "d"], ["e"]]
+    assert _ids(shuffled) == _ids(forward)
+
+
+def test_every_batch_reports_the_configured_size_not_its_own_length():
+    """The last batch is short, but the control in force is still the
+    configured size — provenance would otherwise report a size no call ran
+    under whenever the input divided unevenly."""
+    batches = partition(["a", "b", "c"], 2, key=str)
+
+    assert [len(batch.items) for batch in batches] == [2, 1]
+    assert [batch.size for batch in batches] == [2, 2]
+    assert [batch.index for batch in batches] == [0, 1]
+    assert {batch.count for batch in batches} == {2}
+
+
+def test_request_partition_carries_size_only():
+    """`size` is in the request hash because it is a run control. `index` and
+    `count` are deliberately out: the messages already differ per batch, and
+    hashing `count` would invalidate an unchanged early batch's transcript every
+    time an item was appended."""
+    batches = partition(["a", "b", "c"], 2, key=str)
+
+    assert batches[0].request_partition() == {"size": 2}
+    assert batches[1].request_partition() == {"size": 2}
+
+
+def test_changing_the_size_changes_the_descriptor_even_when_batches_match():
+    """Two sizes can yield identical batches when the input is smaller than
+    both. The descriptor must still differ, or changing the control would leave
+    recorded transcripts replaying as if nothing had changed."""
+    small = partition(["a"], 4, key=str)
+    large = partition(["a"], 8, key=str)
+
+    assert _ids(small) == _ids(large)
+    assert small[0].request_partition() != large[0].request_partition()
+
+
+def test_no_items_yields_no_batches():
+    assert partition([], 4, key=str) == []
+
+
+def test_a_size_below_one_is_rejected():
+    with pytest.raises(ValueError, match="at least 1"):
+        partition(["a"], 0, key=str)
+
+
+def test_a_batch_is_immutable():
+    batch = partition(["a", "b"], 2, key=str)[0]
+
+    with pytest.raises(Exception):
+        batch.size = 99


### PR DESCRIPTION
Closes #164 (reopen or leave closed as you prefer — it was auto-closed by
`08d0862`, the §3.2 reframe, which did not implement it).

## The failure

The M4 mapping stage asked one call for tests × obligations relevance
judgments — 1,632 on a review of this repo. It came back schema-valid with an
empty `obligation_ids` list for up to 80 of 96 tests, so every obligation
rendered `unsupported (no mapped test)` and the review reported **the
reviewer's own failure as the user's untested change**. Size was measured and
was not the constraint (2.5% context utilisation); decisions per call were.

## The change

`partition.py` holds the generic mechanism; `evidence/mapping.py` is its only
caller, per DR-164 decision 2 — the diff-dominated stages would pay ~3.8× the
tokens for no measured benefit.

Three things about it are load-bearing and look optional, all covered in
DR-164's new "As built" section:

- **Batches sort their own input** rather than trusting discovery order. Batch
  composition must be a pure function of the input or request keys churn and
  replay misses, and an upstream ordering guarantee is one refactor away from
  being untrue.
- **Only `size` enters the request hash, not `index`/`count`.** `size` must be
  there — two sizes can produce identical batches on small input, so without it
  changing the control would silently replay old recordings. `index`/`count`
  must not be, or appending one test would invalidate an unchanged early
  batch's transcript.
- **A batch may only answer for its own tests.** Otherwise a model echoing a
  neighbour's test gets its duplicate judgment merged, and the result depends
  on which batch answered last.

Provenance reports `request_partition_size` **observed from the calls**, not
read from config — #160's rule. `None` means no partitioned call was made,
which is a different claim from a partition of size one.

## Dogfood

| run | obligations receiving >=1 mapped test |
|---|---|
| DR-164 worst, unpartitioned | **0 of 17** |
| this branch at `142e6cc` | 8 of 9 |
| this branch at `d8cb2b8` | **9 of 9** |

Gate 1 passed (9 obligations, decomposition confirmed). Gate 2 clean at
`d8cb2b8`: `NO-MATERIAL-GAPS`, every obligation strongly supported, open
question resolved, no recommended tests, 7 unrequested changes all
`in_service`. 518 tests, ruff clean.

The first Gate 2 run was **not** clean. Two findings were fair and are fixed in
`d8cb2b8`. The third is a tool defect, filed as #173: an obligation drew eleven
unrelated `test_disposition.py` tests while the on-point test was rejected. It
did not reproduce on the second run, so it is diff-sensitive rather than
stable — see the issue.

## Costs, as budgeted in DR-164

- The mapping transcript corpus was re-recorded; old mapping transcripts are
  dead.
- **Mapping-accuracy figures are not comparable across this change.** Stated at
  all three benchmark surfaces where a reader meets the number, plus the DR,
  and pinned by a test.

M7.5 (#36) was tabled pending this; its dogfood verdict should be trustworthy
now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)