### PR TITLE
chore: add /orient skill for re-orienting after a context reset

### DIFF
--- a/.claude/skills/orient/SKILL.md
+++ b/.claude/skills/orient/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: orient
+description: Re-orient in this repo after a context reset — read CLAUDE.md, session-state.md and current-task.md, check git and the tracking issue, then report where the work stands before touching anything. Use ONLY when the user explicitly invokes /orient. A question about project status, what's left, or what a file does is not a request for this; answer it directly instead.
+---
+
+# Orient after a context reset
+
+Re-orient before doing anything. Do not edit, plan, or run the tool until the
+final step.
+
+## 1. Read, in this order
+
+1. `CLAUDE.md` — conventions, invariants, and the dogfooding gates. Follow it
+   literally; it is the authority on how work happens in this repo.
+2. `session-state.md` — the task in flight. Assume it is accurate; it is the
+   work log, carried across context resets.
+3. `current-task.md` — the mandate under review, in the tool's own input format.
+
+## 2. Check the ground truth
+
+Run `git status` and `git log --oneline -5` so you know the branch and whether
+the tree is dirty.
+
+Then read the GitHub issue named in `session-state.md` for the **Deliverable**
+and **Acceptance** you are working against. GitHub is authoritative for task
+state — the issue is the plan, not any file in the repo (#168).
+
+## 3. Do not
+
+- **Do not read `.acceptance/`.** It is per-run output, regenerated from the
+  current review, and can be stale relative to the report.
+- **Do not edit `current-task.md`** except to reword a genuinely weak
+  obligation — requirement text that is badly worded. Never edit it to change
+  what the review says: suppressing a finding or an open question destroys the
+  only signal that the tool is wrong. Progress notes go in `session-state.md`.
+- **Do not start implementing.** Orienting is the whole job here.
+
+## 4. Then stop and report
+
+Tell the user, briefly:
+
+- Where the work stands — branch, what has landed, what is uncommitted.
+- What remains on the issue's Acceptance check, item by item.
+- What you propose to do next, and why.
+
+Then wait for a go-ahead before editing anything.


### PR DESCRIPTION
Adds `.claude/skills/orient/SKILL.md` — a repeatable startup read-order so a fresh session picks up the task in flight without re-deriving it, or guessing.

## What it does

Reads `CLAUDE.md` → `session-state.md` → `current-task.md`, checks `git status` / recent log, reads the tracking issue named in session state for the Deliverable and Acceptance, then **stops and reports** — where the work stands, what's left on the acceptance check, and what it proposes next — before touching anything.

It also states the two things not to do, both of which are existing `CLAUDE.md` invariants that are easy to lose across a reset: don't read `.acceptance/` (per-run output, regenerable, can contradict the report), and don't edit `current-task.md` except to reword a genuinely weak obligation.

## Two notes on the shape

**Named `orient`, not `reset`.** `/reset` is a built-in alias for `/clear` in Claude Code and can't be overridden. The workflow is two steps: `/reset` to wipe context, then `/orient` to reload the orientation. A slash command can't clear context itself.

**The description is deliberately narrow.** Skills can trigger autonomously when Claude recognizes the situation, which is wrong for this one — a question like "what's left on this issue?" should get answered directly, not trigger a full re-read. The description says explicit invocation only. Worth watching in practice; if it fires unprompted, tighten it further.

Chose `.claude/skills/` over the legacy `.claude/commands/` since the latter may eventually be deprecated. Project-scoped rather than `~/.claude/` so it's versioned alongside `CLAUDE.md`, where the rest of the conventions now live.

## No linked issue

Small enough that filing one first seemed like more ceremony than signal — flagging it since `CLAUDE.md` says one issue per branch and PR. Happy to file one retroactively if you'd rather keep that rule absolute.
