### PR TITLE
Constrain id-bearing response fields to the ids actually supplied (#163)

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,43 +1,51 @@
 # Task
-Make a second review of the same task cheaper and more honest than starting
-over. Today every run is a first run: the checker re-derives every judgment
-from scratch even when the new work could not have touched most of them, and it
-says nothing about what changed since it last looked. Let a review be re-run
-against a new head, starting from the previous review of the same task —
-re-judging the obligations the new work could have affected, keeping the
-judgments it could not have affected, and reporting what closed since last time.
+Make the ids a model hands back verifiable against the ids it was given. Every
+stage that asks the model to echo back an id we supplied types that id as
+free-form text, so an id that does not exist is valid output. Four of those
+stages then discard a foreign id without trace, leaving a result
+indistinguishable from a substantive negative answer — the review reports that
+nothing evidences an obligation when the truth is that the reviewer answered a
+different question. Constrain each id-bearing response field to the ids actually
+supplied for that call, and where an answer still cannot be honoured, record it
+as an answer not obtained rather than as a negative judgment.
 
 ## Constraints
-- A preserved judgment must never be presented as though it were re-derived
-  against the new head. It carries a standing invariant of this tool: a reader
-  can tell what each conclusion rests on.
-- A re-run must not be able to improve a judgment it did not actually
-  re-examine.
+- The set of allowed ids is built per call, from the ids that call itself
+  supplied — not from a fixed list.
+- An id outside the supplied set is never accepted as a judgment about anything.
+- An answer that could not be honoured must not read as a substantive negative
+  answer — "no test evidences this obligation", "no hunk answers this question".
+- One answer that cannot be honoured must not discard the usable judgments
+  returned alongside it.
 
 ## Scope exclusions
-- The checker's inputs are unchanged by this task; it reads what it already
-  reads.
-- The file the checker writes when a review has gaps is superseded by #167 and
-  is not part of this task.
+- Ids the model invents rather than echoes back — the ids assigned to newly
+  decomposed obligations — have no supplied set to constrain them to and are
+  unchanged by this task.
+- Verifying that a quoted span really appears in the task text is a different
+  check against supplied input, and is not part of this task.
+- An empty answer — a model that returns no ids at all — is schema-valid and
+  indistinguishable from a correct negative judgment. No change is attempted
+  here, and none is proposed.
+- Prompt wording is unchanged except where the constraint itself requires it.
 
 ## Completion expectations
 - Implementation
-- A re-run against a new head starts from the previous review of the same task
-  rather than treating the run as a first review.
-- An obligation the new work could not have affected keeps the judgment the
-  previous review reached, instead of being re-derived.
-- An obligation the new work could have affected is judged again against the new
-  head, so a fix made since the previous review is seen.
-- A preserved judgment is marked as carried forward and names the revision it
-  was established against, so a reader can tell it was not re-examined here.
-- The evidence strength of a preserved judgment is the strength the previous
-  review recorded, so a re-run cannot raise a claim it did not re-examine.
-- The review reports what changed since the previous review, including the gaps
-  that closed and the obligations whose status moved.
-- A first review — one with no previous review to build on — reports no such
-  comparison, rather than an empty or misleading one.
-- When no usable previous review exists, the run completes as a first review
-  rather than failing.
-- On the archetype #9 revision cycle, an obligation that the previous review
-  found weakly supported becomes strongly supported once the discriminating
-  test is added, and the completion verdict moves with it.
+- Each model stage that echoes back a supplied id constrains that response field
+  to the ids supplied for that call: test-to-obligation mapping, test
+  recommendation, unrequested-change detection, coverage classification,
+  open-question judgment, and discrimination judgment.
+- The allowed-id set a call carries reflects that call's own supplied ids, so a
+  stage whose request is partitioned constrains each call to its own partition.
+- An id outside the supplied set is not accepted as a judgment, at every one of
+  those stages.
+- An item whose returned id cannot be honoured is recorded as having no usable
+  answer, distinguishably from an item the model judged negatively.
+- An obligation whose judgment could not be honoured is left indeterminate,
+  rather than reported as an obligation lacking evidence.
+- A review holding an indeterminate judgment does not reach a clean completion
+  verdict.
+- The usable judgments returned in the same response as one that cannot be
+  honoured are retained.
+- The review names the stage and the id that could not be honoured, so a reader
+  can tell which judgment was not obtained and why.

--- a/src/acceptance/coverage/classify.py
+++ b/src/acceptance/coverage/classify.py
@@ -22,6 +22,7 @@ from pydantic import Field
 
 from acceptance.coverage.prompt import DiffRef, hunk_labels, render_diff_prompt, resolve_refs
 from acceptance.llm import ModelClient, StrictResponseModel
+from acceptance.supplied_ids import UnusableAnswerLog, constrain, scan
 from acceptance.model_base import PersistableModel
 from acceptance.review_state import ChangeSet, Obligation
 
@@ -46,6 +47,8 @@ class ImplementationCoverage(PersistableModel):
     rationale: str
     diff_refs: list[DiffRef] = Field(default_factory=list)
 
+
+_STAGE = "coverage classification"
 
 _SYSTEM_PROMPT = """\
 You classify how a code diff addresses each acceptance obligation. This is
@@ -107,7 +110,10 @@ class _Coverage(StrictResponseModel):
 
 
 def classify_coverage(
-    obligations: list[Obligation], change_set: ChangeSet, client: ModelClient
+    obligations: list[Obligation],
+    change_set: ChangeSet,
+    client: ModelClient,
+    unusable: UnusableAnswerLog | None = None,
 ) -> list[ImplementationCoverage]:
     """Classify each obligation against the change set (implementation coverage)."""
     label_to_ref = hunk_labels(change_set)
@@ -115,7 +121,13 @@ def classify_coverage(
         {"role": "system", "content": _SYSTEM_PROMPT},
         {"role": "user", "content": render_diff_prompt(obligations, change_set)},
     ]
-    result = client.complete(messages, _Coverage)
+    allowed = {
+        "obligation_id": [obligation.id for obligation in obligations],
+        "diff_refs": list(label_to_ref),
+    }
+    result = client.complete(messages, constrain(_Coverage, allowed), parse_as=_Coverage)
+    if unusable is not None:
+        unusable.record(scan(result, allowed, _STAGE))
 
     by_id = {c.obligation_id: c for c in result.classifications}
     coverages = []

--- a/src/acceptance/coverage/open_questions.py
+++ b/src/acceptance/coverage/open_questions.py
@@ -23,8 +23,11 @@ from pydantic import Field
 
 from acceptance.coverage.prompt import DiffRef, hunk_labels, render_diff_section, resolve_refs
 from acceptance.llm import ModelClient, StrictResponseModel
+from acceptance.supplied_ids import UnusableAnswerLog, constrain, scan
 from acceptance.model_base import PersistableModel
 from acceptance.review_state import ChangeSet, Link, OpenQuestion
+
+_STAGE = "open-question judgment"
 
 _SYSTEM_PROMPT = """\
 You judge whether a code diff resolves an OPEN QUESTION raised about a task —
@@ -77,7 +80,10 @@ def _render_prompt(open_questions: list[OpenQuestion], change_set: ChangeSet) ->
 
 
 def resolve_open_questions(
-    open_questions: list[OpenQuestion], change_set: ChangeSet, client: ModelClient
+    open_questions: list[OpenQuestion],
+    change_set: ChangeSet,
+    client: ModelClient,
+    unusable: UnusableAnswerLog | None = None,
 ) -> list[OpenQuestionResolution]:
     """Judge each open question against the diff: resolved (with citation) or
     still open. No open questions -> no model call."""
@@ -89,7 +95,15 @@ def resolve_open_questions(
         {"role": "system", "content": _SYSTEM_PROMPT},
         {"role": "user", "content": _render_prompt(open_questions, change_set)},
     ]
-    result = client.complete(messages, _Judgments)
+    allowed = {
+        "question_id": [question.id for question in open_questions],
+        "diff_refs": list(label_to_ref),
+    }
+    result = client.complete(
+        messages, constrain(_Judgments, allowed), parse_as=_Judgments
+    )
+    if unusable is not None:
+        unusable.record(scan(result, allowed, _STAGE))
 
     valid_ids = {q.id for q in open_questions}
     judged_ids: set[str] = set()

--- a/src/acceptance/coverage/recommendations.py
+++ b/src/acceptance/coverage/recommendations.py
@@ -25,12 +25,15 @@ from __future__ import annotations
 from acceptance.coverage.prompt import render_diff_section
 from acceptance.evidence.discrimination import ObligationDiscrimination
 from acceptance.llm import ModelClient, StrictResponseModel
+from acceptance.supplied_ids import UnusableAnswerLog, constrain, scan
 from acceptance.review_state import ChangeSet, Obligation, TestRecommendation
 
 # §9.3 classes that represent a real evidence gap — anything short of
 # strongly_supported earns a recommendation (the M7.1 trigger). An obligation
 # with no evidence_class set yet (not classified) is not recommended for here.
 _STRONG = "strongly_supported"
+
+_STAGE = "test recommendation"
 
 _SYSTEM_PROMPT = """\
 You prescribe ADDITIONAL TESTS for criteria whose current test evidence is
@@ -110,6 +113,7 @@ def recommend_tests(
     discriminations: list[ObligationDiscrimination],
     change_set: ChangeSet,
     client: ModelClient,
+    unusable: UnusableAnswerLog | None = None,
 ) -> list[TestRecommendation]:
     """Prescribe a §9.5 test recommendation for each not-strongly-supported
     obligation. No weak obligations -> no model call."""
@@ -125,7 +129,15 @@ def recommend_tests(
             "content": _render_prompt(weak, discriminations_by_obligation, change_set),
         },
     ]
-    result = client.complete(messages, _Recommendations)
+    # Only the WEAK obligations are supplied — those are the ones the call is
+    # about, so a recommendation for any other obligation is unusable by
+    # construction, not merely unmatched.
+    allowed = {"obligation_id": [obligation.id for obligation in weak]}
+    result = client.complete(
+        messages, constrain(_Recommendations, allowed), parse_as=_Recommendations
+    )
+    if unusable is not None:
+        unusable.record(scan(result, allowed, _STAGE))
 
     criterion_by_id = {
         obligation.id: (obligation.observable_behavior or obligation.description)

--- a/src/acceptance/coverage/unrequested.py
+++ b/src/acceptance/coverage/unrequested.py
@@ -28,6 +28,7 @@ from pydantic import Field
 
 from acceptance.coverage.prompt import DiffRef, hunk_labels, render_diff_prompt, resolve_refs
 from acceptance.llm import ModelClient, StrictResponseModel
+from acceptance.supplied_ids import UnusableAnswerLog, constrain, scan
 from acceptance.model_base import PersistableModel
 from acceptance.review_state import ChangeSet, Obligation
 
@@ -47,6 +48,8 @@ class UnrequestedChange(PersistableModel):
     rationale: str
     diff_refs: list[DiffRef] = Field(default_factory=list)
 
+
+_STAGE = "unrequested-change detection"
 
 _SYSTEM_PROMPT = """\
 You find UNREQUESTED changes: diff regions that no listed obligation calls for.
@@ -92,7 +95,10 @@ class _Detections(StrictResponseModel):
 
 
 def detect_unrequested_changes(
-    obligations: list[Obligation], change_set: ChangeSet, client: ModelClient
+    obligations: list[Obligation],
+    change_set: ChangeSet,
+    client: ModelClient,
+    unusable: UnusableAnswerLog | None = None,
 ) -> list[UnrequestedChange]:
     """Flag diff regions no obligation calls for as candidate unrequested changes."""
     label_to_ref = hunk_labels(change_set)
@@ -100,7 +106,12 @@ def detect_unrequested_changes(
         {"role": "system", "content": _SYSTEM_PROMPT},
         {"role": "user", "content": render_diff_prompt(obligations, change_set)},
     ]
-    result = client.complete(messages, _Detections)
+    allowed = {"diff_refs": list(label_to_ref)}
+    result = client.complete(
+        messages, constrain(_Detections, allowed), parse_as=_Detections
+    )
+    if unusable is not None:
+        unusable.record(scan(result, allowed, _STAGE))
 
     changes = []
     for detected in result.unrequested_changes:

--- a/src/acceptance/evidence/discrimination.py
+++ b/src/acceptance/evidence/discrimination.py
@@ -24,8 +24,11 @@ the predictions by execution.
 from __future__ import annotations
 
 from acceptance.llm import ModelClient, StrictResponseModel
+from acceptance.supplied_ids import UnusableAnswerLog, constrain, scan
 from acceptance.model_base import PersistableModel
 from acceptance.review_state import ChangeSet, Obligation, TestEvidence
+
+_STAGE = "discrimination judgment"
 
 _SYSTEM_PROMPT = """\
 You judge whether a criterion's mapped tests would actually FAIL if the
@@ -132,6 +135,7 @@ def judge_discrimination(
     test_evidence: list[TestEvidence],
     change_set: ChangeSet,
     client: ModelClient,
+    unusable: UnusableAnswerLog | None = None,
 ) -> list[ObligationDiscrimination]:
     """Judge, per criterion with mapped tests, whether those tests would fail
     under a plausible defect (§9.3). Criteria with no mapped test are not
@@ -151,7 +155,19 @@ def judge_discrimination(
             "content": _render_prompt(obligations, evidence_by_obligation, change_set),
         },
     ]
-    result = client.complete(messages, _Discrimination)
+    allowed = {"obligation_id": list(evidence_by_obligation)}
+    result = client.complete(
+        messages, constrain(_Discrimination, allowed), parse_as=_Discrimination
+    )
+    if unusable is not None and unusable.record(scan(result, allowed, _STAGE)):
+        # An obligation we asked about but got no usable judgment for is not
+        # "no defect survives" — it is a judgment we never obtained. Saying
+        # otherwise would let a re-run claim discrimination it never assessed.
+        unusable.mark_indeterminate(
+            obligation_id
+            for obligation_id in evidence_by_obligation
+            if obligation_id not in {item.obligation_id for item in result.obligations}
+        )
 
     returned = {
         item.obligation_id: item.defects

--- a/src/acceptance/evidence/mapping.py
+++ b/src/acceptance/evidence/mapping.py
@@ -25,6 +25,9 @@ from acceptance.llm import ModelClient, StrictResponseModel
 from acceptance.model_base import PersistableModel
 from acceptance.partition import partition
 from acceptance.review_state import Obligation
+from acceptance.supplied_ids import UnusableAnswer, UnusableAnswerLog, constrain, scan
+
+_STAGE = "test-to-obligation mapping"
 
 _SYSTEM_PROMPT = """\
 You map each candidate test to the acceptance obligation(s) it PURPORTS to
@@ -63,6 +66,11 @@ class TestMapping(PersistableModel):
 class MappingResult(PersistableModel):
     mappings: list[TestMapping]
     unmapped_obligation_ids: list[str]  # obligations no test purports to evidence
+    # Obligations whose mapping could not be honoured. Disjoint from
+    # `unmapped_obligation_ids` in meaning: unmapped is a substantive negative
+    # answer, this is the absence of an answer.
+    indeterminate_obligation_ids: list[str] = []
+    unusable_answers: list[UnusableAnswer] = []
 
 
 class _TestMapping(StrictResponseModel):
@@ -95,6 +103,7 @@ def map_tests_to_obligations(
     tests: list[DiscoveredTest],
     client: ModelClient,
     batch_size: int = DEFAULT_MAPPING_BATCH_SIZE,
+    unusable: UnusableAnswerLog | None = None,
 ) -> MappingResult:
     """Map each candidate test to the obligation(s) it purports to evidence.
 
@@ -112,22 +121,39 @@ def map_tests_to_obligations(
     mapped_obligation_ids: set[str] = set()
     mappings: list[TestMapping] = []
     seen_test_ids: set[str] = set()
+    unusable_answers: list[UnusableAnswer] = []
 
     for batch in partition(tests, batch_size, key=lambda test: test.test_id):
+        batch_test_ids = [test.test_id for test in batch.items]
         messages = [
             {"role": "system", "content": _SYSTEM_PROMPT},
             {"role": "user", "content": _render_prompt(obligations, list(batch.items))},
         ]
-        result = client.complete(messages, _Mappings, batch.request_partition())
+        # Asked for with the ids of THIS batch: every obligation (each batch
+        # judges all of them) but only this batch's tests. Parsed permissively so
+        # one unusable id costs one judgment, not the whole batch — see
+        # `supplied_ids`.
+        allowed = {
+            "test_id": batch_test_ids,
+            "obligation_ids": sorted(valid_obligation_ids),
+        }
+        result = client.complete(
+            messages,
+            constrain(_Mappings, allowed),
+            batch.request_partition(),
+            parse_as=_Mappings,
+        )
 
-        # A batch may only speak for its own tests. Without this, a model that
-        # echoes tests from a neighbouring batch would have its duplicate
-        # judgment merged in alongside the real one, and the merged mapping
-        # would depend on which batch answered last.
-        batch_test_ids = {test.test_id for test in batch.items}
+        unusable_answers.extend(scan(result, allowed, _STAGE))
+
+        batch_test_id_set = set(batch_test_ids)
         for mapping in result.mappings:
-            if mapping.test_id not in batch_test_ids:
-                continue  # not a candidate in this batch — drop it
+            # A batch may only speak for its own tests. Without this, a model that
+            # echoes tests from a neighbouring batch would have its duplicate
+            # judgment merged in alongside the real one, and the merged mapping
+            # would depend on which batch answered last.
+            if mapping.test_id not in batch_test_id_set:
+                continue
             if mapping.test_id in seen_test_ids:
                 continue  # already judged, in its own batch
             seen_test_ids.add(mapping.test_id)
@@ -147,6 +173,23 @@ def map_tests_to_obligations(
     # which judgments came back and not on the order the batches returned them.
     mappings.sort(key=lambda mapping: mapping.test_id)
     unmapped = sorted(valid_obligation_ids - mapped_obligation_ids)
+
+    # An obligation that ended up unmapped, in a run where some answer could not
+    # be honoured, is INDETERMINATE rather than unmapped. Every batch judges every
+    # obligation, so the answer that would have mapped it may be exactly the one
+    # we could not read — and "no test evidences this" is a substantive claim we
+    # are no longer entitled to make. An obligation that WAS mapped keeps its
+    # judgment: that is a positive answer we could honour.
+    if unusable_answers:
+        if unusable is not None:
+            unusable.record(unusable_answers)
+            unusable.mark_indeterminate(unmapped)
+        return MappingResult(
+            mappings=mappings,
+            unmapped_obligation_ids=[],
+            indeterminate_obligation_ids=unmapped,
+            unusable_answers=unusable_answers,
+        )
     return MappingResult(mappings=mappings, unmapped_obligation_ids=unmapped)
 
 

--- a/src/acceptance/llm.py
+++ b/src/acceptance/llm.py
@@ -122,6 +122,28 @@ def _default_completion_fn(**kwargs: Any) -> Any:
     return litellm.completion(drop_params=True, **kwargs)
 
 
+def _const_to_enum(node: Any) -> Any:
+    """Rewrite `{"const": x}` as `{"enum": [x]}`.
+
+    Pydantic emits `const` for a single-valued `Literal`, which is what a
+    constrained id field collapses to whenever a call supplies exactly one id
+    (#163) — a one-obligation task, or the last partition of a batch. The two
+    are equivalent in JSON Schema, but `enum` is the form providers actually
+    honour under strict decoding, so a one-id call would otherwise be the one
+    case where the constraint quietly stopped binding.
+    """
+    if isinstance(node, dict):
+        rewritten = {
+            key: _const_to_enum(value) for key, value in node.items() if key != "const"
+        }
+        if "const" in node:
+            rewritten["enum"] = [node["const"]]
+        return rewritten
+    if isinstance(node, list):
+        return [_const_to_enum(item) for item in node]
+    return node
+
+
 def inline_schema_refs(schema: dict) -> dict:
     """Resolve every `$ref` against `$defs` and drop the definitions block.
 
@@ -148,7 +170,7 @@ def inline_schema_refs(schema: dict) -> dict:
             return [resolve(item, defs) for item in node]
         return node
 
-    return resolve(schema, schema.get("$defs", {}))
+    return _const_to_enum(resolve(schema, schema.get("$defs", {})))
 
 
 def _litellm_effective_controls(model: str, **requested: Any) -> dict[str, Any]:
@@ -275,8 +297,21 @@ class ModelClient:
         messages: list[dict],
         response_model: type[ResponseModelT],
         partition: dict[str, Any] | None = None,
+        parse_as: type[BaseModel] | None = None,
     ) -> ResponseModelT:
-        """Return a validated `response_model`, from a live call or a transcript."""
+        """Return a validated response, from a live call or a transcript.
+
+        `response_model` is what we *ask* for — it is the schema sent to the
+        provider and hashed into the request key. `parse_as` is what we *accept*,
+        and defaults to the same model.
+
+        The two differ only where a stage constrains id fields to the ids it
+        supplied (#163). There the request carries an enum so a foreign id is
+        unrepresentable, while parsing stays permissive so that a provider which
+        ignored the enum yields one unusable item to record rather than a
+        `SchemaValidationError` that discards every judgment in the batch. The
+        stage then checks the ids itself — see `supplied_ids`.
+        """
         request = self.build_request(messages, response_model, partition)
         key = request_key(request)
         record = self.store.read(key)
@@ -297,7 +332,7 @@ class ModelClient:
                     "Recording makes live calls AND runs the assertions, so a prompt "
                     "that degrades quality fails rather than silently re-recording."
                 )
-            record = self._persist_live_call(key, request, response_model)
+            record = self._persist_live_call(key, request, parse_as or response_model)
 
         # Observed on both paths: a replayed run's reproducibility is exactly
         # that of the recording it replays, so a transcript recorded against a
@@ -305,7 +340,7 @@ class ModelClient:
         self._observed_controls.append(record.get("controls_applied"))
         if partition is not None:
             self._observed_partitions.append(partition)
-        return self._validate(record["response"], response_model)
+        return self._validate(record["response"], parse_as or response_model)  # type: ignore[arg-type]
 
     @property
     def controls_in_force(self) -> dict[str, Any] | None:
@@ -356,6 +391,11 @@ class ModelClient:
         response schema. Persisting before validating let one of those replies
         into the corpus, where replay would serve it forever (#160). A response
         the harness rejects is not evidence and must not be stored.
+
+        The gate is `parse_as` — what we *accept* — not the constrained schema we
+        asked for. Gating on the constraint would refuse to record the very
+        replies that prove a provider ignores it, and would make RECORD and
+        REPLAY disagree about the same response (#163).
         """
         record = self._live_call(key, request)
         self._validate(record["response"], response_model)

--- a/src/acceptance/pipeline.py
+++ b/src/acceptance/pipeline.py
@@ -47,6 +47,7 @@ from acceptance.evidence.discrimination import judge_discrimination
 from acceptance.evidence.extraction import extract_test_evidence
 from acceptance.evidence.mapping import apply_test_mapping, map_tests_to_obligations
 from acceptance.evidence.strength import apply_evidence_strength, classify_strength
+from acceptance.supplied_ids import UnusableAnswer, UnusableAnswerLog
 from acceptance.evidence_tier import Component, EvidenceTier
 from acceptance.llm import ModelClient
 from acceptance.requirement.declaration import declaration_absent_finding, parse_declaration
@@ -54,6 +55,7 @@ from acceptance.requirement.obligations import decompose
 from acceptance.requirement.task_file import parse_task_file
 from acceptance.review_state import (
     UNREQUESTED_CHANGE,
+    UNUSABLE_ANSWER,
     ChangeSet,
     Finding,
     Link,
@@ -95,6 +97,49 @@ def coverage_finding(obligation: Obligation, coverage: ImplementationCoverage) -
         produced_by=Component.STATIC_ANALYZER,
         links=links,
         related_obligation=obligation.description,
+    )
+
+
+def _apply_indeterminate(
+    obligations: list[Obligation], unusable: UnusableAnswerLog
+) -> list[Obligation]:
+    """Mark obligations whose judgment was never obtained as `indeterminate`.
+
+    Only the evidence axis: `indeterminate` says "we did not obtain this
+    judgment", which is exactly what an unusable answer means. `verdict.py`
+    already routes it to `unable_to_determine` and lists it as an escalation
+    candidate, so a review that could not read part of its own reviewer cannot
+    come back clean.
+    """
+    if not unusable.indeterminate_obligations:
+        return obligations
+    return [
+        obligation.model_copy(update={"evidence_class": "indeterminate"})
+        if obligation.id in unusable.indeterminate_obligations
+        else obligation
+        for obligation in obligations
+    ]
+
+
+def unusable_answer_finding(answer: UnusableAnswer) -> Finding:
+    """Name the stage and the id, so a reader can tell which judgment is missing.
+
+    Deliberately not advisory. An unrequested change or a declaration overclaim
+    is about the delivered work and leaves the verdict alone; this is about the
+    review itself failing to answer a question it asked, which is precisely the
+    thing a reader must not mistake for a clean result.
+    """
+    return Finding(
+        type=UNUSABLE_ANSWER,
+        severity="major",
+        description=(
+            f"The {answer.stage} stage returned {answer.returned_id!r} for "
+            f"{answer.field!r}, which was never supplied to that call. The "
+            "judgment it was meant to carry was not obtained."
+        ),
+        evidence_tier=EvidenceTier.STATIC,
+        produced_by=Component.STATIC_ANALYZER,
+        links=[Link(kind="requirement", ref=answer.returned_id, text=answer.stage)],
     )
 
 
@@ -181,26 +226,41 @@ def run_review(
     if prior is not None:
         obligations = obligations_to_rederive(fresh_obligations, prior, change_set)
 
+    # One log for the whole run: every stage that asks the model to echo back an
+    # id we supplied reports the ids it could not honour here (#163).
+    unusable = UnusableAnswerLog()
+
     discovered = discover_tests(repo, change_set)
     mapping = map_tests_to_obligations(
-        obligations, discovered.tests, client, mapping_batch_size
+        obligations, discovered.tests, client, mapping_batch_size, unusable
     )
     obligations = apply_test_mapping(obligations, mapping)
 
     test_evidence = extract_test_evidence(repo, discovered.tests, change_set, mapping)
-    discriminations = judge_discrimination(obligations, test_evidence, change_set, client)
+    discriminations = judge_discrimination(
+        obligations, test_evidence, change_set, client, unusable
+    )
     strengths = classify_strength(obligations, test_evidence, discriminations)
     obligations = apply_evidence_strength(obligations, strengths)
+    # After strength, deliberately: an obligation whose judgment was never
+    # obtained must not carry the strength the classifier inferred from its
+    # absence. A re-run cannot improve a judgment it did not re-examine, and
+    # neither can a first run claim one it never made.
+    obligations = _apply_indeterminate(obligations, unusable)
 
-    coverages = classify_coverage(obligations, change_set, client)
+    coverages = classify_coverage(obligations, change_set, client, unusable)
     obligations = _apply_coverage_status(obligations, coverages)
-    unrequested = detect_unrequested_changes(obligations, change_set, client)
+    unrequested = detect_unrequested_changes(obligations, change_set, client, unusable)
     dispositioned = classify_dispositions(
         unrequested, obligations, coverages, change_set, policy, client
     )
-    resolutions = resolve_open_questions(decomposition.open_questions, change_set, client)
+    resolutions = resolve_open_questions(
+        decomposition.open_questions, change_set, client, unusable
+    )
     open_questions = apply_open_question_resolutions(decomposition.open_questions, resolutions)
-    recommendations = recommend_tests(obligations, discriminations, change_set, client)
+    recommendations = recommend_tests(
+        obligations, discriminations, change_set, client, unusable
+    )
 
     obligations_by_id = {obligation.id: obligation for obligation in obligations}
     findings = [
@@ -226,6 +286,7 @@ def run_review(
         for finding in (unrequested_finding(change) for change in dispositioned)
         if finding is not None
     )
+    findings.extend(unusable_answer_finding(answer) for answer in unusable.answers)
 
     if declaration_text is not None:
         declaration = parse_declaration(declaration_text)

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -86,6 +86,13 @@ DECLARATION_ABSENT = "declaration_absent"
 # e.g. a claimed behavior the code doesn't implement and no test exercises.
 DECLARATION_MISMATCH = "declaration_mismatch"
 
+# The canonical `Finding.type` for a model answer that named an id we never
+# supplied (#163). It is a fact about the review's own machinery, not about the
+# delivered code — but it is never advisory: it means a judgment we asked for was
+# not obtained, and the affected obligation is left `indeterminate` so the
+# verdict cannot come back clean on a question that was never actually answered.
+UNUSABLE_ANSWER = "unusable_answer"
+
 # Finding types allowed to be obligation-less (related_obligation is None).
 # Almost every finding is *about* an obligation and must name it; an
 # unrequested change is the code→obligation dual and is obligation-less by
@@ -94,9 +101,11 @@ DECLARATION_MISMATCH = "declaration_mismatch"
 # claim matching neither the task nor the code — obligation-less too, and
 # advisory / low-weight on the verdict, since nothing was actually mis-delivered
 # in the code (M6.2, issue #31); distinct from an unrequested change, which is
-# real code that *was* changed.
+# real code that *was* changed. An unusable answer is obligation-less when the id
+# the model returned belongs to no obligation we supplied — which is the whole
+# point of the finding, so it cannot be required to name one (#163).
 _OBLIGATION_LESS_TYPES = frozenset(
-    {UNREQUESTED_CHANGE, DECLARATION_ABSENT, DECLARATION_MISMATCH}
+    {UNREQUESTED_CHANGE, DECLARATION_ABSENT, DECLARATION_MISMATCH, UNUSABLE_ANSWER}
 )
 
 

--- a/src/acceptance/supplied_ids.py
+++ b/src/acceptance/supplied_ids.py
@@ -1,0 +1,207 @@
+"""Holding a model to the ids it was given (#163).
+
+Several stages paste a set of ids into the prompt — obligation ids, test ids,
+diff-hunk labels — and ask the model to echo the relevant ones back. Typed as
+free-form `str`, an id that does not exist is valid output. The mapping stage
+once answered about obligations it had read out of the *test sources* pasted
+into its own prompt; the foreign ids were then filtered out silently, leaving a
+result indistinguishable from "no test evidences any obligation". The review
+told the reader their change was untested when the truth was that the reviewer
+had answered a different question.
+
+Two mechanisms, deliberately separate:
+
+- `constrain` puts the supplied ids into the response schema as an enum, built
+  per call. Under constrained decoding a foreign id is not merely detected but
+  **unrepresentable** — the tokens are not available. This is the enforcement,
+  and it is the #158 lesson applied one level further: encode the constraint
+  where the model is bound by it, not in the prose.
+- `unsupplied` checks returned ids against the supplied set locally. This is
+  detection, and it is not redundant with the schema. The harness routes through
+  LiteLLM with `drop_params=True` precisely so it can run against providers whose
+  structured-output support differs, and a provider that ignores the enum would
+  otherwise put us straight back where we started.
+
+The local check is deliberately **per item**. `ModelClient._validate` parses the
+whole response object, so constraining the model it parses *with* would turn one
+bad id in a 96-entry batch into an aborted review, discarding the 95 usable
+judgments that came back alongside it. Hence the `parse_as` seam on
+`ModelClient.complete`: the constrained schema is what we ask for, a permissive
+one is what we parse with, and the difference between them is recorded rather
+than dropped. Dropping is what made the original defect invisible.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Container, Iterable, Mapping, Sequence
+from typing import Any, Literal, TypeVar, get_args, get_origin
+
+from pydantic import BaseModel, create_model
+
+ModelT = TypeVar("ModelT", bound=BaseModel)
+
+
+def _literal(ids: Sequence[str]) -> Any:
+    return Literal[tuple(ids)]  # type: ignore[valid-type]
+
+
+def _constrained_field(annotation: Any, ids: Sequence[str]) -> Any:
+    """`str` -> one supplied id; `list[str]` -> a list of supplied ids."""
+    if annotation is str:
+        return _literal(ids)
+    if get_origin(annotation) is list and get_args(annotation) == (str,):
+        return list[_literal(ids)]  # type: ignore[misc]
+    raise TypeError(
+        f"cannot constrain a field annotated {annotation!r}: "
+        "expected `str` or `list[str]`"
+    )
+
+
+def _constrained_nested(annotation: Any, allowed: Mapping[str, Sequence[str]]) -> Any:
+    """Constrain id fields on a nested response model; None if nothing changed.
+
+    The id fields live on the *item* model (`_TestMapping.obligation_ids`), not
+    on the container the call returns (`_Mappings.mappings`), so the walk has to
+    descend rather than look only at top-level fields.
+    """
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        nested = constrain(annotation, allowed)
+        return None if nested is annotation else nested
+    if get_origin(annotation) is list:
+        args = get_args(annotation)
+        item = args[0] if args else None
+        if isinstance(item, type) and issubclass(item, BaseModel):
+            nested = constrain(item, allowed)
+            return None if nested is item else list[nested]  # type: ignore[valid-type]
+    return None
+
+
+def constrain(model: type[ModelT], allowed: Mapping[str, Sequence[str]]) -> type[ModelT]:
+    """Return `model` with each named id field restricted to the ids supplied.
+
+    `allowed` maps a field name to the ids that call actually supplied — built
+    per call, never from a fixed list, so a partitioned stage constrains each
+    call to its own partition.
+
+    A field whose supplied set is **empty** is left unconstrained: `Literal[]` is
+    not a type, and a call that offered no ids has nothing to enforce. The
+    guarantee degrades to `unsupplied`'s local detection rather than vanishing.
+
+    The result is a subclass, so it satisfies every use of the original model,
+    and it deliberately keeps the same `__name__`: that name is the schema name
+    in the request, which the transcript key hashes and the test doubles
+    dispatch on.
+    """
+    overrides: dict[str, Any] = {}
+    for name, field in model.model_fields.items():
+        if name in allowed:
+            ids = list(allowed[name])
+            if ids:
+                overrides[name] = (_constrained_field(field.annotation, ids), ...)
+            continue
+        nested = _constrained_nested(field.annotation, allowed)
+        if nested is not None:
+            overrides[name] = (nested, ...)
+    if not overrides:
+        return model
+    return create_model(model.__name__, __base__=model, **overrides)
+
+
+class UnusableAnswer(BaseModel):
+    """A returned id that was never supplied to the call that returned it.
+
+    Kept rather than dropped: an id we cannot honour means the judgment we asked
+    for was not obtained, which is a different thing from the model considering
+    the question and answering it negatively. Dropping the two together is what
+    made the original defect invisible.
+    """
+
+    stage: str
+    field: str
+    returned_id: str
+
+
+class UnusableAnswerLog:
+    """Unusable answers accumulated across the stages of one review run.
+
+    Passed down rather than returned because six stages produce these and their
+    return types are otherwise unrelated; an optional accumulator keeps each
+    signature additive. The pipeline owns the instance, so a stage cannot quietly
+    decline to report — and a test that the pipeline actually passes one is part
+    of this task's wiring, not an extra.
+    """
+
+    def __init__(self) -> None:
+        self.answers: list[UnusableAnswer] = []
+        self.indeterminate_obligations: set[str] = set()
+
+    def record(self, answers: Iterable[UnusableAnswer]) -> list[UnusableAnswer]:
+        found = list(answers)
+        self.answers.extend(found)
+        return found
+
+    def mark_indeterminate(self, obligation_ids: Iterable[str]) -> None:
+        """Obligations whose judgment was not obtained, so it cannot be reported
+        as a substantive finding about their evidence."""
+        self.indeterminate_obligations.update(obligation_ids)
+
+    def __bool__(self) -> bool:
+        return bool(self.answers)
+
+
+def scan(
+    response: BaseModel,
+    allowed: Mapping[str, Sequence[str]],
+    stage: str,
+) -> list[UnusableAnswer]:
+    """Every id in `response` that `allowed` never supplied, in traversal order.
+
+    Walks the whole response tree so it finds id fields on nested item models,
+    which is where they all live — the container a call returns holds a list of
+    judgments, and the ids are on the judgments.
+
+    This is the detection half of the guarantee, and it runs even when
+    `constrain` already put the ids in the schema: `constrain` binds providers
+    that honour structured output, and the harness deliberately runs against
+    providers whose support differs.
+    """
+    supplied = {field: set(ids) for field, ids in allowed.items()}
+    found: list[UnusableAnswer] = []
+    seen: set[tuple[str, str]] = set()
+
+    def visit(node: Any) -> None:
+        if isinstance(node, BaseModel):
+            for name, _ in type(node).model_fields.items():
+                value = getattr(node, name)
+                if name in supplied:
+                    values = value if isinstance(value, list) else [value]
+                    for item in values:
+                        if isinstance(item, str) and item not in supplied[name]:
+                            if (name, item) not in seen:
+                                seen.add((name, item))
+                                found.append(
+                                    UnusableAnswer(
+                                        stage=stage, field=name, returned_id=item
+                                    )
+                                )
+                else:
+                    visit(value)
+        elif isinstance(node, list):
+            for item in node:
+                visit(item)
+
+    visit(response)
+    return found
+
+
+def unsupplied(values: Iterable[str], supplied: Container[str]) -> list[str]:
+    """The returned ids that were never supplied, in first-seen order.
+
+    Order is stable rather than sorted-by-accident because it reaches the report,
+    and two recorded runs over the same input must be byte-identical (M0.5).
+    """
+    seen: dict[str, None] = {}
+    for value in values:
+        if value not in supplied:
+            seen.setdefault(value, None)
+    return list(seen)

--- a/tests/support.py
+++ b/tests/support.py
@@ -74,6 +74,30 @@ def client_answering_per_call(
     return client, calls
 
 
+def client_capturing_schemas(
+    response: dict, model: str = _DEFAULT_MODEL
+) -> tuple[ModelClient, list[dict]]:
+    """A client returning a fixed response, recording the schema each call sent.
+
+    The response schema is now part of what a stage produces, not just plumbing:
+    the ids a call supplies are constrained there, so "the constraint reached the
+    provider" is only assertable by looking at the schema actually sent (#163).
+    """
+    schemas: list[dict] = []
+
+    def completion_fn(**kwargs):
+        schemas.append(kwargs["response_format"]["json_schema"]["schema"])
+        return _fake_response(json.dumps(response))
+
+    client = ModelClient(
+        model=model,
+        mode=Mode.RECORD,
+        store=TranscriptStore(tempfile.mkdtemp()),
+        completion_fn=completion_fn,
+    )
+    return client, schemas
+
+
 def make_obligation(obligation_id: str, description: str, typ: ObligationType) -> Obligation:
     """A minimal but valid Obligation for tests that don't exercise its
     importance/explicitness/observable-behavior fields directly."""

--- a/tests/test_supplied_ids.py
+++ b/tests/test_supplied_ids.py
@@ -1,0 +1,408 @@
+"""Holding a model to the ids it was given (#163).
+
+The defect these cover, observed in a real run: the mapping call returned 96
+entries naming obligations that belonged to a fixture pasted into its own
+prompt, and the foreign ids were filtered out silently — leaving a result
+indistinguishable from "no test evidences any obligation". The review told the
+reader their change was untested when the reviewer had answered a different
+question.
+
+Two guarantees, tested separately because they fail separately: the ids are in
+the SCHEMA (so a foreign id is unrepresentable), and an id we still cannot
+honour is RECORDED rather than dropped.
+"""
+
+import json
+
+from acceptance.evidence.discovery import DiscoveredTest, DiscoveryReason
+from acceptance.evidence.mapping import map_tests_to_obligations
+from acceptance.llm import StrictResponseModel, inline_schema_refs
+from acceptance.review_state import ObligationType
+from acceptance.supplied_ids import UnusableAnswerLog, constrain, scan, unsupplied
+from tests.support import client_capturing_schemas, client_returning, make_obligation
+
+
+class _Item(StrictResponseModel):
+    obligation_id: str
+    obligation_ids: list[str]
+    rationale: str
+
+
+class _Container(StrictResponseModel):
+    items: list[_Item]
+
+
+def _test(test_id: str, source: str = "def t():\n    pass") -> DiscoveredTest:
+    return DiscoveredTest(
+        test_id=test_id,
+        file=test_id.split("::", 1)[0],
+        reasons=[DiscoveryReason.CALLS_CHANGED_SYMBOL],
+        source=source,
+    )
+
+
+# --- the schema constraint (prevention) ---
+
+
+def test_supplied_ids_become_an_enum_on_the_field_the_model_sees():
+    """The whole point: the constraint lives in the schema, not the prose.
+
+    Asserted on the INLINED schema because that is what actually reaches the
+    provider — #158 established that enum values behind a `$ref` measurably
+    change the answer, so a constraint the model only sees one indirection away
+    is not a constraint.
+    """
+    constrained = constrain(_Container, {"obligation_id": ["ob-1", "ob-2"]})
+    schema = inline_schema_refs(constrained.model_json_schema())
+
+    field = schema["properties"]["items"]["items"]["properties"]["obligation_id"]
+    assert field["enum"] == ["ob-1", "ob-2"]
+    assert "$defs" not in json.dumps(schema)
+
+
+def test_a_list_valued_id_field_constrains_its_items():
+    constrained = constrain(_Container, {"obligation_ids": ["ob-1"]})
+    schema = inline_schema_refs(constrained.model_json_schema())
+
+    field = schema["properties"]["items"]["items"]["properties"]["obligation_ids"]
+    assert field["items"]["enum"] == ["ob-1"]
+
+
+def test_a_foreign_id_does_not_validate_against_the_constrained_schema():
+    constrained = constrain(_Container, {"obligation_id": ["ob-1"]})
+
+    ok = constrained.model_validate_json(
+        '{"items":[{"obligation_id":"ob-1","obligation_ids":[],"rationale":"r"}]}'
+    )
+    assert ok.items[0].obligation_id == "ob-1"
+
+    try:
+        constrained.model_validate_json(
+            '{"items":[{"obligation_id":"show-fields","obligation_ids":[],"rationale":"r"}]}'
+        )
+    except Exception as exc:
+        assert "show-fields" in str(exc)
+    else:
+        raise AssertionError("a foreign id validated against the constrained schema")
+
+
+def test_the_schema_name_is_preserved_so_the_request_key_stays_meaningful():
+    """`__name__` is the schema name in the hashed request and the key the test
+    doubles dispatch on. A generated name would make every recorded transcript
+    unreachable and every dispatching double miss."""
+    assert constrain(_Container, {"obligation_id": ["ob-1"]}).__name__ == "_Container"
+
+
+def test_an_empty_supplied_set_leaves_the_field_unconstrained():
+    """`Literal[]` is not a type, and a call that supplied nothing has nothing to
+    enforce. The guarantee degrades to local detection rather than raising."""
+    assert constrain(_Container, {"obligation_id": []}) is _Container
+
+
+# --- the local check (detection) ---
+
+
+def test_scan_finds_ids_that_were_never_supplied():
+    response = _Container(
+        items=[
+            _Item(obligation_id="ob-1", obligation_ids=["ob-1", "show-fields"], rationale="r"),
+        ]
+    )
+
+    found = scan(response, {"obligation_id": ["ob-1"], "obligation_ids": ["ob-1"]}, "mapping")
+
+    assert [(a.field, a.returned_id) for a in found] == [("obligation_ids", "show-fields")]
+    assert found[0].stage == "mapping"
+
+
+def test_scan_reports_each_unusable_id_once():
+    """It reaches the report, and two recorded runs over the same input must be
+    byte-identical (M0.5) — so no duplicates and a stable order."""
+    response = _Container(
+        items=[
+            _Item(obligation_id="x", obligation_ids=["y"], rationale="r"),
+            _Item(obligation_id="x", obligation_ids=["y"], rationale="r"),
+        ]
+    )
+
+    found = scan(response, {"obligation_id": ["ob-1"], "obligation_ids": ["ob-1"]}, "s")
+
+    assert [(a.field, a.returned_id) for a in found] == [
+        ("obligation_id", "x"),
+        ("obligation_ids", "y"),
+    ]
+
+
+def test_unsupplied_preserves_first_seen_order_without_duplicates():
+    assert unsupplied(["a", "b", "a", "c"], {"b"}) == ["a", "c"]
+
+
+# --- the mapping stage, where the defect was observed ---
+
+
+def test_a_foreign_obligation_id_is_recorded_not_silently_dropped():
+    """The original defect. `show-fields` belongs to a fixture the prompt
+    happened to contain; before #163 it was filtered at mapping.py and the
+    result read as 'no test evidences this'."""
+    obligations = [make_obligation("ob-1", "Discount reduces total", ObligationType.FUNCTIONAL)]
+    tests = [_test("test_cart.py::test_discount")]
+    response = {
+        "mappings": [
+            {
+                "test_id": "test_cart.py::test_discount",
+                "obligation_ids": ["show-fields"],
+                "rationale": "asserts total",
+            }
+        ]
+    }
+    log = UnusableAnswerLog()
+
+    result = map_tests_to_obligations(
+        obligations, tests, client_returning(response), unusable=log
+    )
+
+    assert [a.returned_id for a in log.answers] == ["show-fields"]
+    assert result.unusable_answers[0].returned_id == "show-fields"
+
+
+def test_an_obligation_is_indeterminate_not_unmapped_when_an_answer_was_unusable():
+    """The distinction the whole task turns on. 'No test evidences this' is a
+    substantive claim; we are not entitled to it when the answer that would have
+    mapped the obligation is the one we could not read."""
+    obligations = [make_obligation("ob-1", "Discount reduces total", ObligationType.FUNCTIONAL)]
+    tests = [_test("test_cart.py::test_discount")]
+    response = {
+        "mappings": [
+            {
+                "test_id": "test_cart.py::test_discount",
+                "obligation_ids": ["show-fields"],
+                "rationale": "r",
+            }
+        ]
+    }
+    log = UnusableAnswerLog()
+
+    result = map_tests_to_obligations(
+        obligations, tests, client_returning(response), unusable=log
+    )
+
+    assert result.indeterminate_obligation_ids == ["ob-1"]
+    assert result.unmapped_obligation_ids == []  # NOT a negative answer
+    assert log.indeterminate_obligations == {"ob-1"}
+
+
+def test_a_usable_judgment_survives_an_unusable_one_in_the_same_response():
+    """Per-item, not per-response. Parsing strictly would abort the batch and
+    discard every judgment that came back alongside the bad id."""
+    obligations = [
+        make_obligation("ob-1", "Discount reduces total", ObligationType.FUNCTIONAL),
+        make_obligation("ob-2", "Total is money-formatted", ObligationType.FUNCTIONAL),
+    ]
+    tests = [_test("t.py::test_a"), _test("t.py::test_b")]
+    response = {
+        "mappings": [
+            {"test_id": "t.py::test_a", "obligation_ids": ["ob-1"], "rationale": "good"},
+            {"test_id": "t.py::test_b", "obligation_ids": ["show-fields"], "rationale": "bad"},
+        ]
+    }
+    log = UnusableAnswerLog()
+
+    result = map_tests_to_obligations(
+        obligations, tests, client_returning(response), unusable=log
+    )
+
+    good = next(m for m in result.mappings if m.test_id == "t.py::test_a")
+    assert good.obligation_ids == ["ob-1"]  # retained
+    assert [a.returned_id for a in log.answers] == ["show-fields"]
+
+
+def test_a_clean_mapping_records_nothing_and_keeps_its_negative_answers():
+    """The guarantee must not fire spuriously: with every id honoured, an
+    unmapped obligation is still a real, reportable negative answer."""
+    obligations = [
+        make_obligation("ob-1", "Discount reduces total", ObligationType.FUNCTIONAL),
+        make_obligation("ob-2", "Total is money-formatted", ObligationType.FUNCTIONAL),
+    ]
+    tests = [_test("t.py::test_a")]
+    response = {
+        "mappings": [{"test_id": "t.py::test_a", "obligation_ids": ["ob-1"], "rationale": "r"}]
+    }
+    log = UnusableAnswerLog()
+
+    result = map_tests_to_obligations(
+        obligations, tests, client_returning(response), unusable=log
+    )
+
+    assert result.unmapped_obligation_ids == ["ob-2"]
+    assert result.indeterminate_obligation_ids == []
+    assert not log.answers
+
+
+def test_each_partition_constrains_test_ids_to_its_own_batch():
+    """A partitioned stage constrains each call to its own partition — every
+    obligation (each batch judges all of them), but only that batch's tests."""
+    obligations = [make_obligation("ob-1", "Discount reduces total", ObligationType.FUNCTIONAL)]
+    tests = [_test("t.py::test_a"), _test("t.py::test_b")]
+    client, seen = client_capturing_schemas({"mappings": []})
+
+    map_tests_to_obligations(obligations, tests, client, batch_size=1)
+
+    assert len(seen) == 2
+    enums = [s["properties"]["mappings"]["items"]["properties"]["test_id"]["enum"] for s in seen]
+    assert enums == [["t.py::test_a"], ["t.py::test_b"]]
+    # Every batch still judges every obligation.
+    for schema in seen:
+        obligation_field = schema["properties"]["mappings"]["items"]["properties"][
+            "obligation_ids"
+        ]
+        assert obligation_field["items"]["enum"] == ["ob-1"]
+
+
+def test_the_schema_asked_for_differs_from_the_shape_parsed():
+    """The `parse_as` seam. Without it a provider that ignored the enum would
+    raise `SchemaValidationError` and cost the whole batch — which is exactly the
+    all-or-nothing failure the per-item recording exists to avoid."""
+    obligations = [make_obligation("ob-1", "Discount reduces total", ObligationType.FUNCTIONAL)]
+    tests = [_test("t.py::test_a")]
+    response = {
+        "mappings": [
+            {"test_id": "t.py::test_a", "obligation_ids": ["not-supplied"], "rationale": "r"}
+        ]
+    }
+
+    # Does not raise: parsed permissively, then checked per item.
+    result = map_tests_to_obligations(obligations, tests, client_returning(response))
+
+    assert result.unusable_answers[0].returned_id == "not-supplied"
+
+
+# --- the pipeline actually uses it (the wiring, not just the helper) ---
+
+
+_TASK = "# Task\n\n- Alpha behaves\n"
+
+_JUDGMENTS = {
+    "_Decomposition": {
+        "obligations": [
+            {
+                "id": "alpha",
+                "description": "Alpha behaves",
+                "type": "functional",
+                "importance": "critical",
+                "explicit": True,
+                "observable_behavior": "alpha() == 1",
+                "source_quote": "Alpha behaves",
+            }
+        ],
+        "open_questions": [],
+    },
+    # The defect, reproduced: a mapping naming an obligation nobody supplied.
+    "_Mappings": {
+        "mappings": [
+            {
+                "test_id": "test_alpha.py::test_alpha",
+                "obligation_ids": ["show-fields"],
+                "rationale": "from a fixture in the prompt",
+            }
+        ]
+    },
+    "_Discrimination": {"obligations": []},
+    "_Coverage": {
+        "classifications": [
+            {
+                "obligation_id": "alpha",
+                "status": "addressed",
+                "rationale": "alpha.py implements it.",
+                "diff_refs": [],
+            }
+        ]
+    },
+    "_Detections": {"unrequested_changes": []},
+    "_Judgments": {"resolutions": []},
+    "_Recommendations": {"recommendations": []},
+    "_Mismatches": {"mismatches": []},
+}
+
+
+def _repo_with_a_change(tmp_path):
+    import subprocess
+
+    def git(*args):
+        return subprocess.run(
+            ["git", *args], cwd=tmp_path, capture_output=True, text=True, check=True
+        ).stdout.strip()
+
+    git("init", "-q")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "t")
+    (tmp_path / "alpha.py").write_text("def alpha():\n    return 0\n")
+    (tmp_path / "test_alpha.py").write_text(
+        "from alpha import alpha\n\n\ndef test_alpha():\n    assert alpha() is not None\n"
+    )
+    git("add", "-A")
+    git("commit", "-qm", "base")
+    base = git("rev-parse", "HEAD")
+    (tmp_path / "alpha.py").write_text("def alpha():\n    return 1\n")
+    git("add", "-A")
+    git("commit", "-qm", "head")
+    return base, git("rev-parse", "HEAD")
+
+
+def _review(tmp_path):
+    from acceptance.change.diff import extract_change_set
+    from acceptance.pipeline import run_review
+    from tests.support import client_dispatching
+
+    base, head = _repo_with_a_change(tmp_path)
+    return run_review(
+        task_text=_TASK,
+        change_set=extract_change_set(tmp_path, base, head),
+        repo=tmp_path,
+        client=client_dispatching(_JUDGMENTS),
+        reviewed_revision=head,
+    )
+
+
+def test_the_pipeline_reports_an_unusable_answer_naming_the_stage_and_the_id(tmp_path):
+    """Wiring, not the helper. Defect injection has repeatedly found a
+    well-tested helper the pipeline never calls — so assert the review itself
+    carries the finding, with enough detail to tell WHICH judgment is missing."""
+    review = _review(tmp_path)
+
+    unusable = [f for f in review.findings if f.type == "unusable_answer"]
+    assert len(unusable) == 1
+    assert "show-fields" in unusable[0].description
+    assert "mapping" in unusable[0].description
+
+
+def test_an_unusable_answer_leaves_the_obligation_indeterminate(tmp_path):
+    """Not `unsupported`. The model never answered about `alpha`, so claiming
+    its tests are weak asserts something we did not establish."""
+    review = _review(tmp_path)
+
+    alpha = next(o for o in review.obligation_map if o.id == "alpha")
+    assert alpha.evidence_class == "indeterminate"
+
+
+def test_a_review_holding_an_unusable_answer_does_not_come_back_clean(tmp_path):
+    """The point of gating the verdict: a half-blind review and a clean one look
+    identical unless the uncertainty is carried all the way to the headline."""
+    review = _review(tmp_path)
+
+    assert review.completion is not None
+    assert review.completion.verdict.value != "no_material_gaps"
+    assert "alpha" in review.completion.escalation_candidates
+
+
+def test_a_single_supplied_id_is_still_sent_as_an_enum():
+    """Pydantic renders a one-value `Literal` as `const`. Providers honour
+    `enum` under strict decoding, so without normalising, a call supplying
+    exactly one id — a one-obligation task, or a final partition — would be the
+    one case where the constraint silently stopped binding."""
+    from acceptance.llm import inline_schema_refs
+
+    schema = inline_schema_refs(constrain(_Container, {"obligation_id": ["only"]}).model_json_schema())
+
+    field = schema["properties"]["items"]["items"]["properties"]["obligation_id"]
+    assert field["enum"] == ["only"]
+    assert "const" not in field


### PR DESCRIPTION
Closes #163.

Every stage that asks the model to echo back an id we supplied typed that id as a
free-form `str`, so an id that does not exist was **valid output**. Four of the six
then discarded a foreign id without trace, leaving a result indistinguishable from a
substantive negative answer — the failure observed dogfooding #36, where the mapping
call answered about obligations it had read out of the test sources pasted into its
own prompt, and the review reported the change untested.

## The fix

Two mechanisms in the new `supplied_ids` module, deliberately separate:

- **`constrain`** builds the response model per call with each id field restricted to
  an enum of that call's own supplied ids. Under constrained decoding a foreign id is
  not merely detected but *unrepresentable*. This is the #158 lesson applied one level
  further: encode the constraint where the model is bound by it, not in the prose.
- **`scan`** checks returned ids locally. Not redundant — the harness routes through
  LiteLLM with `drop_params=True` precisely so it can run against providers whose
  structured-output support differs.

The local check is **per item**. `ModelClient.complete` gains a `parse_as` seam — the
constrained schema is what we ask for, a permissive one is what we parse with — so one
bad id costs one judgment instead of aborting a 96-entry batch and discarding the 95
usable judgments alongside it.

All six stages are covered: mapping, recommendations, unrequested-change detection,
coverage classification, open-question judgment, discrimination.

## What an unusable answer means

Settled with the human before implementation, rather than left to the code:

An id we cannot honour is **recorded, never dropped**, and the affected obligation is
left `indeterminate` rather than reported as lacking evidence. That routes through the
existing `verdict.py` path to `unable_to_determine`, so a review that could not read
part of its own reviewer can no longer come back clean. `unmapped` is a substantive
claim we are not entitled to when the answer that would have mapped the obligation is
the one we could not read.

Also normalises `const` to `enum` in the emitted schema. Pydantic renders a one-value
`Literal` as `const`; `enum` is what providers honour under strict decoding, so without
this a call supplying exactly one id — a one-obligation task, or a final partition —
would have been the one case where the constraint quietly stopped binding.

## Dogfooding

**Gate 1** — decomposition accurate, 10 obligations, nothing invented. Its one open
question was triaged as answerable from the task file and filed as **#178** (decomposer
prompt defect); the human ruled the task file correct and directed no rewrite.

**Gate 2** — `NO-MATERIAL-GAPS`. All 10 obligations addressed and strongly supported,
open question resolved, no recommended tests. Six unrequested changes, all `in_service`.

**Mapping transcript checked** per CLAUDE.md, since a clean verdict is only as
trustworthy as the mapping behind it: 9 partitioned calls, **all 10 obligations mapped,
zero foreign ids returned**. (First measurement spanned prior runs and had to be
re-scoped to this run's transcripts — the hazard `session-state.md` warns about.)

**Defect injection** — removing the log from the pipeline's mapping call fails all three
wiring tests while every unit test still passes, which is the exact shape of hole
CLAUDE.md flags.

568 tests green, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)