### PR TITLE
M7.3.r1: replace the next-instruction file with on-demand retrieval (#167)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ htmlcov/
 .acceptance/cache/
 # The checker's own output when dogfooding this repo (M7.3) — a per-run
 # artifact regenerated from the current review, not a source file to commit.
-.acceptance/next-instruction.md
 .acceptance/reviews/
 *.local
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,26 @@ was delivered gets a **superseding issue** (`M7.3.r1` supersedes `M7.3`), not an
 edit in place: the original acceptance check genuinely passed, and that record is
 worth keeping. See #34 → #167.
 
+**Tool defects found by dogfooding hang off a subsystem umbrella**, one per area
+of `src/acceptance/`, labelled `umbrella` and holding its children as GitHub
+sub-issues. Dogfooding generates defects faster than they can be fixed, and they
+cluster: several children of one umbrella touch the same file, share one prompt,
+and force the same transcript re-record, so they are sequenced together rather
+than independently.
+
+| umbrella | area |
+|---|---|
+| #181 | decomposition — `requirement/` |
+| #182 | test discovery & mapping — `evidence/discovery.py`, `mapping.py` |
+| #183 | evidence judgement — `evidence/discrimination.py`, `strength.py` |
+| #184 | determinism & reproducibility — `llm.py`, `serialization.py`, `partition.py` |
+| #185 | findings model, verdict & presentation — `coverage/`, `verdict.py`, `report.py` |
+| #186 | benchmark — `benchmark/` |
+
+File a new defect **as a child of its umbrella**, not standalone. Mapping and
+evidence judgement are deliberately separate umbrellas: #167's Gate 2 showed they
+fail independently — a byte-identical mapped set with a flipped judgement over it.
+
 Which milestone proves which §13.5 demonstration scenario:
 
 | # | Scenario | Proven by |

--- a/current-task.md
+++ b/current-task.md
@@ -1,51 +1,56 @@
 # Task
-Make the ids a model hands back verifiable against the ids it was given. Every
-stage that asks the model to echo back an id we supplied types that id as
-free-form text, so an id that does not exist is valid output. Four of those
-stages then discard a foreign id without trace, leaving a result
-indistinguishable from a substantive negative answer — the review reports that
-nothing evidences an obligation when the truth is that the reviewer answered a
-different question. Constrain each id-bearing response field to the ids actually
-supplied for that call, and where an answer still cannot be honoured, record it
-as an answer not obtained rather than as a negative judgment.
+Stop pushing a recommendation file nobody asked for, and let an agent pull the
+detail when it decides to act. Today a review with gaps writes its next
+instruction to one fixed path in the repo. That path is keyed to no task and no
+revision, so whichever run last found gaps owns it; a later clean run leaves it
+untouched, and the file then contradicts the report while only the report is
+telling the truth. The content is also a second, lossier copy of recommendations
+the review already carries as structured fields. Replace the written file
+`.acceptance/next-instruction.md` with `acceptance recommendation --criterion
+<id> [--format json|text]`, which returns a criterion's recommendation from
+stored review state on demand, defaulting to JSON.
+
+The command surface is fixed here rather than left to implementation: the
+specification has to name a specific command, and a document written against a
+command that later changes would recreate the same two-artifacts-drifting
+failure this task exists to remove.
 
 ## Constraints
-- The set of allowed ids is built per call, from the ids that call itself
-  supplied — not from a fixed list.
-- An id outside the supplied set is never accepted as a judgment about anything.
-- An answer that could not be honoured must not read as a substantive negative
-  answer — "no test evidences this obligation", "no hunk answers this question".
-- One answer that cannot be honoured must not discard the usable judgments
-  returned alongside it.
+- Nothing is written speculatively, so nothing can go stale.
+- A recommendation returned on demand is the one the stored review holds for that
+  criterion — retrieval reads state, it does not re-run the review.
+- The structured fields keep their prose values. Compressing a field to a terse
+  token loses the reasoning that makes the recommendation actionable.
+- A reader of the review's own output can tell how to obtain the detail; if the
+  output does not make the detail's existence known, the pull never happens.
+- A repo that already contains `.acceptance/next-instruction.md` from an
+  earlier version is left in a state where nothing on disk contradicts the
+  review.
 
 ## Scope exclusions
-- Ids the model invents rather than echoes back — the ids assigned to newly
-  decomposed obligations — have no supplied set to constrain them to and are
-  unchanged by this task.
-- Verifying that a quoted span really appears in the task text is a different
-  check against supplied input, and is not part of this task.
-- An empty answer — a model that returns no ids at all — is schema-valid and
-  indistinguishable from a correct negative judgment. No change is attempted
-  here, and none is proposed.
-- Prompt wording is unchanged except where the constraint itself requires it.
+- What the recommendations themselves contain is unchanged; this task moves how
+  they are obtained, not how they are produced.
+- The review-state store's format and the review pipeline are unchanged.
+- Recording that this task supersedes the earlier one belongs to the issue
+  tracker, not to any file in this repo.
 
 ## Completion expectations
 - Implementation
-- Each model stage that echoes back a supplied id constrains that response field
-  to the ids supplied for that call: test-to-obligation mapping, test
-  recommendation, unrequested-change detection, coverage classification,
-  open-question judgment, and discrimination judgment.
-- The allowed-id set a call carries reflects that call's own supplied ids, so a
-  stage whose request is partitioned constrains each call to its own partition.
-- An id outside the supplied set is not accepted as a judgment, at every one of
-  those stages.
-- An item whose returned id cannot be honoured is recorded as having no usable
-  answer, distinguishably from an item the model judged negatively.
-- An obligation whose judgment could not be honoured is left indeterminate,
-  rather than reported as an obligation lacking evidence.
-- A review holding an indeterminate judgment does not reach a clean completion
-  verdict.
-- The usable judgments returned in the same response as one that cannot be
-  honoured are retained.
-- The review names the stage and the id that could not be honoured, so a reader
-  can tell which judgment was not obtained and why.
+- `acceptance recommendation --criterion <id>` returns that criterion's
+  recommendation from stored review state, without re-running the review.
+- The retrieved recommendation carries each structured field as a discrete key
+  — required inputs, boundary conditions, expected output, required assertions,
+  plausible defect, repo conventions — with their prose values intact.
+- A criterion that has no recommendation returns an empty result rather than an
+  error.
+- Retrieval defaults to the most recently stored review when the caller does not
+  name one.
+- No code path writes `.acceptance/next-instruction.md`.
+- A run that finds an `.acceptance/next-instruction.md` left by an earlier
+  version removes it and reports that it did so.
+- Starting from a repo that already contains `.acceptance/next-instruction.md`,
+  a clean run leaves the review's own output as the only statement of status.
+- The review's rendered output names the command to run, not a file to open, for
+  every verdict that has gaps.
+- Two retrievals over unchanged review state return byte-identical output.
+- The specification no longer describes the recommendation as a written file.

--- a/docs/AI-Assisted-Software-Development-Review-Spec.md
+++ b/docs/AI-Assisted-Software-Development-Review-Spec.md
@@ -71,7 +71,7 @@ Used during development, before/while preparing a PR.
 
 **Inputs:** task file; base and current (or working-tree) revisions; source and test changes; relevant existing tests; optional builder declaration; optional project config (including the test command that enables execution).
 
-**Outputs:** interpreted obligations; implementation-coverage classification; test-to-obligation mapping; test-evidence assessment *with evidence tier*; missing/weak obligations; potential unrequested changes; builder-declaration discrepancies; **recommended new tests (structured for automated pickup, §9.5)**; a recommended next instruction; explicit confidence limitations.
+**Outputs:** interpreted obligations; implementation-coverage classification; test-to-obligation mapping; test-evidence assessment *with evidence tier*; missing/weak obligations; potential unrequested changes; builder-declaration discrepancies; **recommended new tests (structured for automated pickup, §9.5)**; a next instruction, retrieved on demand per criterion rather than written to a file; explicit confidence limitations.
 
 ```
 Developer writes task → agent implements → agent reports complete
@@ -264,7 +264,7 @@ Recommendations are emitted in a **structured, machine-readable form** — each 
 
 ### 10.1 Local Completion Check
 
-1. Capture the task file. 2. Coding work occurs (any agent/human). 3. Optional builder declaration produced. 4. Checker reads task, base revision, diff, relevant source/tests, and declaration if present. 5. Decompose into obligations; flag material ambiguities. 6. Implementation-coverage review (§9.2). 7. Test-evidence review (§9.3). 8. **Execution confirmation where feasible** — run mapped tests with coverage and targeted mutation to elevate tiers (§8); otherwise proceed statically. 9. Identify additional/unrequested changes. 10. Compare builder declaration against requirement/code/tests. 11. Produce completion result: *no material gaps / incomplete / needs clarification / needs non-code review / unable to determine.* 12. Produce a next instruction when gaps exist, e.g.:
+1. Capture the task file. 2. Coding work occurs (any agent/human). 3. Optional builder declaration produced. 4. Checker reads task, base revision, diff, relevant source/tests, and declaration if present. 5. Decompose into obligations; flag material ambiguities. 6. Implementation-coverage review (§9.2). 7. Test-evidence review (§9.3). 8. **Execution confirmation where feasible** — run mapped tests with coverage and targeted mutation to elevate tiers (§8); otherwise proceed statically. 9. Identify additional/unrequested changes. 10. Compare builder declaration against requirement/code/tests. 11. Produce completion result: *no material gaps / incomplete / needs clarification / needs non-code review / unable to determine.* 12. Make the next instruction available when gaps exist — pulled per criterion via `acceptance recommendation --criterion <id>`, never pushed to a file that outlives the run that wrote it, e.g.:
 
 > Apply active filters to CSV exports and add explicit handling for exports over 100,000 rows. Add tests that distinguish filtered from unfiltered output, verify displayed column order, and assert the row-limit error. Update the builder declaration after the changes.
 
@@ -338,7 +338,7 @@ Show the system can independently identify meaningful completion and test-eviden
 
 ### 13.3 Stage 1 — Local Completion Checker
 
-Capabilities: **task ingestion** (read `current-task.md`; extract behavior/constraints/exclusions/expectations; flag ambiguity; produce structured obligations); **Git change analysis** (base↔head; read changed source/tests; config/dependency changes; retrieve surrounding code); **builder-declaration ingestion, optional** (compare declared mandate/implementation/tests/exclusions/assumptions/limitations with task and diff); **implementation-coverage analysis** (§9.2, incl. unrequested-change detection); **test discovery** (added/modified and relevant existing; map to obligations); **test semantic analysis** (per candidate test: what's exercised/asserted, fixtures/mocks, input discrimination, expected-value provenance, undetected plausible defects, strength classification); **optional execution tier** (§8: coverage + targeted mutation; confirm recommended tests); **completion result** (obligation findings, test-evidence findings with tiers, declaration discrepancies, confidence limitations, overall result, next instruction).
+Capabilities: **task ingestion** (read `current-task.md`; extract behavior/constraints/exclusions/expectations; flag ambiguity; produce structured obligations); **Git change analysis** (base↔head; read changed source/tests; config/dependency changes; retrieve surrounding code); **builder-declaration ingestion, optional** (compare declared mandate/implementation/tests/exclusions/assumptions/limitations with task and diff); **implementation-coverage analysis** (§9.2, incl. unrequested-change detection); **test discovery** (added/modified and relevant existing; map to obligations); **test semantic analysis** (per candidate test: what's exercised/asserted, fixtures/mocks, input discrimination, expected-value provenance, undetected plausible defects, strength classification); **optional execution tier** (§8: coverage + targeted mutation; confirm recommended tests); **completion result** (obligation findings, test-evidence findings with tiers, declaration discrepancies, confidence limitations, overall result, next instruction retrieved on demand).
 
 *Stage 1 non-goals:* GitHub access; agent sessions; modifying code; writing production-ready tests; managing tasks; provisioning environments; proving runtime correctness. Running the project's *own hermetic tests* for targeted confirmation is in scope (§8); standing up environments the project doesn't already support is not.
 
@@ -439,7 +439,8 @@ Unrequested changes:
   1. [separable] Export filename behavior changed
        export/naming.py#@@ -5,2 +5,6 @@
 
-Recommended next instruction: .acceptance/next-instruction.md
+Next: retrieve a criterion's full recommendation with
+  acceptance recommendation --criterion <id>
 ```
 
 **GitHub PR** — primary team interface: Checks, PR comments, file/line annotations, links to issue text and tests. No separate web app required for routine review. **Optional web app (later)** — installation/config, review-policy settings, historical reviews, user corrections, evidence exploration, cross-PR analysis, usage/quality reporting; secondary to CLI and GitHub-native.

--- a/docs/AI-Assisted-Software-Development-Review-Spec.md
+++ b/docs/AI-Assisted-Software-Development-Review-Spec.md
@@ -256,7 +256,7 @@ When evidence is missing/weak, prescribe a test obligation: the criterion; requi
 
 > Add a case where calendar-month and contractual-period logic select different index observations: accrual period Jan 26 → Feb 25. Assert both the selected fixing date and the resulting coupon. This test should fail if the implementation uses calendar-month boundaries.
 
-Recommendations are emitted in a **structured, machine-readable form** — each tied to a criterion, with the fields above as discrete data — so a coding agent or harness can pick them up and add the test directly, and each is complete enough that the gap can typically be closed in a **single iteration**. The product recommends rather than modifies code; the recommendation may surface in the CLI, a Markdown file, the coding agent, a PR comment, or the GitHub check. Where execution is available, a subsequently added test is confirmed via §8.4 before its gap counts as closed.
+Recommendations are emitted in a **structured, machine-readable form** — each tied to a criterion, with the fields above as discrete data — so a coding agent or harness can pick them up and add the test directly, and each is complete enough that the gap can typically be closed in a **single iteration**. The product recommends rather than modifies code; the recommendation is retrieved on demand per criterion (`acceptance recommendation --criterion <id>`) and may surface in the CLI, the coding agent, a PR comment, or the GitHub check. It is never written to a file that outlives the run that produced it. Where execution is available, a subsequently added test is confirmed via §8.4 before its gap counts as closed.
 
 ---
 

--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -519,16 +519,21 @@ def main(argv: list[str] | None = None) -> int:
             return 1
         # The CLI's §16 invocation has no --repo flag and always means "here".
         removed = remove_legacy_instruction_file(Path("."))
+        if removed is not None:
+            # On stderr, and so in BOTH modes. Deleting a file in the user's repo
+            # must never be silent, and the first version reported it only in
+            # text mode — `--json` deleted and said nothing. stderr keeps stdout
+            # parseable for the agent consuming the JSON.
+            print(
+                f"Removed a stale {removed} left by an earlier version; "
+                "recommendations are now retrieved with\n"
+                "  acceptance recommendation --criterion <id>",
+                file=sys.stderr,
+            )
         if args.json:
             print(json.dumps(review.to_dict(), indent=2))
         else:
             print(render_report(review))
-            if removed is not None:
-                print(
-                    f"\nRemoved a stale {removed} left by an earlier version; "
-                    "recommendations are now retrieved with\n"
-                    "  acceptance recommendation --criterion <id>"
-                )
         return 0
 
     if args.command == "recommendation":

--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -33,7 +33,9 @@ from acceptance.coverage.open_questions import apply_open_question_resolutions, 
 from acceptance.coverage.unrequested import detect_unrequested_changes
 from acceptance.llm import LLMError, Mode, ModelClient
 from acceptance.pipeline import run_review
-from acceptance.report import render_next_instruction, render_report
+from acceptance.recommendation import lookup as lookup_recommendation
+from acceptance.recommendation import render as render_recommendation
+from acceptance.report import render_report
 from acceptance.rerun import find_prior_review
 from acceptance.requirement.obligations import Decomposition, Obligation, decompose
 from acceptance.requirement.task_file import parse_task_file
@@ -172,26 +174,33 @@ def run_check(
         task_identifier=task,
         prior=prior,
     )
-    # §10.1 step 12: when gaps exist, hand the agent a next instruction. The
-    # file is a CLI side effect, not part of the pipeline — the benchmark runs
-    # the same review over fixture repos and must not write into them.
-    instruction_path = _write_next_instruction(review, repo_path)
-    if instruction_path is not None:
-        review = review.model_copy(update={"recommendation": str(instruction_path)})
     store.write(review)
     return review
 
 
-def _write_next_instruction(review: Review, repo: Path) -> Path | None:
-    """Write `.acceptance/next-instruction.md` when the review has gaps to
-    close; return its path, or None when there is nothing to instruct."""
-    instruction = render_next_instruction(review)
-    if instruction is None:
+# The artifact M7.3 used to write. Nothing writes it now (M7.3.r1) — a run only
+# clears one left behind by an older version.
+_LEGACY_INSTRUCTION_PATH = Path(".acceptance") / "next-instruction.md"
+
+
+def remove_legacy_instruction_file(repo: Path) -> Path | None:
+    """Delete a `next-instruction.md` left by an older version; return its path.
+
+    Migration, run once per repo in effect: nothing recreates the file, so the
+    second run finds nothing. Deleting rather than leaving it is the point of the
+    task — the file is stale by construction, and a stale file that still asserts
+    gaps while the report says none contradicts the review. Both cannot be true
+    and only the report is entitled to speak.
+
+    Safe to delete without asking: it sits in `.acceptance/`, which the tool owns
+    and gitignores, and it was never authored by the user. The caller reports the
+    removal so it is visible rather than silent.
+    """
+    path = repo / _LEGACY_INSTRUCTION_PATH
+    if not path.is_file():
         return None
-    path = repo / ".acceptance" / "next-instruction.md"
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(instruction + "\n", encoding="utf-8")
-    return path.relative_to(repo) if path.is_relative_to(repo) else path
+    path.unlink()
+    return _LEGACY_INSTRUCTION_PATH
 
 
 def run_decompose(task: str, config: RunConfig) -> Decomposition:
@@ -412,6 +421,23 @@ def build_parser() -> argparse.ArgumentParser:
         help="Path to an optional §7.4 builder declaration (absence is a minor finding).",
     )
     _add_model_flags(check, default_mode=Mode.REPLAY.value)  # never call live unbidden
+    rec = subparsers.add_parser(
+        "recommendation",
+        help="Retrieve a criterion's §9.5 test recommendation from stored review state.",
+    )
+    rec.add_argument("--criterion", required=True, help="The obligation id to look up.")
+    rec.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output form (default: json, for pickup by a coding agent).",
+    )
+    rec.add_argument(
+        "--revision",
+        default=None,
+        help="Reviewed revision to read (default: the most recently stored review).",
+    )
+
     check.add_argument(
         "--json",
         action="store_true",
@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
         except LLMError as exc:
             print(f"acceptance: model error: {exc}", file=sys.stderr)
             return 1
+        # The CLI's §16 invocation has no --repo flag and always means "here".
+        removed = remove_legacy_instruction_file(Path("."))
         if args.json:
             print(json.dumps(review.to_dict(), indent=2))
         else:
             print(render_report(review))
+            if removed is not None:
+                print(
+                    f"\nRemoved a stale {removed} left by an earlier version; "
+                    "recommendations are now retrieved with\n"
+                    "  acceptance recommendation --criterion <id>"
+                )
+        return 0
+
+    if args.command == "recommendation":
+        store = ReviewStore()
+        review = store.read(args.revision) if args.revision else store.latest()
+        if review is None:
+            where = f"revision {args.revision}" if args.revision else "the review store"
+            print(f"acceptance: error: no stored review found for {where}", file=sys.stderr)
+            return 1
+        # A criterion with no recommendation is an ordinary answer, not an
+        # error: a strongly-supported obligation earns none, and asking is a
+        # reasonable thing for an agent to do.
+        print(render_recommendation(lookup_recommendation(review, args.criterion), args.format))
         return 0
 
     if args.command == "decompose":

--- a/src/acceptance/recommendation.py
+++ b/src/acceptance/recommendation.py
@@ -1,0 +1,87 @@
+"""On-demand retrieval of a §9.5 test recommendation (M7.3.r1, #167).
+
+Replaces the pushed `.acceptance/next-instruction.md`. That file was written
+speculatively by whichever run last found gaps, keyed to no task and no
+revision, and never cleaned up — so a later clean run printed "(none)" while a
+stale file on disk still asserted gaps, and only the report was telling the
+truth. Moving from push to pull removes the whole class of defect: nothing is
+written speculatively, so nothing can go stale, and there is no path that needs
+keying to a task or a SHA.
+
+Retrieval reads the M0 review-state store. It never re-runs analysis, so it
+makes no model call and costs nothing — the recommendation it returns is the one
+the review already reached, not a fresh judgment that might differ.
+
+The §9.5 fields stay PROSE inside a machine-readable envelope: structure for the
+agent, sentences inside it where the reasoning lives. Flattening
+`plausible_defect` to a terse token is what makes a recommendation unactionable.
+"""
+
+from __future__ import annotations
+
+from acceptance.review_state import Review, TestRecommendation
+from acceptance.serialization import canonical_json
+
+# §9.5's discrete prescriptions, plus the criterion they serve. Ordered as §9.5
+# lists them — a reader works down from what to feed the test to what it must
+# assert — though `canonical_json` sorts keys on the way out, so the ordering
+# here is documentation rather than the wire format.
+_FIELDS = (
+    "obligation_id",
+    "criterion",
+    "required_inputs",
+    "boundary_conditions",
+    "expected_output",
+    "required_assertions",
+    "plausible_defect",
+    "repo_conventions",
+)
+
+
+def lookup(review: Review, criterion: str) -> TestRecommendation | None:
+    """The stored recommendation for `criterion`, or None if it has none.
+
+    None is an ordinary answer, not a failure: an obligation that is strongly
+    supported earns no recommendation, and asking about one is a reasonable
+    thing for an agent to do.
+    """
+    for recommendation in review.recommendations:
+        if recommendation.obligation_id == criterion:
+            return recommendation
+    return None
+
+
+def render_json(recommendation: TestRecommendation | None) -> str:
+    """Canonical JSON, so two retrievals over unchanged state are byte-identical.
+
+    An absent recommendation renders as `{}` rather than `null`: a caller
+    parsing the output gets the same *type* either way and can test emptiness
+    without special-casing, which is the difference between "no recommendation"
+    being data and being an error to handle.
+    """
+    if recommendation is None:
+        return canonical_json({})
+    payload = {field: getattr(recommendation, field) for field in _FIELDS}
+    return canonical_json(payload)
+
+
+def render_text(recommendation: TestRecommendation | None) -> str:
+    """The same content for a human reading a terminal."""
+    if recommendation is None:
+        return "(no recommendation for this criterion)"
+    lines = [f"Criterion: {recommendation.criterion}", ""]
+    for field in _FIELDS:
+        if field in ("obligation_id", "criterion"):
+            continue
+        value = getattr(recommendation, field)
+        label = field.replace("_", " ")
+        if isinstance(value, list):
+            lines.append(f"{label}:")
+            lines.extend(f"  - {item}" for item in value)
+        else:
+            lines.append(f"{label}: {value}")
+    return "\n".join(lines)
+
+
+def render(recommendation: TestRecommendation | None, fmt: str) -> str:
+    return render_text(recommendation) if fmt == "text" else render_json(recommendation)

--- a/src/acceptance/report.py
+++ b/src/acceptance/report.py
@@ -76,6 +76,13 @@ def render_report(review: Review) -> str:
             lines.append(f"  {index}. {rec.criterion}")
             lines.append(f"       inputs:  {rec.required_inputs}")
             lines.append(f"       detects: {rec.plausible_defect}")
+            # §9.5's single-iteration goal depends on the agent KNOWING the full
+            # prescription exists. Naming the command per recommendation — rather
+            # than once at the foot of the report — is what makes the pull happen
+            # at the moment the reader decides to act on this criterion.
+            lines.append(
+                f"       full detail: acceptance recommendation --criterion {rec.obligation_id}"
+            )
         lines.append("")
 
     if completion is not None and completion.limitations:
@@ -84,75 +91,39 @@ def render_report(review: Review) -> str:
             lines.append(f"  {index}. {limitation}")
         lines.append("")
 
-    lines.append(f"Recommended next instruction: {review.recommendation or '(none)'}")
+    # A command, never a file (M7.3.r1). The artifact this used to name was
+    # written speculatively and never cleaned up, so a clean run printed
+    # "(none)" while a stale file on disk still asserted gaps. Pointing at a
+    # command that reads current review state cannot go out of date.
+    if _has_gaps(review):
+        lines.append(
+            "Next: retrieve a criterion's full recommendation with\n"
+            "  acceptance recommendation --criterion <id>"
+        )
+    else:
+        lines.append("Recommended next instruction: (none)")
 
     return "\n".join(lines)
 
 
-def render_next_instruction(review: Review) -> str | None:
-    """The §10.1 step-12 next instruction, or None when there is nothing to do.
+def _has_gaps(review: Review) -> bool:
+    """Whether there is anything for the next iteration to act on.
 
-    A deliberately thin projection of the same Review `render_report` renders —
-    no new judgment, no model call, every line traced to a finding, an M7.1
-    recommendation, or an unresolved open question. What it adds over the §16
-    report is SELECTION and mood: the report says "here is everything I found,
-    you judge"; this says "here is what to do next", addressed to the coding
-    agent rather than the human reviewer. So it drops satisfied obligations,
-    advisory unrequested changes, and evidence limitations.
-
-    Kept beside `render_report` rather than in its own module because both are
-    the same concern (render a Review for a consumer) — and kept a SEPARATE
-    function because the two audiences diverge: terminal styling (M7.6) must
-    never reach a file on disk, and reviewer-facing explanations (#143) are
-    noise in an agent handoff.
-
-    Produced only when gaps exist (§10.1 step 12), keyed off M7.2's verdict so
-    there is no second definition of what counts as material.
+    Keyed off M7.2's verdict so there is no second definition of what counts as
+    material — but a non-positive verdict is not sufficient on its own. A review
+    with no obligations is `unable_to_determine` and has nothing to pull, so
+    pointing it at the retrieval command would advertise detail that does not
+    exist. Both conditions, exactly as the pushed instruction required them
+    before it was removed.
     """
-    if review.completion is not None and review.completion.verdict is CompletionVerdict.NO_MATERIAL_GAPS:
-        return None
-
-    gaps = [
-        f.related_obligation
-        for f in review.findings
-        if f.type == "coverage_gap" and f.related_obligation is not None
-    ]
-    unresolved = [q.question for q in review.open_questions if not q.resolved]
-    if not gaps and not review.recommendations and not unresolved:
-        return None
-
-    lines = ["# Next instruction", ""]
-    if review.completion is not None:
-        lines += [f"Review verdict: **{review.completion.verdict.value}**.", ""]
-
-    if unresolved:
-        lines.append("## Answer these first")
-        lines += [f"{i}. {q}" for i, q in enumerate(unresolved, start=1)]
-        lines += ["", "These are unresolved ambiguities in the task; the work cannot be "
-                  "judged complete until they are settled.", ""]
-
-    if gaps:
-        lines.append("## Implement")
-        lines += [f"{i}. {g}" for i, g in enumerate(gaps, start=1)]
-        lines.append("")
-
-    if review.recommendations:
-        lines.append("## Add these tests")
-        for i, rec in enumerate(review.recommendations, start=1):
-            lines.append(f"{i}. **{rec.criterion}**")
-            lines.append(f"   - Inputs: {rec.required_inputs}")
-            if rec.boundary_conditions:
-                lines.append(f"   - Boundaries: {rec.boundary_conditions}")
-            lines.append(f"   - Expected: {rec.expected_output}")
-            for assertion in rec.required_assertions:
-                lines.append(f"   - Assert: {assertion}")
-            lines.append(f"   - Must fail if: {rec.plausible_defect}")
-            if rec.repo_conventions:
-                lines.append(f"   - Conventions: {rec.repo_conventions}")
-        lines.append("")
-
-    lines.append("Update the builder declaration after the changes.")
-    return "\n".join(lines)
+    if review.completion is None:
+        return False
+    if review.completion.verdict is CompletionVerdict.NO_MATERIAL_GAPS:
+        return False
+    # A review with no obligations is `unable_to_determine` because there was
+    # nothing to assess, not because something is wrong — the one non-positive
+    # verdict with nothing to pull.
+    return bool(review.obligation_map)
 
 
 def _short(revision: str) -> str:

--- a/src/acceptance/review_store.py
+++ b/src/acceptance/review_store.py
@@ -37,3 +37,18 @@ class ReviewStore:
         if not path.is_file():
             return None
         return Review.from_dict(json.loads(path.read_text()))
+
+    def latest(self) -> Review | None:
+        """The most recently written review, or None when the store is empty.
+
+        Keyed on the file's own mtime rather than anything inside the review:
+        reviews are keyed by revision, and revisions carry no order the store
+        can see — a re-run against an older head is legitimately the newest
+        review. What a caller who names no review means is "the one I just
+        produced", which is exactly write order (M7.3.r1).
+        """
+        paths = [path for path in self.root.glob("*.json") if path.is_file()]
+        if not paths:
+            return None
+        newest = max(paths, key=lambda path: path.stat().st_mtime)
+        return Review.from_dict(json.loads(newest.read_text()))

--- a/tests/benchmark/test_coverage.py
+++ b/tests/benchmark/test_coverage.py
@@ -663,32 +663,32 @@ def test_the_shared_pipeline_partitions_the_mapping_call(tmp_path):
     ].count("\n### ")
 
 
-def test_the_shared_pipeline_writes_nothing_into_the_reviewed_repo(tmp_path):
-    """The next-instruction file (M7.3) is a CLI side effect, deliberately NOT
-    part of `run_review`. The benchmark runs the same review over fixture
+def test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo(tmp_path):
+    """The reviewed repo is an input, never an output.
+
+    This mattered for the benchmark first: it runs the same review over fixture
     repos, so a write inside the pipeline would mutate the very fixtures the
     scores are computed from.
 
-    Asserts BOTH halves of that boundary in one test: the pipeline writes
-    nothing, AND the CLI over the same repo does write. Checking only the
-    first half would pass just as well if the feature were broken and nothing
-    ever wrote anywhere -- isolation that is trivially true proves nothing.
+    It used to assert both halves of a boundary — pipeline writes nothing, CLI
+    writes `next-instruction.md` — because an isolation that is trivially true
+    proves nothing. M7.3.r1 removed that write entirely, so the contrast is gone
+    and the claim is now the stronger one: NOTHING writes into the repo, on
+    either path. The CLI's one remaining repo-touching behaviour is *removing* a
+    legacy file, covered in `tests/test_cli.py`.
     """
     case = build_benchmark_case(ARCHETYPES_DIR / "01-missed-obligation", tmp_path / "repo")
     repo = Path(case.inputs.repo)
-    instruction = repo / ".acceptance" / "next-instruction.md"
 
     def snapshot() -> set:
         return {p.relative_to(repo) for p in repo.rglob("*") if ".git" not in p.parts}
 
-    # The pipeline leaves the reviewed repo untouched...
     before = snapshot()
     classify_case(case, client_finding_nothing())
     assert snapshot() == before
-    assert not instruction.exists()
 
-    # ...while the CLI, over that same repo and a review with a real gap,
-    # does write the instruction. The boundary is real, not vacuous.
+    # The same repo through the CLI, with a review that has a real gap — the
+    # case that used to write a file.
     task_file = tmp_path / "task.md"
     task_file.write_text(case.inputs.task_text)
     run_check(
@@ -714,19 +714,5 @@ def test_the_shared_pipeline_writes_nothing_into_the_reviewed_repo(tmp_path):
             "_Mismatches": {"mismatches": []},
         }),
     )
-    assert instruction.is_file()
-
-    # ...and SKIPS that branch when the review has nothing to instruct, over
-    # the same repo. Without this, a CLI that wrote unconditionally would pass:
-    # the write would be a side effect, just not a conditional one.
-    instruction.unlink()
-    run_check(
-        task=str(task_file),
-        base=case.inputs.base_revision,
-        head=case.inputs.head_revision,
-        config=RunConfig(),
-        store=ReviewStore(tmp_path / "reviews-2"),
-        repo=repo,
-        client=client_finding_nothing(),
-    )
-    assert not instruction.exists()
+    assert snapshot() == before
+    assert not (repo / ".acceptance" / "next-instruction.md").exists()

--- a/tests/fixtures/rating-stability/163-gate2-run1/check-output.log
+++ b/tests/fixtures/rating-stability/163-gate2-run1/check-output.log
@@ -1,0 +1,239 @@
+Task completion: NO-MATERIAL-GAPS
+
+Every obligation is addressed and strongly supported by discriminating tests.
+
+Obligations:
+
+  1. Each model stage that echoes back a supplied id constrains that response field to the ids supplied for that call.
+       code evidence: addressed
+         1.1  src/acceptance/supplied_ids.py#@@ -0,0 +1,207 @@
+         1.2  src/acceptance/coverage/classify.py#@@ -115,7 +121,13 @@ def classify_coverage(
+         1.3  src/acceptance/coverage/open_questions.py#@@ -89,7 +95,15 @@ def resolve_open_questions(
+         1.4  src/acceptance/coverage/recommendations.py#@@ -125,7 +129,15 @@ def recommend_tests(
+         1.5  src/acceptance/coverage/unrequested.py#@@ -100,7 +106,12 @@ def detect_unrequested_changes(
+         1.6  src/acceptance/evidence/discrimination.py#@@ -151,7 +155,19 @@ def judge_discrimination(
+         1.7  src/acceptance/evidence/mapping.py#@@ -112,22 +121,39 @@ def map_tests_to_obligations(
+         1.8  src/acceptance/llm.py#@@ -122,6 +122,28 @@ def _default_completion_fn(**kwargs: Any) -> Any:
+         1.9  src/acceptance/llm.py#@@ -148,7 +170,7 @@ def inline_schema_refs(schema: dict) -> dict:
+         1.10  tests/test_supplied_ids.py#@@ -0,0 +1,408 @@
+       test evidence: strongly supported  [tier: static]
+         1.11  tests/coverage/test_recommendations.py::test_weak_criterion_gets_a_fully_populated_recommendation
+         1.12  tests/evidence/test_discrimination.py::test_a_caught_defect_makes_the_criterion_discriminating
+         1.13  tests/evidence/test_discrimination.py::test_discriminating_is_true_if_any_defect_is_caught
+         1.14  tests/evidence/test_discrimination.py::test_non_discriminating_input_is_judged_non_discriminating_with_a_reason
+         1.15  tests/evidence/test_mapping.py::test_a_batch_may_not_answer_for_a_test_outside_it
+         1.16  tests/evidence/test_mapping.py::test_a_test_can_map_to_multiple_obligations
+         1.17  tests/evidence/test_mapping.py::test_unknown_ids_are_dropped
+         1.18  tests/test_llm.py::test_the_schema_sent_to_the_provider_has_no_ref_indirection
+         1.19  tests/test_supplied_ids.py::test_a_foreign_id_does_not_validate_against_the_constrained_schema
+         1.20  tests/test_supplied_ids.py::test_a_list_valued_id_field_constrains_its_items
+         1.21  tests/test_supplied_ids.py::test_a_single_supplied_id_is_still_sent_as_an_enum
+         1.22  tests/test_supplied_ids.py::test_each_partition_constrains_test_ids_to_its_own_batch
+         1.23  tests/test_supplied_ids.py::test_supplied_ids_become_an_enum_on_the_field_the_model_sees
+         1.24  tests/test_supplied_ids.py::test_the_schema_asked_for_differs_from_the_shape_parsed
+
+  2. The allowed-id set for a call is built from the ids that call itself supplied.
+       code evidence: addressed
+         2.1  src/acceptance/coverage/classify.py#@@ -115,7 +121,13 @@ def classify_coverage(
+         2.2  src/acceptance/coverage/open_questions.py#@@ -89,7 +95,15 @@ def resolve_open_questions(
+         2.3  src/acceptance/coverage/recommendations.py#@@ -125,7 +129,15 @@ def recommend_tests(
+         2.4  src/acceptance/coverage/unrequested.py#@@ -100,7 +106,12 @@ def detect_unrequested_changes(
+         2.5  src/acceptance/evidence/discrimination.py#@@ -151,7 +155,19 @@ def judge_discrimination(
+         2.6  src/acceptance/evidence/mapping.py#@@ -112,22 +121,39 @@ def map_tests_to_obligations(
+         2.7  src/acceptance/supplied_ids.py#@@ -0,0 +1,207 @@
+       test evidence: strongly supported  [tier: static]
+         2.8  tests/coverage/test_recommendations.py::test_weak_criterion_gets_a_fully_populated_recommendation
+         2.9  tests/evidence/test_discrimination.py::test_a_caught_defect_makes_the_criterion_discriminating
+         2.10  tests/evidence/test_discrimination.py::test_discriminating_is_true_if_any_defect_is_caught
+         2.11  tests/evidence/test_discrimination.py::test_non_discriminating_input_is_judged_non_discriminating_with_a_reason
+         2.12  tests/evidence/test_mapping.py::test_a_batch_may_not_answer_for_a_test_outside_it
+         2.13  tests/evidence/test_mapping.py::test_a_test_can_map_to_multiple_obligations
+         2.14  tests/evidence/test_mapping.py::test_unknown_ids_are_dropped
+         2.15  tests/test_rerun.py::test_only_the_affected_obligation_is_re_derived
+         2.16  tests/test_supplied_ids.py::test_an_empty_supplied_set_leaves_the_field_unconstrained
+
+  3. An id outside the supplied set is never accepted as a judgment about anything.
+       code evidence: addressed
+         3.1  src/acceptance/supplied_ids.py#@@ -0,0 +1,207 @@
+         3.2  src/acceptance/coverage/classify.py#@@ -115,7 +121,13 @@ def classify_coverage(
+         3.3  src/acceptance/coverage/open_questions.py#@@ -89,7 +95,15 @@ def resolve_open_questions(
+         3.4  src/acceptance/coverage/recommendations.py#@@ -125,7 +129,15 @@ def recommend_tests(
+         3.5  src/acceptance/coverage/unrequested.py#@@ -100,7 +106,12 @@ def detect_unrequested_changes(
+         3.6  src/acceptance/evidence/discrimination.py#@@ -151,7 +155,19 @@ def judge_discrimination(
+         3.7  src/acceptance/evidence/mapping.py#@@ -112,22 +121,39 @@ def map_tests_to_obligations(
+         3.8  src/acceptance/pipeline.py#@@ -98,6 +100,49 @@ def coverage_finding(obligation: Obligation, coverage: ImplementationCoverage) -
+         3.9  src/acceptance/pipeline.py#@@ -226,6 +286,7 @@ def run_review(
+         3.10  tests/test_supplied_ids.py#@@ -0,0 +1,408 @@
+       test evidence: strongly supported  [tier: static]
+         3.11  tests/coverage/test_open_questions.py::test_unknown_question_id_in_response_is_dropped
+         3.12  tests/coverage/test_unrequested.py::test_change_the_model_judges_requested_is_not_emitted
+         3.13  tests/evidence/test_discrimination.py::test_a_caught_defect_makes_the_criterion_discriminating
+         3.14  tests/evidence/test_discrimination.py::test_discriminating_is_true_if_any_defect_is_caught
+         3.15  tests/evidence/test_discrimination.py::test_non_discriminating_input_is_judged_non_discriminating_with_a_reason
+         3.16  tests/evidence/test_mapping.py::test_a_batch_may_not_answer_for_a_test_outside_it
+         3.17  tests/evidence/test_mapping.py::test_a_test_can_map_to_multiple_obligations
+         3.18  tests/evidence/test_mapping.py::test_unknown_ids_are_dropped
+         3.19  tests/test_supplied_ids.py::test_a_foreign_id_does_not_validate_against_the_constrained_schema
+         3.20  tests/test_supplied_ids.py::test_a_foreign_obligation_id_is_recorded_not_silently_dropped
+         3.21  tests/test_supplied_ids.py::test_a_usable_judgment_survives_an_unusable_one_in_the_same_response
+         3.22  tests/test_supplied_ids.py::test_scan_finds_ids_that_were_never_supplied
+         3.23  tests/test_supplied_ids.py::test_scan_reports_each_unusable_id_once
+         3.24  tests/test_supplied_ids.py::test_the_schema_asked_for_differs_from_the_shape_parsed
+
+  4. An answer that could not be honoured is recorded as an answer not obtained rather than as a negative judgment.
+       code evidence: addressed
+         4.1  src/acceptance/supplied_ids.py#@@ -0,0 +1,207 @@
+         4.2  src/acceptance/evidence/mapping.py#@@ -147,6 +173,23 @@ def map_tests_to_obligations(
+         4.3  src/acceptance/evidence/discrimination.py#@@ -151,7 +155,19 @@ def judge_discrimination(
+         4.4  src/acceptance/pipeline.py#@@ -98,6 +100,49 @@ def coverage_finding(obligation: Obligation, coverage: ImplementationCoverage) -
+         4.5  src/acceptance/pipeline.py#@@ -181,26 +226,41 @@ def run_review(
+         4.6  src/acceptance/pipeline.py#@@ -226,6 +286,7 @@ def run_review(
+         4.7  src/acceptance/review_state.py#@@ -86,6 +86,13 @@ DECLARATION_ABSENT = "declaration_absent"
+         4.8  tests/test_supplied_ids.py#@@ -0,0 +1,408 @@
+       test evidence: strongly supported  [tier: static]
+         4.9  tests/prompts/test_corpus_mechanism.py::test_a_recorded_call_completed_against_a_provider_that_rejects_our_controls
+         4.10  tests/test_config.py::test_provenance_reports_the_controls_the_provider_honoured
+         4.11  tests/test_supplied_ids.py::test_a_clean_mapping_records_nothing_and_keeps_its_negative_answers
+         4.12  tests/test_supplied_ids.py::test_a_foreign_obligation_id_is_recorded_not_silently_dropped
+         4.13  tests/test_supplied_ids.py::test_a_usable_judgment_survives_an_unusable_one_in_the_same_response
+         4.14  tests/test_supplied_ids.py::test_the_pipeline_reports_an_unusable_answer_naming_the_stage_and_the_id
+
+  5. An answer that could not be honoured does not read as a substantive negative answer.
+       code evidence: addressed
+         5.1  src/acceptance/evidence/mapping.py#@@ -147,6 +173,23 @@ def map_tests_to_obligations(
+         5.2  src/acceptance/evidence/discrimination.py#@@ -151,7 +155,19 @@ def judge_discrimination(
+         5.3  src/acceptance/pipeline.py#@@ -98,6 +100,49 @@ def coverage_finding(obligation: Obligation, coverage: ImplementationCoverage) -
+         5.4  src/acceptance/review_state.py#@@ -86,6 +86,13 @@ DECLARATION_ABSENT = "declaration_absent"
+         5.5  tests/test_supplied_ids.py#@@ -0,0 +1,408 @@
+       test evidence: strongly supported  [tier: static]
+         5.6  tests/prompts/test_corpus_mechanism.py::test_a_recorded_call_completed_against_a_provider_that_rejects_our_controls
+         5.7  tests/test_config.py::test_provenance_reports_the_controls_the_provider_honoured
+         5.8  tests/test_supplied_ids.py::test_a_clean_mapping_records_nothing_and_keeps_its_negative_answers
+         5.9  tests/test_supplied_ids.py::test_an_obligation_is_indeterminate_not_unmapped_when_an_answer_was_unusable
+         5.10  tests/test_supplied_ids.py::test_the_pipeline_reports_an_unusable_answer_naming_the_stage_and_the_id
+
+  6. Usable judgments returned alongside an unhonored answer are retained.
+       code evidence: addressed
+         6.1  src/acceptance/llm.py#@@ -275,8 +297,21 @@ class ModelClient:
+         6.2  src/acceptance/llm.py#@@ -297,7 +332,7 @@ class ModelClient:
+         6.3  src/acceptance/llm.py#@@ -305,7 +340,7 @@ class ModelClient:
+         6.4  src/acceptance/evidence/mapping.py#@@ -112,22 +121,39 @@ def map_tests_to_obligations(
+         6.5  src/acceptance/evidence/mapping.py#@@ -147,6 +173,23 @@ def map_tests_to_obligations(
+         6.6  tests/test_supplied_ids.py#@@ -0,0 +1,408 @@
+       test evidence: strongly supported  [tier: static]
+         6.7  tests/evidence/test_discrimination.py::test_an_obligation_the_model_omits_is_conservatively_non_discriminating
+         6.8  tests/evidence/test_mapping.py::test_the_per_call_results_are_merged
+         6.9  tests/test_rerun.py::test_a_rerun_still_reports_a_gap_in_code_the_new_work_never_touched
+         6.10  tests/test_supplied_ids.py::test_a_usable_judgment_survives_an_unusable_one_in_the_same_response
+
+  7. When a stage request is partitioned, each call constrains its response to the ids in its own partition.
+       code evidence: addressed
+         7.1  src/acceptance/evidence/mapping.py#@@ -112,22 +121,39 @@ def map_tests_to_obligations(
+         7.2  tests/test_supplied_ids.py#@@ -0,0 +1,408 @@
+       test evidence: strongly supported  [tier: static]
+         7.3  tests/evidence/test_mapping.py::test_a_batch_may_not_answer_for_a_test_outside_it
+         7.4  tests/evidence/test_mapping.py::test_changing_the_batch_size_changes_every_request_key
+         7.5  tests/evidence/test_mapping.py::test_each_batch_is_recorded_as_its_own_request
+         7.6  tests/evidence/test_mapping.py::test_every_test_is_judged_against_every_obligation_across_the_calls
+         7.7  tests/evidence/test_mapping.py::test_repeating_a_run_reuses_the_recorded_batches
+         7.8  tests/evidence/test_mapping.py::test_the_per_call_results_are_merged
+         7.9  tests/evidence/test_mapping.py::test_the_tests_are_split_across_several_calls
+         7.10  tests/test_config.py::test_provenance_of_an_unpartitioned_run_reports_no_partition_size
+         7.11  tests/test_config.py::test_provenance_reports_the_partition_size_the_run_actually_used
+         7.12  tests/test_rerun.py::test_only_the_affected_obligation_is_re_derived
+         7.13  tests/test_supplied_ids.py::test_each_partition_constrains_test_ids_to_its_own_batch
+
+  8. An obligation whose judgment could not be honoured is left indeterminate rather than reported as lacking evidence.
+       code evidence: addressed
+         8.1  src/acceptance/evidence/mapping.py#@@ -147,6 +173,23 @@ def map_tests_to_obligations(
+         8.2  src/acceptance/evidence/discrimination.py#@@ -151,7 +155,19 @@ def judge_discrimination(
+         8.3  src/acceptance/pipeline.py#@@ -98,6 +100,49 @@ def coverage_finding(obligation: Obligation, coverage: ImplementationCoverage) -
+         8.4  src/acceptance/pipeline.py#@@ -181,26 +226,41 @@ def run_review(
+         8.5  tests/test_supplied_ids.py#@@ -0,0 +1,408 @@
+       test evidence: strongly supported  [tier: static]
+         8.6  tests/evidence/test_discrimination.py::test_an_obligation_the_model_omits_is_conservatively_non_discriminating
+         8.7  tests/test_config.py::test_provenance_of_a_run_that_made_no_model_call_is_indeterminate
+         8.8  tests/test_rerun.py::test_a_rerun_still_reports_a_gap_in_code_the_new_work_never_touched
+         8.9  tests/test_supplied_ids.py::test_an_obligation_is_indeterminate_not_unmapped_when_an_answer_was_unusable
+         8.10  tests/test_supplied_ids.py::test_an_unusable_answer_leaves_the_obligation_indeterminate
+         8.11  tests/test_verdict.py::test_coverage_gap_is_incomplete
+         8.12  tests/test_verdict.py::test_unresolved_open_question_blocks_positive_and_needs_clarification
+
+  9. A review holding an indeterminate judgment does not reach a clean completion verdict.
+       code evidence: addressed
+         9.1  src/acceptance/pipeline.py#@@ -98,6 +100,49 @@ def coverage_finding(obligation: Obligation, coverage: ImplementationCoverage) -
+         9.2  src/acceptance/pipeline.py#@@ -226,6 +286,7 @@ def run_review(
+         9.3  tests/test_supplied_ids.py#@@ -0,0 +1,408 @@
+       test evidence: strongly supported  [tier: static]
+         9.4  tests/evidence/test_discrimination.py::test_an_obligation_the_model_omits_is_conservatively_non_discriminating
+         9.5  tests/test_config.py::test_provenance_of_a_run_that_made_no_model_call_is_indeterminate
+         9.6  tests/test_rerun.py::test_a_rerun_still_reports_a_gap_in_code_the_new_work_never_touched
+         9.7  tests/test_supplied_ids.py::test_a_review_holding_an_unusable_answer_does_not_come_back_clean
+         9.8  tests/test_verdict.py::test_coverage_gap_is_incomplete
+         9.9  tests/test_verdict.py::test_unresolved_open_question_blocks_positive_and_needs_clarification
+
+  10. The review names the stage and the id that could not be honoured.
+       code evidence: addressed
+         10.1  src/acceptance/pipeline.py#@@ -98,6 +100,49 @@ def coverage_finding(obligation: Obligation, coverage: ImplementationCoverage) -
+         10.2  tests/test_supplied_ids.py#@@ -0,0 +1,408 @@
+       test evidence: strongly supported  [tier: static]
+         10.3  tests/prompts/test_corpus_mechanism.py::test_a_recorded_call_completed_against_a_provider_that_rejects_our_controls
+         10.4  tests/test_report.py::test_unresolved_open_questions_lead_the_instruction
+         10.5  tests/test_supplied_ids.py::test_a_foreign_obligation_id_is_recorded_not_silently_dropped
+         10.6  tests/test_supplied_ids.py::test_a_usable_judgment_survives_an_unusable_one_in_the_same_response
+         10.7  tests/test_supplied_ids.py::test_an_obligation_is_indeterminate_not_unmapped_when_an_answer_was_unusable
+         10.8  tests/test_supplied_ids.py::test_scan_finds_ids_that_were_never_supplied
+         10.9  tests/test_supplied_ids.py::test_scan_reports_each_unusable_id_once
+         10.10  tests/test_supplied_ids.py::test_the_pipeline_reports_an_unusable_answer_naming_the_stage_and_the_id
+
+Unrequested changes:
+  1. [in_service] Added a new helper module for constraining/scanning supplied ids, but the task only required behavior around supplied ids and indeterminate handling; the module-level documentation and generic utilities (`unsupplied`, schema rewriting helpers) are extra implementation surface not directly called for by any obligation.
+       src/acceptance/supplied_ids.py#@@ -0,0 +1,207 @@
+  2. [in_service] `ModelClient.complete` now accepts a new `parse_as` parameter and changes replay/live validation behavior to parse against a different model than the requested schema. That is a broad API and behavior change beyond the stated obligations, which only require supplied-id constraints and recording unusable answers.
+       src/acceptance/llm.py#@@ -275,8 +297,21 @@ class ModelClient:
+       src/acceptance/llm.py#@@ -297,7 +332,7 @@ class ModelClient:
+       src/acceptance/llm.py#@@ -305,7 +340,7 @@ class ModelClient:
+       src/acceptance/llm.py#@@ -356,6 +391,11 @@ class ModelClient:
+  3. [in_service] `run_review` now creates and threads a global unusable-answer log through every stage, adds a new finding type to the review output, and marks obligations indeterminate after strength classification. The obligations require indeterminate handling for unhonored judgments, but not this specific cross-stage accumulator design or the new finding emission path.
+       src/acceptance/pipeline.py#@@ -54,6 +55,7 @@ from acceptance.requirement.obligations import decompose
+       src/acceptance/pipeline.py#@@ -98,6 +100,49 @@ def coverage_finding(obligation: Obligation, coverage: ImplementationCoverage) -
+       src/acceptance/pipeline.py#@@ -181,26 +226,41 @@ def run_review(
+       src/acceptance/pipeline.py#@@ -226,6 +286,7 @@ def run_review(
+       src/acceptance/review_state.py#@@ -86,6 +86,13 @@ DECLARATION_ABSENT = "declaration_absent"
+       src/acceptance/review_state.py#@@ -94,9 +101,11 @@ DECLARATION_MISMATCH = "declaration_mismatch"
+  4. [in_service] `map_tests_to_obligations` now changes its return type semantics by adding `indeterminate_obligation_ids` and `unusable_answers`, and returns indeterminate instead of unmapped when any unusable answer exists. The obligations require indeterminate treatment for unhonored judgments, but not this new result-shape expansion or the specific all-or-nothing return branching.
+       src/acceptance/evidence/mapping.py#@@ -63,6 +66,11 @@ class TestMapping(PersistableModel):
+       src/acceptance/evidence/mapping.py#@@ -95,6 +103,7 @@ def map_tests_to_obligations(
+       src/acceptance/evidence/mapping.py#@@ -112,22 +121,39 @@ def map_tests_to_obligations(
+       src/acceptance/evidence/mapping.py#@@ -147,6 +173,23 @@ def map_tests_to_obligations(
+  5. [in_service] The coverage/open-question/discrimination/recommendation stages now all accept an optional unusable-answer accumulator and perform schema constraining plus local scanning. The obligations require per-call supplied-id constraints and recording unhonored answers, but not changing every stage signature to thread an accumulator through the pipeline.
+       src/acceptance/coverage/classify.py#@@ -22,6 +22,7 @@ from pydantic import Field
+       src/acceptance/coverage/classify.py#@@ -107,7 +110,10 @@ class _Coverage(StrictResponseModel):
+       src/acceptance/coverage/classify.py#@@ -115,7 +121,13 @@ def classify_coverage(
+       src/acceptance/coverage/open_questions.py#@@ -23,9 +23,12 @@ from pydantic import Field
+       src/acceptance/coverage/open_questions.py#@@ -77,7 +80,10 @@ def _render_prompt(open_questions: list[OpenQuestion], change_set: ChangeSet) ->
+       src/acceptance/coverage/open_questions.py#@@ -89,7 +95,15 @@ def resolve_open_questions(
+       src/acceptance/coverage/recommendations.py#@@ -25,6 +25,7 @@ from __future__ import annotations
+       src/acceptance/coverage/recommendations.py#@@ -32,6 +33,8 @@ from acceptance.review_state import ChangeSet, Obligation, TestRecommendation
+       src/acceptance/coverage/recommendations.py#@@ -110,6 +113,7 @@ def recommend_tests(
+       src/acceptance/coverage/recommendations.py#@@ -125,7 +129,15 @@ def recommend_tests(
+       src/acceptance/coverage/unrequested.py#@@ -28,6 +28,7 @@ from pydantic import Field
+       src/acceptance/coverage/unrequested.py#@@ -92,7 +95,10 @@ class _Detections(StrictResponseModel):
+       src/acceptance/coverage/unrequested.py#@@ -100,7 +106,12 @@ def detect_unrequested_changes(
+       src/acceptance/evidence/discrimination.py#@@ -24,9 +24,12 @@ the predictions by execution.
+       src/acceptance/evidence/discrimination.py#@@ -132,6 +135,7 @@ def judge_discrimination(
+       src/acceptance/evidence/mapping.py#@@ -25,6 +25,9 @@ from acceptance.llm import ModelClient, StrictResponseModel
+       src/acceptance/evidence/mapping.py#@@ -95,6 +103,7 @@ def map_tests_to_obligations(
+       src/acceptance/evidence/mapping.py#@@ -112,22 +121,39 @@ def map_tests_to_obligations(
+  6. [in_service] The new tests add extensive coverage for schema-shaping, helper utilities, pipeline wiring, and a specific defect narrative. While tests are requested in general only insofar as they verify the obligations, several of these cases exercise implementation details and new helper behavior that no obligation explicitly requires.
+       tests/support.py#@@ -74,6 +74,30 @@ def client_answering_per_call(
+       tests/test_supplied_ids.py#@@ -0,0 +1,408 @@
+
+Open questions:
+  1. [resolved] What exact conditions make a returned id 'cannot be honoured' versus simply invalid or empty, so the implementation can decide when to mark an answer as not obtained?
+       The diff defines the distinction in `supplied_ids.py` and applies it in the stages: a returned id is 'cannot be honoured' when it was never supplied to that call, detected by `scan(...)` and recorded as `UnusableAnswer`; empty supplied sets are explicitly left unconstrained in `constrain(...)`, so they are not treated as unusable. The mapping stage comments also state that an unusable id is 'not merely unmatched' and that an unmapped obligation becomes indeterminate when any answer was unusable, which clarifies the implementation rule for marking an answer as not obtained.
+
+Evidence limitations:
+  1. No material gaps found at the achievable evidence tier — not proof of correctness. The full application was not independently executed (§3.7).
+
+Recommended next instruction: (none)

--- a/tests/fixtures/rating-stability/163-gate2-run1/current-task.md
+++ b/tests/fixtures/rating-stability/163-gate2-run1/current-task.md
@@ -1,0 +1,51 @@
+# Task
+Make the ids a model hands back verifiable against the ids it was given. Every
+stage that asks the model to echo back an id we supplied types that id as
+free-form text, so an id that does not exist is valid output. Four of those
+stages then discard a foreign id without trace, leaving a result
+indistinguishable from a substantive negative answer — the review reports that
+nothing evidences an obligation when the truth is that the reviewer answered a
+different question. Constrain each id-bearing response field to the ids actually
+supplied for that call, and where an answer still cannot be honoured, record it
+as an answer not obtained rather than as a negative judgment.
+
+## Constraints
+- The set of allowed ids is built per call, from the ids that call itself
+  supplied — not from a fixed list.
+- An id outside the supplied set is never accepted as a judgment about anything.
+- An answer that could not be honoured must not read as a substantive negative
+  answer — "no test evidences this obligation", "no hunk answers this question".
+- One answer that cannot be honoured must not discard the usable judgments
+  returned alongside it.
+
+## Scope exclusions
+- Ids the model invents rather than echoes back — the ids assigned to newly
+  decomposed obligations — have no supplied set to constrain them to and are
+  unchanged by this task.
+- Verifying that a quoted span really appears in the task text is a different
+  check against supplied input, and is not part of this task.
+- An empty answer — a model that returns no ids at all — is schema-valid and
+  indistinguishable from a correct negative judgment. No change is attempted
+  here, and none is proposed.
+- Prompt wording is unchanged except where the constraint itself requires it.
+
+## Completion expectations
+- Implementation
+- Each model stage that echoes back a supplied id constrains that response field
+  to the ids supplied for that call: test-to-obligation mapping, test
+  recommendation, unrequested-change detection, coverage classification,
+  open-question judgment, and discrimination judgment.
+- The allowed-id set a call carries reflects that call's own supplied ids, so a
+  stage whose request is partitioned constrains each call to its own partition.
+- An id outside the supplied set is not accepted as a judgment, at every one of
+  those stages.
+- An item whose returned id cannot be honoured is recorded as having no usable
+  answer, distinguishably from an item the model judged negatively.
+- An obligation whose judgment could not be honoured is left indeterminate,
+  rather than reported as an obligation lacking evidence.
+- A review holding an indeterminate judgment does not reach a clean completion
+  verdict.
+- The usable judgments returned in the same response as one that cannot be
+  honoured are retained.
+- The review names the stage and the id that could not be honoured, so a reader
+  can tell which judgment was not obtained and why.

--- a/tests/fixtures/rating-stability/163-gate2-run1/judgement.md
+++ b/tests/fixtures/rating-stability/163-gate2-run1/judgement.md
@@ -1,0 +1,18 @@
+# Judgement — #163 Gate 2, run 1 (`41cd0da`)
+
+Verdict: **NO-MATERIAL-GAPS**. All 10 obligations `addressed` and `strongly
+supported`; open question resolved; no recommended tests.
+
+Included as the **negative control**: a single run that came back clean, against
+which the #167 runs' churn can be compared. It was never re-run, so it says
+nothing about whether *this* verdict is reproducible — which is itself the point.
+A clean verdict from one run is not evidence of stability.
+
+Mapping was audited before the verdict was believed (CLAUDE.md requires it):
+9 partitioned calls, 104 entries, 59% empty `obligation_ids`, **all 10
+obligations mapped, zero foreign ids**.
+
+Caveat worth carrying: the first mapping audit globbed the last 40 mapping
+transcripts and showed obligation ids from earlier #164/#36 runs, which looked
+like foreign-id leakage. Re-scoping by mtime to this run's 13 transcripts gave
+the real number. Any tooling built on this corpus must filter by run.

--- a/tests/fixtures/rating-stability/167-gate2-run1/check-output.log
+++ b/tests/fixtures/rating-stability/167-gate2-run1/check-output.log
@@ -1,0 +1,177 @@
+Task completion: INCOMPLETE
+
+2 obligation(s) with non-discriminating test evidence (replace-written-file-with-command, fixed-command-surface).
+
+Obligations:
+
+  1. Replace the written file `.acceptance/next-instruction.md` with the `acceptance recommendation --criterion <id> [--format json|text]` command surface for retrieving a criterion's recommendation on demand, defaulting to JSON.
+       code evidence: addressed
+         1.1  src/acceptance/cli.py#@@ -172,26 +174,33 @@ def run_check(
+         1.2  src/acceptance/cli.py#@@ -412,6 +421,23 @@ def build_parser() -> argparse.ArgumentParser:
+         1.3  src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+         1.4  src/acceptance/report.py#@@ -76,6 +76,13 @@ def render_report(review: Review) -> str:
+         1.5  src/acceptance/report.py#@@ -84,75 +91,39 @@ def render_report(review: Review) -> str:
+         1.6  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -71,7 +71,7 @@ Used during development, before/while preparing a PR.
+         1.7  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -264,7 +264,7 @@ Recommendations are emitted in a **structured, machine-readable form** — each
+         1.8  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -338,7 +338,7 @@ Show the system can independently identify meaningful completion and test-eviden
+         1.9  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -439,7 +439,8 @@ Unrequested changes:
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  2. Keep the recommendation retrieval command surface fixed to the specified command name and arguments in the specification.
+       code evidence: addressed
+         2.1  src/acceptance/cli.py#@@ -412,6 +421,23 @@ def build_parser() -> argparse.ArgumentParser:
+         2.2  src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+         2.3  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -71,7 +71,7 @@ Used during development, before/while preparing a PR.
+         2.4  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -264,7 +264,7 @@ Recommendations are emitted in a **structured, machine-readable form** — each
+         2.5  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -338,7 +338,7 @@ Show the system can independently identify meaningful completion and test-eviden
+         2.6  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -439,7 +439,8 @@ Unrequested changes:
+       test evidence: nominally supported  [tier: static]
+         2.7  tests/test_cli.py::test_check_rejects_unknown_mode
+         2.8  tests/test_cli.py::test_check_requires_all_flags
+
+  3. Ensure recommendation retrieval performs no speculative writes so nothing can go stale.
+       code evidence: addressed
+         3.1  src/acceptance/cli.py#@@ -172,26 +174,33 @@ def run_check(
+         3.2  src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+         3.3  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+       test evidence: strongly supported  [tier: static]
+         3.4  tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo
+         3.5  tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps
+
+  4. Return a recommendation from stored review state on demand without re-running the review.
+       code evidence: addressed
+         4.1  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+         4.2  src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+         4.3  src/acceptance/review_store.py#@@ -37,3 +37,18 @@ class ReviewStore:
+       test evidence: strongly supported  [tier: static]
+         4.4  tests/test_cli.py::test_recommendation_defaults_to_the_most_recently_stored_review
+         4.5  tests/test_cli.py::test_recommendation_returns_the_stored_prescription_for_a_criterion
+         4.6  tests/test_review_store.py::test_rerun_over_the_same_head_overwrites_in_place
+         4.7  tests/test_review_store.py::test_review_round_trips_through_the_store
+
+  5. Keep the recommendation's structured fields as discrete keys with their prose values intact.
+       code evidence: addressed
+         5.1  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+       test evidence: strongly supported  [tier: static]
+         5.2  tests/benchmark/test_coverage.py::test_the_shared_pipeline_runs_every_stage
+         5.3  tests/test_cli.py::test_recommendation_returns_the_stored_prescription_for_a_criterion
+         5.4  tests/test_report.py::test_every_test_evidence_line_shows_a_tier
+         5.5  tests/test_report.py::test_open_questions_and_recommendations_are_numbered
+
+  6. Make the review's own output tell a reader how to obtain the recommendation detail.
+       code evidence: addressed
+         6.1  src/acceptance/report.py#@@ -76,6 +76,13 @@ def render_report(review: Review) -> str:
+         6.2  src/acceptance/report.py#@@ -84,75 +91,39 @@ def render_report(review: Review) -> str:
+       test evidence: strongly supported  [tier: static]
+         6.3  tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps
+         6.4  tests/test_cli.py::test_render_classify_output
+         6.5  tests/test_cli.py::test_report_shell_renders_all_sections_present_and_empty
+         6.6  tests/test_report.py::test_a_carried_forward_obligation_says_so_and_names_the_revision
+         6.7  tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered
+
+  7. Remove any pre-existing `.acceptance/next-instruction.md` left by an earlier version and report that it was removed.
+       code evidence: addressed
+         7.1  src/acceptance/cli.py#@@ -172,26 +174,33 @@ def run_check(
+         7.2  src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+         7.3  tests/test_cli.py#@@ -549,33 +543,142 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+       test evidence: strongly supported  [tier: static]
+         7.4  tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo
+         7.5  tests/test_cli.py::test_a_stale_instruction_file_is_removed_and_the_removal_reported
+         7.6  tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps
+         7.7  tests/test_cli.py::test_the_removal_leaves_the_report_as_the_only_statement_of_status
+         7.8  tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered
+
+  8. Leave the review's own output as the only statement of status when starting from a repo that already contains `.acceptance/next-instruction.md`.
+       code evidence: addressed
+         8.1  src/acceptance/cli.py#@@ -172,26 +174,33 @@ def run_check(
+         8.2  src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+         8.3  tests/benchmark/test_coverage.py#@@ -663,32 +663,32 @@ def test_the_shared_pipeline_partitions_the_mapping_call(tmp_path):
+         8.4  tests/benchmark/test_coverage.py#@@ -714,19 +714,5 @@ def test_the_shared_pipeline_writes_nothing_into_the_reviewed_repo(tmp_path):
+         8.5  tests/test_cli.py#@@ -549,33 +543,142 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+       test evidence: strongly supported  [tier: static]
+         8.6  tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo
+         8.7  tests/test_cli.py::test_a_stale_instruction_file_is_removed_and_the_removal_reported
+         8.8  tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps
+         8.9  tests/test_cli.py::test_the_removal_leaves_the_report_as_the_only_statement_of_status
+         8.10  tests/test_report.py::test_empty_review_renders_the_full_shell
+         8.11  tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered
+
+  9. Return an empty result when a criterion has no recommendation.
+       code evidence: addressed
+         9.1  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+         9.2  tests/test_cli.py#@@ -549,33 +543,142 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+       test evidence: strongly supported  [tier: static]
+         9.3  tests/test_cli.py::test_recommendation_for_an_unknown_criterion_is_empty_not_an_error
+         9.4  tests/test_review_store.py::test_read_missing_revision_returns_none
+
+  10. Default retrieval to the most recently stored review when the caller does not name one.
+       code evidence: addressed
+         10.1  src/acceptance/review_store.py#@@ -37,3 +37,18 @@ class ReviewStore:
+         10.2  src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+       test evidence: strongly supported  [tier: static]
+         10.3  tests/test_cli.py::test_recommendation_defaults_to_the_most_recently_stored_review
+         10.4  tests/test_review_store.py::test_rerun_over_the_same_head_overwrites_in_place
+
+  11. Produce byte-identical output for repeated retrievals over unchanged review state.
+       code evidence: addressed
+         11.1  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+         11.2  tests/test_cli.py#@@ -549,33 +543,142 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+       test evidence: strongly supported  [tier: static]
+         11.3  tests/test_cli.py::test_two_retrievals_over_unchanged_state_are_byte_identical
+         11.4  tests/test_review_store.py::test_rerun_over_the_same_head_overwrites_in_place
+
+  12. Keep the specification from describing the recommendation as a written file.
+       code evidence: addressed
+         12.1  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -71,7 +71,7 @@ Used during development, before/while preparing a PR.
+         12.2  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -264,7 +264,7 @@ Recommendations are emitted in a **structured, machine-readable form** — each
+         12.3  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -338,7 +338,7 @@ Show the system can independently identify meaningful completion and test-eviden
+         12.4  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -439,7 +439,8 @@ Unrequested changes:
+       test evidence: strongly supported  [tier: static]
+         12.5  tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered
+
+Unrequested changes:
+  1. [in_service] The CLI now removes `.acceptance/next-instruction.md` during `check` and prints a removal notice. The obligations require removing the stale file and making retrieval on-demand, but they do not call for changing the normal check output to emit an extra status message after deletion.
+       src/acceptance/cli.py#@@ -172,26 +174,33 @@ def run_check(
+       src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+       tests/test_cli.py#@@ -511,21 +511,15 @@ def test_check_without_a_head_reviews_the_working_tree(
+       tests/test_cli.py#@@ -549,33 +543,142 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+  2. [in_service] `recommendation` now defaults to the most recently stored review by filesystem mtime. The task requires defaulting to the most recent stored review, but not to a specific mtime-based selection policy; this is an implementation choice that changes behavior when multiple stored reviews have close or manipulated timestamps.
+       src/acceptance/review_store.py#@@ -37,3 +37,18 @@ class ReviewStore:
+  3. [in_service] The new recommendation retrieval command returns `{}` for a missing criterion recommendation and treats that as a successful CLI result. The obligations ask for an empty result when a criterion has no recommendation, but they do not specify the exact JSON shape or that the command should succeed with an empty object rather than another empty representation.
+       src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+       src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+       tests/test_cli.py#@@ -549,33 +543,142 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+  4. [in_service] `render_report` now appends per-criterion `full detail: acceptance recommendation --criterion <id>` lines inside the report. The obligations require the review output to tell readers how to obtain recommendation detail, but not to add a per-recommendation command line to every listed recommendation; that is extra report content beyond the specified discoverability change.
+       src/acceptance/report.py#@@ -76,6 +76,13 @@ def render_report(review: Review) -> str:
+  5. [in_service] The new `acceptance.recommendation` module introduces `_FIELDS` and helper rendering functions to serialize stored recommendations. The retrieval feature is requested, but the specific internal factoring and field list constant are implementation details not demanded by the obligations.
+       src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+  6. [in_service] The benchmark test was rewritten from asserting the old write/no-write boundary to asserting that neither the pipeline nor the CLI writes into the reviewed repo. The obligations require removing the stale file and ensuring no speculative writes, but they do not require changing benchmark coverage to remove the CLI-write assertion or to broaden the invariant in this way.
+       tests/benchmark/test_coverage.py#@@ -663,32 +663,32 @@ def test_the_shared_pipeline_partitions_the_mapping_call(tmp_path):
+       tests/benchmark/test_coverage.py#@@ -714,19 +714,5 @@ def test_the_shared_pipeline_writes_nothing_into_the_reviewed_repo(tmp_path):
+  7. [in_service] The report test now asserts that `next-instruction.md` is absent from the rendered report and that the new command string appears. The obligations require discoverability and spec updates, but not this exact negative assertion about the filename text in report output.
+       tests/test_report.py#@@ -17,9 +17,8 @@ from acceptance.review_state import (
+       tests/test_report.py#@@ -109,7 +107,10 @@ def test_report_renders_each_obligation_with_both_axes_numbered():
+
+Open questions:
+  1. [resolved] What exact output shape should `acceptance recommendation --criterion <id> [--format json|text]` use for JSON and text modes, including field names, ordering, and whether empty results are represented as `null`, `{}`, or another form?
+       The diff adds a dedicated recommendation renderer and CLI flag handling that specifies the output modes. `src/acceptance/recommendation.py#0` defines the JSON payload fields via `_FIELDS`, renders missing recommendations as `{}` (not `null`), and uses `canonical_json(payload)` for JSON output. It also defines the text form as a simple labeled block starting with `Criterion: ...` and then one line per remaining field in `_FIELDS` order. `src/acceptance/cli.py#2` wires `--format json|text` with default `json`, and `src/acceptance/cli.py#3` prints the rendered string directly.
+
+Recommended tests:
+  1. Users can invoke `acceptance recommendation --criterion <id>` to retrieve a recommendation instead of relying on a generated file, and the default output format is JSON.
+       inputs:  Use a review state that contains at least one stored recommendation, then invoke `acceptance recommendation --criterion <existing-id>` without any `--format` flag. The input must be the same stored review that previously would have produced a next-instruction file, so the correct implementation returns the recommendation directly while the defective one still depends on a generated file or defaults to non-JSON output.
+       detects: The CLI still relies on a generated next-instruction file instead of retrieving the recommendation on demand, or it defaults to text/other output instead of JSON.
+       full detail: acceptance recommendation --criterion replace-written-file-with-command
+  2. The documented interface names `acceptance recommendation --criterion <id> [--format json|text]` as the command to use.
+       inputs:  Invoke the CLI with command-surface variants that should be rejected by the documented interface, such as `acceptance check --criterion <id>` or `acceptance recommend --criterion <id>`, and separately invoke `acceptance recommendation` without `--criterion`. Also include the valid documented form `acceptance recommendation --criterion <id> [--format json|text]` as the control.
+       detects: The CLI accepts an extra mode name like `check` or `recommend` instead of only `recommendation`, or it makes `--criterion` optional/ignores required flags for recommendation retrieval.
+       full detail: acceptance recommendation --criterion fixed-command-surface
+
+Evidence limitations:
+  1. Judgments are static inferences unless a higher tier is recorded; the full application was not independently executed.
+
+Next: retrieve a criterion's full recommendation with
+  acceptance recommendation --criterion <id>
+
+Removed a stale .acceptance/next-instruction.md left by an earlier version; recommendations are now retrieved with
+  acceptance recommendation --criterion <id>

--- a/tests/fixtures/rating-stability/167-gate2-run1/current-task.md
+++ b/tests/fixtures/rating-stability/167-gate2-run1/current-task.md
@@ -1,0 +1,56 @@
+# Task
+Stop pushing a recommendation file nobody asked for, and let an agent pull the
+detail when it decides to act. Today a review with gaps writes its next
+instruction to one fixed path in the repo. That path is keyed to no task and no
+revision, so whichever run last found gaps owns it; a later clean run leaves it
+untouched, and the file then contradicts the report while only the report is
+telling the truth. The content is also a second, lossier copy of recommendations
+the review already carries as structured fields. Replace the written file
+`.acceptance/next-instruction.md` with `acceptance recommendation --criterion
+<id> [--format json|text]`, which returns a criterion's recommendation from
+stored review state on demand, defaulting to JSON.
+
+The command surface is fixed here rather than left to implementation: the
+specification has to name a specific command, and a document written against a
+command that later changes would recreate the same two-artifacts-drifting
+failure this task exists to remove.
+
+## Constraints
+- Nothing is written speculatively, so nothing can go stale.
+- A recommendation returned on demand is the one the stored review holds for that
+  criterion — retrieval reads state, it does not re-run the review.
+- The structured fields keep their prose values. Compressing a field to a terse
+  token loses the reasoning that makes the recommendation actionable.
+- A reader of the review's own output can tell how to obtain the detail; if the
+  output does not make the detail's existence known, the pull never happens.
+- A repo that already contains `.acceptance/next-instruction.md` from an
+  earlier version is left in a state where nothing on disk contradicts the
+  review.
+
+## Scope exclusions
+- What the recommendations themselves contain is unchanged; this task moves how
+  they are obtained, not how they are produced.
+- The review-state store's format and the review pipeline are unchanged.
+- Recording that this task supersedes the earlier one belongs to the issue
+  tracker, not to any file in this repo.
+
+## Completion expectations
+- Implementation
+- `acceptance recommendation --criterion <id>` returns that criterion's
+  recommendation from stored review state, without re-running the review.
+- The retrieved recommendation carries each structured field as a discrete key
+  — required inputs, boundary conditions, expected output, required assertions,
+  plausible defect, repo conventions — with their prose values intact.
+- A criterion that has no recommendation returns an empty result rather than an
+  error.
+- Retrieval defaults to the most recently stored review when the caller does not
+  name one.
+- No code path writes `.acceptance/next-instruction.md`.
+- A run that finds an `.acceptance/next-instruction.md` left by an earlier
+  version removes it and reports that it did so.
+- Starting from a repo that already contains `.acceptance/next-instruction.md`,
+  a clean run leaves the review's own output as the only statement of status.
+- The review's rendered output names the command to run, not a file to open, for
+  every verdict that has gaps.
+- Two retrievals over unchanged review state return byte-identical output.
+- The specification no longer describes the recommendation as a written file.

--- a/tests/fixtures/rating-stability/167-gate2-run1/judgement.md
+++ b/tests/fixtures/rating-stability/167-gate2-run1/judgement.md
@@ -1,0 +1,16 @@
+# Judgement — #167 Gate 2, run 1 (`07075a6`)
+
+Verdict: **INCOMPLETE**. 2 of 12 obligations below `strongly supported`.
+
+| obligation | rating | my judgement | disposition |
+|---|---|---|---|
+| `replace-written-file-with-command` | `unsupported`, **no mapped test** | **Partly tool, partly real.** A compound umbrella obligation ("replace the file WITH the command surface, defaulting to JSON") whose constituents the other 11 obligations already cover individually — a #144-shaped decomposition artifact, and the mapper reasonably preferred the specific obligations. But its *"defaulting to JSON"* clause appears in no other obligation, and I tested that only implicitly (a test that happened to `json.loads` the output). | **Addressed** — added `test_json_is_the_default_format_when_none_is_requested`, stating the guarantee by name. |
+| `fixed-command-surface` | `nominally supported`, mapped to `test_check_rejects_unknown_mode` and `test_check_requires_all_flags` (both irrelevant) | **Real.** #167 fixed the command surface up front precisely so the spec could name it; nothing pinned the spec string to the parser, which is the drift this task exists to prevent. The two mapped tests are unrelated — mapping noise on top of a genuine gap. | **Addressed** — added tests pinning the documented command string to the parser, plus rejection of undocumented command names, missing `--criterion`, and unknown `--format`. |
+
+**Outcome:** both rose to `strongly supported` in run 2. The fixes worked.
+
+**Retrospective (added after run 3):** run 1 rated
+`default-to-most-recent-review` **`strongly supported`** while its only test
+stored a *single* review — a test that could not distinguish "the newest" from
+"the only one". Run 2 correctly flagged it. So run 1's STRONG here was a **false
+negative**: the rating was wrong, not merely unstable.

--- a/tests/fixtures/rating-stability/167-gate2-run2/check-output.log
+++ b/tests/fixtures/rating-stability/167-gate2-run2/check-output.log
@@ -1,0 +1,211 @@
+Task completion: INCOMPLETE
+
+4 obligation(s) with non-discriminating test evidence (retrieve-from-stored-review-state, default-to-most-recent-review, byte-identical-retrievals, spec-no-longer-describes-written-file).
+
+Obligations:
+
+  1. Replace the written file `.acceptance/next-instruction.md` with the `acceptance recommendation --criterion <id> [--format json|text]` command surface for retrieving a criterion's recommendation on demand, defaulting to JSON.
+       code evidence: addressed
+         1.1  src/acceptance/cli.py#@@ -33,7 +33,9 @@ from acceptance.coverage.open_questions import apply_open_question_resolutions,
+         1.2  src/acceptance/cli.py#@@ -172,26 +174,33 @@ def run_check(
+         1.3  src/acceptance/cli.py#@@ -412,6 +421,23 @@ def build_parser() -> argparse.ArgumentParser:
+         1.4  src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+         1.5  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+       test evidence: strongly supported  [tier: static]
+         1.6  tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps
+         1.7  tests/test_cli.py::test_json_is_the_default_format_when_none_is_requested
+
+  2. Keep the recommendation retrieval command surface fixed to the specified command name and arguments in the specification.
+       code evidence: addressed
+         2.1  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -71,7 +71,7 @@ Used during development, before/while preparing a PR.
+         2.2  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -264,7 +264,7 @@ Recommendations are emitted in a **structured, machine-readable form** — each
+         2.3  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -338,7 +338,7 @@ Show the system can independently identify meaningful completion and test-eviden
+         2.4  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -439,7 +439,8 @@ Unrequested changes:
+         2.5  src/acceptance/cli.py#@@ -412,6 +421,23 @@ def build_parser() -> argparse.ArgumentParser:
+         2.6  tests/test_cli.py#@@ -511,21 +511,15 @@ def test_check_without_a_head_reviews_the_working_tree(
+         2.7  tests/test_cli.py#@@ -549,33 +543,231 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+       test evidence: strongly supported  [tier: static]
+         2.8  tests/test_cli.py::test_a_command_name_the_spec_does_not_document_is_rejected
+         2.9  tests/test_cli.py::test_an_undocumented_format_is_rejected
+         2.10  tests/test_cli.py::test_criterion_is_required
+         2.11  tests/test_cli.py::test_json_is_the_default_format_when_none_is_requested
+         2.12  tests/test_cli.py::test_the_spec_names_the_command_the_cli_actually_accepts
+
+  3. Ensure recommendation retrieval performs no speculative writes so nothing can go stale.
+       code evidence: addressed
+         3.1  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+         3.2  src/acceptance/cli.py#@@ -172,26 +174,33 @@ def run_check(
+         3.3  src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+       test evidence: strongly supported  [tier: static]
+         3.4  tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo
+         3.5  tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps
+
+  4. Return a recommendation from stored review state on demand without re-running the review.
+       code evidence: addressed
+         4.1  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+         4.2  src/acceptance/review_store.py#@@ -37,3 +37,18 @@ class ReviewStore:
+         4.3  src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+       test evidence: partially supported  [tier: static]
+         4.4  tests/test_cli.py::test_check_persists_the_review_to_the_store
+         4.5  tests/test_cli.py::test_recommendation_defaults_to_the_most_recently_stored_review
+         4.6  tests/test_cli.py::test_recommendation_returns_the_stored_prescription_for_a_criterion
+         4.7  tests/test_review_store.py::test_review_round_trips_through_the_store
+
+  5. Keep the recommendation's structured fields as discrete keys with their prose values intact.
+       code evidence: addressed
+         5.1  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+         5.2  tests/test_cli.py#@@ -549,33 +543,231 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+       test evidence: strongly supported  [tier: static]
+         5.3  tests/benchmark/test_coverage.py::test_the_shared_pipeline_runs_every_stage
+         5.4  tests/test_cli.py::test_recommendation_defaults_to_the_most_recently_stored_review
+         5.5  tests/test_cli.py::test_recommendation_returns_the_stored_prescription_for_a_criterion
+         5.6  tests/test_report.py::test_open_questions_and_recommendations_are_numbered
+
+  6. Make the review's own output tell a reader how to obtain the recommendation detail.
+       code evidence: addressed
+         6.1  src/acceptance/report.py#@@ -76,6 +76,13 @@ def render_report(review: Review) -> str:
+         6.2  src/acceptance/report.py#@@ -84,75 +91,39 @@ def render_report(review: Review) -> str:
+         6.3  tests/test_report.py#@@ -109,7 +107,10 @@ def test_report_renders_each_obligation_with_both_axes_numbered():
+       test evidence: strongly supported  [tier: static]
+         6.4  tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps
+         6.5  tests/test_cli.py::test_render_classify_output
+         6.6  tests/test_report.py::test_multi_word_verdict_renders_as_the_16_headline
+         6.7  tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered
+         6.8  tests/test_report.py::test_unclassified_obligation_renders_as_unclassified
+
+  7. Remove any pre-existing `.acceptance/next-instruction.md` left by an earlier version and report that it was removed.
+       code evidence: addressed
+         7.1  src/acceptance/cli.py#@@ -172,26 +174,33 @@ def run_check(
+         7.2  src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+         7.3  tests/test_cli.py#@@ -549,33 +543,231 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+       test evidence: strongly supported  [tier: static]
+         7.4  tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo
+         7.5  tests/test_cli.py::test_a_stale_instruction_file_is_removed_and_the_removal_reported
+         7.6  tests/test_cli.py::test_the_removal_leaves_the_report_as_the_only_statement_of_status
+
+  8. Leave the review's own output as the only statement of status when starting from a repo that already contains `.acceptance/next-instruction.md`.
+       code evidence: addressed
+         8.1  src/acceptance/cli.py#@@ -172,26 +174,33 @@ def run_check(
+         8.2  src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+         8.3  tests/test_cli.py#@@ -549,33 +543,231 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+       test evidence: strongly supported  [tier: static]
+         8.4  tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo
+         8.5  tests/test_cli.py::test_a_stale_instruction_file_is_removed_and_the_removal_reported
+         8.6  tests/test_cli.py::test_the_removal_leaves_the_report_as_the_only_statement_of_status
+
+  9. Return an empty result when a criterion has no recommendation.
+       code evidence: addressed
+         9.1  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+         9.2  src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+         9.3  tests/test_cli.py#@@ -549,33 +543,231 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+       test evidence: strongly supported  [tier: static]
+         9.4  tests/test_cli.py::test_recommendation_for_an_unknown_criterion_is_empty_not_an_error
+         9.5  tests/test_review_store.py::test_read_missing_revision_returns_none
+
+  10. Default retrieval to the most recently stored review when the caller does not name one.
+       code evidence: addressed
+         10.1  src/acceptance/review_store.py#@@ -37,3 +37,18 @@ class ReviewStore:
+         10.2  src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+         10.3  tests/test_cli.py#@@ -549,33 +543,231 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+       test evidence: nominally supported  [tier: static]
+         10.4  tests/test_cli.py::test_recommendation_defaults_to_the_most_recently_stored_review
+
+  11. Produce byte-identical output for repeated retrievals over unchanged review state.
+       code evidence: addressed
+         11.1  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+         11.2  tests/test_cli.py#@@ -549,33 +543,231 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+       test evidence: partially supported  [tier: static]
+         11.3  tests/test_cli.py::test_two_retrievals_over_unchanged_state_are_byte_identical
+         11.4  tests/test_cli.py::test_two_runs_over_the_same_input_are_byte_identical
+         11.5  tests/test_review_store.py::test_rerun_over_the_same_head_overwrites_in_place
+
+  12. Keep the specification from describing the recommendation as a written file.
+       code evidence: addressed
+         12.1  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -71,7 +71,7 @@ Used during development, before/while preparing a PR.
+         12.2  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -264,7 +264,7 @@ Recommendations are emitted in a **structured, machine-readable form** — each
+         12.3  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -338,7 +338,7 @@ Show the system can independently identify meaningful completion and test-eviden
+         12.4  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -439,7 +439,8 @@ Unrequested changes:
+         12.5  tests/test_cli.py#@@ -549,33 +543,231 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+       test evidence: partially supported  [tier: static]
+         12.6  tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps
+         12.7  tests/test_cli.py::test_the_spec_no_longer_names_a_written_file
+         12.8  tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered
+
+Unrequested changes:
+  1. [in_service] The CLI now removes `.acceptance/next-instruction.md` during `check` and prints a removal notice. The obligations require removing the stale file and making retrieval on-demand, but they do not call for changing the check command to emit this extra status text or to perform file deletion as part of normal review output beyond reporting the removal.
+       src/acceptance/cli.py#@@ -172,26 +174,33 @@ def run_check(
+       src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+       tests/benchmark/test_coverage.py#@@ -663,32 +663,32 @@ def test_the_shared_pipeline_partitions_the_mapping_call(tmp_path):
+       tests/benchmark/test_coverage.py#@@ -714,19 +714,5 @@ def test_the_shared_pipeline_writes_nothing_into_the_reviewed_repo(tmp_path):
+       tests/test_cli.py#@@ -511,21 +511,15 @@ def test_check_without_a_head_reviews_the_working_tree(
+       tests/test_cli.py#@@ -549,33 +543,231 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+  2. [in_service] `src/acceptance/recommendation.py` introduces a new helper module and rendering logic for recommendation retrieval. The retrieval command itself is requested, but the specific module split, `_FIELDS` constant, and helper functions are implementation choices not explicitly required by the obligations.
+       src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+       src/acceptance/cli.py#@@ -33,7 +33,9 @@ from acceptance.coverage.open_questions import apply_open_question_resolutions,
+       src/acceptance/cli.py#@@ -412,6 +421,23 @@ def build_parser() -> argparse.ArgumentParser:
+       src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+  3. [in_service] `ReviewStore.latest()` selects the most recently modified JSON file by filesystem mtime. The obligations require defaulting to the most recently stored review, but they do not specify mtime-based selection; this adds a concrete ordering policy that may differ from other plausible notions of 'most recent'.
+       src/acceptance/review_store.py#@@ -37,3 +37,18 @@ class ReviewStore:
+       src/acceptance/cli.py#@@ -412,6 +421,23 @@ def build_parser() -> argparse.ArgumentParser:
+       src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+  4. [in_service] The report now prints a per-recommendation 'full detail' command line for each criterion, in addition to the overall next-step command. The obligations require the review output to tell a reader how to obtain the recommendation detail, but not to add this extra per-item command text to every recommendation entry.
+       src/acceptance/report.py#@@ -76,6 +76,13 @@ def render_report(review: Review) -> str:
+  5. [in_service] `render_report` now suppresses the old 'Recommended next instruction: (none)' line whenever `_has_gaps(review)` is true, replacing it with a command hint. The obligations require discoverability of retrieval and removal of the file-based instruction, but they do not specify this new gap-detection gate or the exact report wording change.
+       src/acceptance/report.py#@@ -84,75 +91,39 @@ def render_report(review: Review) -> str:
+  6. [separable] The benchmark test was rewritten from asserting the CLI writes a next-instruction file to asserting it never writes into the repo and that the file is absent. The obligations require removing the stale file and leaving only review output, but not this broader benchmark behavior change or the new assertion structure.
+       tests/benchmark/test_coverage.py#@@ -663,32 +663,32 @@ def test_the_shared_pipeline_partitions_the_mapping_call(tmp_path):
+       tests/benchmark/test_coverage.py#@@ -714,19 +714,5 @@ def test_the_shared_pipeline_writes_nothing_into_the_reviewed_repo(tmp_path):
+  7. [in_service] The CLI test suite adds many new cases around the new recommendation command, default format, error handling, and spec-string checks. While some of these are requested by the obligations, the added parser-surface assertions about the exact documented command string and rejection of undocumented aliases go beyond the stated requirements.
+       tests/test_cli.py#@@ -511,21 +511,15 @@ def test_check_without_a_head_reviews_the_working_tree(
+       tests/test_cli.py#@@ -549,33 +543,231 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+  8. [in_service] `tests/test_report.py` removes the old `render_next_instruction` coverage and changes report expectations to the new command hint. The obligations require the spec and output to stop describing a written file, but not the full deletion of the prior instruction-rendering tests or the exact new report assertions.
+       tests/test_report.py#@@ -17,9 +17,8 @@ from acceptance.review_state import (
+       tests/test_report.py#@@ -88,7 +87,6 @@ def test_report_renders_each_obligation_with_both_axes_numbered():
+       tests/test_report.py#@@ -109,7 +107,10 @@ def test_report_renders_each_obligation_with_both_axes_numbered():
+       tests/test_report.py#@@ -268,192 +269,6 @@ def test_the_two_axes_render_independently_for_the_same_obligation():
+
+Changes since 07075a6d:
+  closed:
+    - Replace the written file `.acceptance/next-instruction.md` with the `acceptance recommendation --criterion <id> [--format json|text]` command surface for retrieving a criterion's recommendation on demand, defaulting to JSON.
+        code evidence: addressed -> addressed
+        test evidence: unsupported -> strongly supported
+    - Keep the recommendation retrieval command surface fixed to the specified command name and arguments in the specification.
+        code evidence: addressed -> addressed
+        test evidence: nominally supported -> strongly supported
+  moved:
+    - Return a recommendation from stored review state on demand without re-running the review.
+        test evidence: strongly supported -> partially supported
+    - Default retrieval to the most recently stored review when the caller does not name one.
+        test evidence: strongly supported -> nominally supported
+    - Produce byte-identical output for repeated retrievals over unchanged review state.
+        test evidence: strongly supported -> partially supported
+    - Keep the specification from describing the recommendation as a written file.
+        test evidence: strongly supported -> partially supported
+
+Open questions:
+  1. [resolved] What exact output shape should `acceptance recommendation --criterion <id> [--format json|text]` use for JSON and text modes, including field names, ordering, and whether empty results are represented as `null`, `{}`, or another form?
+       The diff adds a dedicated recommendation renderer that defines both modes: JSON uses `canonical_json` over a fixed `_FIELDS` tuple, and empty results render as `{}`; text mode prints `Criterion: ...` followed by the remaining fields in `_FIELDS` order, with list values expanded as bullet lines and empty results as `(no recommendation for this criterion)`. The CLI wires `--format` to these renderers and defaults to JSON.
+
+Recommended tests:
+  1. The command reads persisted review state and produces the stored recommendation for the requested criterion without invoking the review pipeline again.
+       inputs:  Create a stored review state where the requested criterion exists in one revision, and a different revision either lacks that criterion or contains a different recommendation; invoke `acceptance recommendation --criterion <id>` against the stored review without any live/replay pipeline hooks enabled. The input must make a recomputation or wrong-revision read observable by producing a different recommendation or no recommendation at all.
+       detects: `recommendation` recomputes the review by rerunning the pipeline instead of reading stored review state, or reads the wrong stored revision but happens to return the same recommendation for the fixture.
+       full detail: acceptance recommendation --criterion retrieve-from-stored-review-state
+  2. Invoking recommendation retrieval without naming a review uses the latest stored review as the source.
+       inputs:  Populate the review store with at least two stored reviews for different revisions, written in a known order where the older review and the newest review have different recommendations for the same criterion. Invoke `acceptance recommendation --criterion <id>` without `--revision`. The inputs must make oldest-vs-newest selection observable.
+       detects: When no revision is named, `recommendation` reads the oldest stored review instead of the newest, or chooses an arbitrary stored review based on filesystem order.
+       full detail: acceptance recommendation --criterion default-to-most-recent-review
+  3. Two invocations against the same unchanged stored review state emit exactly the same bytes.
+       inputs:  Use one unchanged stored review state and invoke `acceptance recommendation --criterion <id>` twice in separate calls with identical arguments and environment. The stored recommendation should include enough structured fields to expose any nondeterministic serialization or formatting differences.
+       detects: The store overwrites the same revision in place but retrieval output remains stable; current tests do not catch byte-level drift or nondeterministic rendering across repeated reads.
+       full detail: acceptance recommendation --criterion byte-identical-retrievals
+  4. The spec text refers to recommendation retrieval via command rather than describing the recommendation as a file written to disk.
+       inputs:  Read the spec document text directly and assert against the exact wording around recommendation retrieval. The input should be the current `docs/AI-Assisted-Software-Development-Review-Spec.md` content, with no reliance on runtime behavior.
+       detects: The spec describes retrieval only as a command surface and never as a written file; the current tests may miss a regression where the spec still omits the file-vs-command distinction or fails to pin the new wording.
+       full detail: acceptance recommendation --criterion spec-no-longer-describes-written-file
+
+Evidence limitations:
+  1. Judgments are static inferences unless a higher tier is recorded; the full application was not independently executed.
+
+Next: retrieve a criterion's full recommendation with
+  acceptance recommendation --criterion <id>

--- a/tests/fixtures/rating-stability/167-gate2-run2/current-task.md
+++ b/tests/fixtures/rating-stability/167-gate2-run2/current-task.md
@@ -1,0 +1,56 @@
+# Task
+Stop pushing a recommendation file nobody asked for, and let an agent pull the
+detail when it decides to act. Today a review with gaps writes its next
+instruction to one fixed path in the repo. That path is keyed to no task and no
+revision, so whichever run last found gaps owns it; a later clean run leaves it
+untouched, and the file then contradicts the report while only the report is
+telling the truth. The content is also a second, lossier copy of recommendations
+the review already carries as structured fields. Replace the written file
+`.acceptance/next-instruction.md` with `acceptance recommendation --criterion
+<id> [--format json|text]`, which returns a criterion's recommendation from
+stored review state on demand, defaulting to JSON.
+
+The command surface is fixed here rather than left to implementation: the
+specification has to name a specific command, and a document written against a
+command that later changes would recreate the same two-artifacts-drifting
+failure this task exists to remove.
+
+## Constraints
+- Nothing is written speculatively, so nothing can go stale.
+- A recommendation returned on demand is the one the stored review holds for that
+  criterion — retrieval reads state, it does not re-run the review.
+- The structured fields keep their prose values. Compressing a field to a terse
+  token loses the reasoning that makes the recommendation actionable.
+- A reader of the review's own output can tell how to obtain the detail; if the
+  output does not make the detail's existence known, the pull never happens.
+- A repo that already contains `.acceptance/next-instruction.md` from an
+  earlier version is left in a state where nothing on disk contradicts the
+  review.
+
+## Scope exclusions
+- What the recommendations themselves contain is unchanged; this task moves how
+  they are obtained, not how they are produced.
+- The review-state store's format and the review pipeline are unchanged.
+- Recording that this task supersedes the earlier one belongs to the issue
+  tracker, not to any file in this repo.
+
+## Completion expectations
+- Implementation
+- `acceptance recommendation --criterion <id>` returns that criterion's
+  recommendation from stored review state, without re-running the review.
+- The retrieved recommendation carries each structured field as a discrete key
+  — required inputs, boundary conditions, expected output, required assertions,
+  plausible defect, repo conventions — with their prose values intact.
+- A criterion that has no recommendation returns an empty result rather than an
+  error.
+- Retrieval defaults to the most recently stored review when the caller does not
+  name one.
+- No code path writes `.acceptance/next-instruction.md`.
+- A run that finds an `.acceptance/next-instruction.md` left by an earlier
+  version removes it and reports that it did so.
+- Starting from a repo that already contains `.acceptance/next-instruction.md`,
+  a clean run leaves the review's own output as the only statement of status.
+- The review's rendered output names the command to run, not a file to open, for
+  every verdict that has gaps.
+- Two retrievals over unchanged review state return byte-identical output.
+- The specification no longer describes the recommendation as a written file.

--- a/tests/fixtures/rating-stability/167-gate2-run2/judgement.md
+++ b/tests/fixtures/rating-stability/167-gate2-run2/judgement.md
@@ -1,0 +1,21 @@
+# Judgement — #167 Gate 2, run 2 (`7de7d71`)
+
+Verdict: **INCOMPLETE**. 4 of 12 obligations below `strongly supported` — a
+**different** four from run 1. The two run 1 flagged were now `strongly
+supported`.
+
+The diff since run 1 was **purely additive**: six added tests, nothing deleted or
+weakened. Adding tests cannot reduce the evidence for an obligation, so any
+rating that fell did so for reasons outside the diff.
+
+| obligation | run 1 → run 2 | my judgement | disposition |
+|---|---|---|---|
+| `default-to-most-recent-review` | STRONG → `nominal` | **Real, and run 1 was wrong.** My test stored exactly one review, so it could not distinguish "newest" from "only". The test did not verify its own name. | **Addressed** — two stored reviews that disagree, written in a known order; plus a case where the newest review is the alphabetically *first* filename, which a name-sorted implementation fails. Defect-injected to confirm it bites. |
+| `retrieve-from-stored-review-state` | STRONG → `partial` | **Real.** Nothing distinguished "read stored state" from "recomputed and happened to agree", and nothing proved the *named* revision was read. | **Addressed** — two stored reviews disagreeing on the same criterion, read by explicit `--revision`; plus a test that retrieval builds no model client and never enters the pipeline. |
+| `byte-identical-retrievals` | STRONG → `partial` | **Rating noise.** The existing test invokes twice and compares output exactly, which is precisely what the recommendation asked for. No change made. | **Attributed** to rating instability. |
+| `spec-no-longer-describes-written-file` | STRONG → `partial` | **Rating noise.** `test_the_spec_no_longer_names_a_written_file` asserts directly on spec text — exactly what the recommendation asked for. No change made. | **Attributed** to rating instability. |
+
+**Outcome:** the two I addressed rose to STRONG in run 3. Of the two I attributed
+to noise, `byte-identical-retrievals` returned to STRONG in run 3 with **no
+change of any kind** — confirming the attribution. `spec-no-longer-describes-
+written-file` stayed `partial`.

--- a/tests/fixtures/rating-stability/167-gate2-run3/check-output.log
+++ b/tests/fixtures/rating-stability/167-gate2-run3/check-output.log
@@ -1,0 +1,206 @@
+Task completion: INCOMPLETE
+
+3 obligation(s) with non-discriminating test evidence (no-speculative-writing, remove-stale-next-instruction-file, spec-no-longer-describes-written-file).
+
+Obligations:
+
+  1. Replace the written file `.acceptance/next-instruction.md` with the `acceptance recommendation --criterion <id> [--format json|text]` command surface for retrieving a criterion's recommendation on demand, defaulting to JSON.
+       code evidence: addressed
+         1.1  src/acceptance/cli.py#@@ -33,7 +33,9 @@ from acceptance.coverage.open_questions import apply_open_question_resolutions,
+         1.2  src/acceptance/cli.py#@@ -172,26 +174,33 @@ def run_check(
+         1.3  src/acceptance/cli.py#@@ -412,6 +421,23 @@ def build_parser() -> argparse.ArgumentParser:
+         1.4  src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+         1.5  src/acceptance/report.py#@@ -76,6 +76,13 @@ def render_report(review: Review) -> str:
+         1.6  src/acceptance/report.py#@@ -84,75 +91,39 @@ def render_report(review: Review) -> str:
+         1.7  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -71,7 +71,7 @@ Used during development, before/while preparing a PR.
+         1.8  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -264,7 +264,7 @@ Recommendations are emitted in a **structured, machine-readable form** — each
+         1.9  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -338,7 +338,7 @@ Show the system can independently identify meaningful completion and test-eviden
+         1.10  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -439,7 +439,8 @@ Unrequested changes:
+       test evidence: strongly supported  [tier: static]
+         1.11  tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps
+         1.12  tests/test_cli.py::test_json_is_the_default_format_when_none_is_requested
+         1.13  tests/test_cli.py::test_the_spec_names_the_command_the_cli_actually_accepts
+
+  2. Keep the recommendation retrieval command surface fixed to the specified command name and arguments in the specification.
+       code evidence: addressed
+         2.1  src/acceptance/cli.py#@@ -412,6 +421,23 @@ def build_parser() -> argparse.ArgumentParser:
+         2.2  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -264,7 +264,7 @@ Recommendations are emitted in a **structured, machine-readable form** — each
+         2.3  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -439,7 +439,8 @@ Unrequested changes:
+       test evidence: strongly supported  [tier: static]
+         2.4  tests/test_cli.py::test_a_command_name_the_spec_does_not_document_is_rejected
+         2.5  tests/test_cli.py::test_an_undocumented_format_is_rejected
+         2.6  tests/test_cli.py::test_criterion_is_required
+         2.7  tests/test_cli.py::test_render_decomposition_lists_obligations_and_open_questions
+         2.8  tests/test_cli.py::test_the_spec_names_the_command_the_cli_actually_accepts
+
+  3. Ensure recommendation retrieval performs no speculative writes so nothing can go stale.
+       code evidence: addressed
+         3.1  src/acceptance/cli.py#@@ -172,26 +174,33 @@ def run_check(
+         3.2  src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+         3.3  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+       test evidence: partially supported  [tier: static]
+         3.4  tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo
+         3.5  tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps
+         3.6  tests/test_cli.py::test_retrieval_makes_no_model_call
+
+  4. Return a recommendation from stored review state on demand without re-running the review.
+       code evidence: addressed
+         4.1  src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+         4.2  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+         4.3  src/acceptance/review_store.py#@@ -37,3 +37,18 @@ class ReviewStore:
+       test evidence: strongly supported  [tier: static]
+         4.4  tests/test_cli.py::test_check_persists_the_review_to_the_store
+         4.5  tests/test_cli.py::test_recommendation_returns_the_stored_prescription_for_a_criterion
+         4.6  tests/test_cli.py::test_retrieval_makes_no_model_call
+         4.7  tests/test_cli.py::test_retrieval_reads_the_named_revision_and_not_a_recomputation
+         4.8  tests/test_cli.py::test_retrieval_without_a_revision_uses_the_newest_stored_review
+         4.9  tests/test_cli.py::test_the_newest_review_wins_regardless_of_filename_order
+         4.10  tests/test_review_store.py::test_review_round_trips_through_the_store
+
+  5. Keep the recommendation's structured fields as discrete keys with their prose values intact.
+       code evidence: addressed
+         5.1  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+       test evidence: strongly supported  [tier: static]
+         5.2  tests/benchmark/test_coverage.py::test_the_shared_pipeline_runs_every_stage
+         5.3  tests/test_cli.py::test_recommendation_returns_the_stored_prescription_for_a_criterion
+         5.4  tests/test_report.py::test_open_questions_and_recommendations_are_numbered
+
+  6. Make the review's own output tell a reader how to obtain the recommendation detail.
+       code evidence: addressed
+         6.1  src/acceptance/report.py#@@ -76,6 +76,13 @@ def render_report(review: Review) -> str:
+         6.2  src/acceptance/report.py#@@ -84,75 +91,39 @@ def render_report(review: Review) -> str:
+       test evidence: strongly supported  [tier: static]
+         6.3  tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps
+         6.4  tests/test_cli.py::test_render_classify_output
+         6.5  tests/test_cli.py::test_report_shell_renders_all_sections_present_and_empty
+         6.6  tests/test_report.py::test_multi_word_verdict_renders_as_the_16_headline
+         6.7  tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered
+
+  7. Remove any pre-existing `.acceptance/next-instruction.md` left by an earlier version and report that it was removed.
+       code evidence: addressed
+         7.1  src/acceptance/cli.py#@@ -172,26 +174,33 @@ def run_check(
+         7.2  src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+         7.3  tests/test_cli.py#@@ -549,33 +543,328 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+       test evidence: partially supported  [tier: static]
+         7.4  tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo
+         7.5  tests/test_cli.py::test_a_stale_instruction_file_is_removed_and_the_removal_reported
+         7.6  tests/test_cli.py::test_the_removal_leaves_the_report_as_the_only_statement_of_status
+
+  8. Leave the review's own output as the only statement of status when starting from a repo that already contains `.acceptance/next-instruction.md`.
+       code evidence: addressed
+         8.1  src/acceptance/cli.py#@@ -172,26 +174,33 @@ def run_check(
+         8.2  src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+         8.3  src/acceptance/report.py#@@ -84,75 +91,39 @@ def render_report(review: Review) -> str:
+         8.4  tests/test_cli.py#@@ -549,33 +543,328 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+       test evidence: strongly supported  [tier: static]
+         8.5  tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo
+         8.6  tests/test_cli.py::test_a_stale_instruction_file_is_removed_and_the_removal_reported
+         8.7  tests/test_cli.py::test_report_shell_renders_all_sections_present_and_empty
+         8.8  tests/test_cli.py::test_the_removal_leaves_the_report_as_the_only_statement_of_status
+
+  9. Return an empty result when a criterion has no recommendation.
+       code evidence: addressed
+         9.1  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+         9.2  src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+         9.3  tests/test_cli.py#@@ -549,33 +543,328 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+       test evidence: strongly supported  [tier: static]
+         9.4  tests/test_cli.py::test_recommendation_for_an_unknown_criterion_is_empty_not_an_error
+         9.5  tests/test_review_store.py::test_read_missing_revision_returns_none
+
+  10. Default retrieval to the most recently stored review when the caller does not name one.
+       code evidence: addressed
+         10.1  src/acceptance/review_store.py#@@ -37,3 +37,18 @@ class ReviewStore:
+         10.2  src/acceptance/cli.py#@@ -412,6 +421,23 @@ def build_parser() -> argparse.ArgumentParser:
+         10.3  src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+       test evidence: strongly supported  [tier: static]
+         10.4  tests/test_cli.py::test_retrieval_without_a_revision_uses_the_newest_stored_review
+         10.5  tests/test_cli.py::test_the_newest_review_wins_regardless_of_filename_order
+
+  11. Produce byte-identical output for repeated retrievals over unchanged review state.
+       code evidence: addressed
+         11.1  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+         11.2  tests/test_cli.py#@@ -549,33 +543,328 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+       test evidence: strongly supported  [tier: static]
+         11.3  tests/test_cli.py::test_retrieval_reads_the_named_revision_and_not_a_recomputation
+         11.4  tests/test_cli.py::test_two_retrievals_over_unchanged_state_are_byte_identical
+         11.5  tests/test_review_store.py::test_rerun_over_the_same_head_overwrites_in_place
+
+  12. Keep the specification from describing the recommendation as a written file.
+       code evidence: addressed
+         12.1  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -71,7 +71,7 @@ Used during development, before/while preparing a PR.
+         12.2  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -264,7 +264,7 @@ Recommendations are emitted in a **structured, machine-readable form** — each
+         12.3  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -338,7 +338,7 @@ Show the system can independently identify meaningful completion and test-eviden
+         12.4  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -439,7 +439,8 @@ Unrequested changes:
+       test evidence: partially supported  [tier: static]
+         12.5  tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps
+         12.6  tests/test_cli.py::test_the_spec_no_longer_names_a_written_file
+
+Unrequested changes:
+  1. [in_service] The CLI now deletes `.acceptance/next-instruction.md` during every `check` run, even when the task only required removing the old written-file mechanism and reporting the removal. That adds a new side effect on the reviewed repo beyond the retrieval command surface and stale-file cleanup requirement.
+       src/acceptance/cli.py#@@ -172,26 +174,33 @@ def run_check(
+       src/acceptance/cli.py#@@ -491,10 +517,31 @@ def main(argv: list[str] | None = None) -> int:
+       tests/benchmark/test_coverage.py#@@ -663,32 +663,32 @@ def test_the_shared_pipeline_partitions_the_mapping_call(tmp_path):
+       tests/benchmark/test_coverage.py#@@ -714,19 +714,5 @@ def test_the_shared_pipeline_writes_nothing_into_the_reviewed_repo(tmp_path):
+       tests/test_cli.py#@@ -511,21 +511,15 @@ def test_check_without_a_head_reviews_the_working_tree(
+       tests/test_cli.py#@@ -549,33 +543,328 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+  2. [in_service] The new `ReviewStore.latest()` implementation selects the newest review by filesystem mtime. The obligations require defaulting to the most recent stored review, but they do not require this specific internal selection strategy or the added method itself.
+       src/acceptance/review_store.py#@@ -37,3 +37,18 @@ class ReviewStore:
+       src/acceptance/cli.py#@@ -412,6 +421,23 @@ def build_parser() -> argparse.ArgumentParser:
+       tests/test_cli.py#@@ -549,33 +543,328 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+  3. [in_service] The spec document was edited to describe the new command surface and remove file-based wording. Updating the specification text is not itself required by the functional obligations, which concern behavior and removal of the stale file, not rewriting the spec prose beyond what is necessary to keep it from describing a written file.
+       docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -71,7 +71,7 @@ Used during development, before/while preparing a PR.
+       docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -264,7 +264,7 @@ Recommendations are emitted in a **structured, machine-readable form** — each
+       docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -338,7 +338,7 @@ Show the system can independently identify meaningful completion and test-eviden
+       docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -439,7 +439,8 @@ Unrequested changes:
+  4. [separable] The benchmark test was broadened from checking the pipeline/CLI write boundary to asserting the CLI no longer writes at all and that it removes a stale file. The removal assertion is requested, but the extra restructuring and new benchmark narrative around the changed boundary go beyond the stated obligations.
+       tests/benchmark/test_coverage.py#@@ -663,32 +663,32 @@ def test_the_shared_pipeline_partitions_the_mapping_call(tmp_path):
+       tests/benchmark/test_coverage.py#@@ -714,19 +714,5 @@ def test_the_shared_pipeline_writes_nothing_into_the_reviewed_repo(tmp_path):
+  5. [in_service] `tests/test_cli.py` gained many new tests around parser rejection, default format, byte-identical output, named revision selection, and no-model-call behavior. Some retrieval tests are requested by the new command surface, but several of these specific cases are not explicitly required by the obligations and appear to be additional coverage.
+       tests/test_cli.py#@@ -511,21 +511,15 @@ def test_check_without_a_head_reviews_the_working_tree(
+       tests/test_cli.py#@@ -549,33 +543,328 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+  6. [in_service] `tests/test_report.py` was heavily pruned and rewritten to assert the new command pointer and remove the old next-instruction rendering tests. The obligation requires discoverable retrieval in review output and removing file-based wording, but the wholesale deletion of the prior render-next-instruction test suite is broader than necessary and not directly called for.
+       tests/test_report.py#@@ -17,9 +17,8 @@ from acceptance.review_state import (
+       tests/test_report.py#@@ -88,7 +87,6 @@ def test_report_renders_each_obligation_with_both_axes_numbered():
+       tests/test_report.py#@@ -109,7 +107,10 @@ def test_report_renders_each_obligation_with_both_axes_numbered():
+       tests/test_report.py#@@ -268,192 +269,6 @@ def test_the_two_axes_render_independently_for_the_same_obligation():
+
+Changes since 7de7d718:
+  closed:
+    - Return a recommendation from stored review state on demand without re-running the review.
+        code evidence: addressed -> addressed
+        test evidence: partially supported -> strongly supported
+    - Default retrieval to the most recently stored review when the caller does not name one.
+        code evidence: addressed -> addressed
+        test evidence: nominally supported -> strongly supported
+    - Produce byte-identical output for repeated retrievals over unchanged review state.
+        code evidence: addressed -> addressed
+        test evidence: partially supported -> strongly supported
+  moved:
+    - Ensure recommendation retrieval performs no speculative writes so nothing can go stale.
+        test evidence: strongly supported -> partially supported
+    - Remove any pre-existing `.acceptance/next-instruction.md` left by an earlier version and report that it was removed.
+        test evidence: strongly supported -> partially supported
+
+Open questions:
+  1. [resolved] What exact output shape should `acceptance recommendation --criterion <id> [--format json|text]` use for JSON and text modes, including field names, ordering, and whether empty results are represented as `null`, `{}`, or another form?
+       The diff adds a dedicated recommendation renderer that defines both formats. JSON is produced by `render_json()` using the fixed `_FIELDS` set and `canonical_json`, with empty results rendered as `{}`. Text is produced by `render_text()`, starting with `Criterion: ...` and then emitting the remaining fields in `_FIELDS` order with list values expanded as bullet lines. The CLI wires `--format` to this renderer and defaults to JSON.
+
+Recommended tests:
+  1. Running recommendation retrieval does not create or update any recommendation file or other speculative artifact.
+       inputs:  Use a review state that contains a real recommendation and invoke the on-demand retrieval command (`acceptance recommendation --criterion <id>`) against an existing stored review, while also arranging a repo snapshot before and after the command. The input must be a repo/store state where a correct implementation only reads stored review data, but the defect would cause a new file or other repo mutation to appear.
+       detects: Retrieval makes a model call or otherwise indirectly mutates repo state, emitting or updating a generated recommendation file or other speculative artifact.
+       full detail: acceptance recommendation --criterion no-speculative-writing
+  2. A run that encounters an existing `.acceptance/next-instruction.md` deletes it and emits output indicating the removal.
+       inputs:  Create a repo that already contains `.acceptance/next-instruction.md` before invoking `check`, and run `check` in the default text mode (not JSON mode). The review should be one that produces a normal completion report so the removal message is the only signal of the cleanup path.
+       detects: `check` deletes the stale file and reports it only when running in JSON mode, leaving the text-mode path unchanged.
+       full detail: acceptance recommendation --criterion remove-stale-next-instruction-file
+  3. The spec text refers to recommendation retrieval via command rather than describing the recommendation as a file written to disk.
+       inputs:  Read the spec text and assert against the exact wording around recommendation retrieval, using the documented command surface (`acceptance recommendation --criterion <id>`) as the reference. The input must include the spec section that previously mentioned a file so the test can distinguish command-based retrieval from file-writing language.
+       detects: The spec removes the file name but still frames recommendation retrieval as writing a recommendation artifact to disk.
+       full detail: acceptance recommendation --criterion spec-no-longer-describes-written-file
+
+Evidence limitations:
+  1. Judgments are static inferences unless a higher tier is recorded; the full application was not independently executed.
+
+Next: retrieve a criterion's full recommendation with
+  acceptance recommendation --criterion <id>

--- a/tests/fixtures/rating-stability/167-gate2-run3/current-task.md
+++ b/tests/fixtures/rating-stability/167-gate2-run3/current-task.md
@@ -1,0 +1,56 @@
+# Task
+Stop pushing a recommendation file nobody asked for, and let an agent pull the
+detail when it decides to act. Today a review with gaps writes its next
+instruction to one fixed path in the repo. That path is keyed to no task and no
+revision, so whichever run last found gaps owns it; a later clean run leaves it
+untouched, and the file then contradicts the report while only the report is
+telling the truth. The content is also a second, lossier copy of recommendations
+the review already carries as structured fields. Replace the written file
+`.acceptance/next-instruction.md` with `acceptance recommendation --criterion
+<id> [--format json|text]`, which returns a criterion's recommendation from
+stored review state on demand, defaulting to JSON.
+
+The command surface is fixed here rather than left to implementation: the
+specification has to name a specific command, and a document written against a
+command that later changes would recreate the same two-artifacts-drifting
+failure this task exists to remove.
+
+## Constraints
+- Nothing is written speculatively, so nothing can go stale.
+- A recommendation returned on demand is the one the stored review holds for that
+  criterion — retrieval reads state, it does not re-run the review.
+- The structured fields keep their prose values. Compressing a field to a terse
+  token loses the reasoning that makes the recommendation actionable.
+- A reader of the review's own output can tell how to obtain the detail; if the
+  output does not make the detail's existence known, the pull never happens.
+- A repo that already contains `.acceptance/next-instruction.md` from an
+  earlier version is left in a state where nothing on disk contradicts the
+  review.
+
+## Scope exclusions
+- What the recommendations themselves contain is unchanged; this task moves how
+  they are obtained, not how they are produced.
+- The review-state store's format and the review pipeline are unchanged.
+- Recording that this task supersedes the earlier one belongs to the issue
+  tracker, not to any file in this repo.
+
+## Completion expectations
+- Implementation
+- `acceptance recommendation --criterion <id>` returns that criterion's
+  recommendation from stored review state, without re-running the review.
+- The retrieved recommendation carries each structured field as a discrete key
+  — required inputs, boundary conditions, expected output, required assertions,
+  plausible defect, repo conventions — with their prose values intact.
+- A criterion that has no recommendation returns an empty result rather than an
+  error.
+- Retrieval defaults to the most recently stored review when the caller does not
+  name one.
+- No code path writes `.acceptance/next-instruction.md`.
+- A run that finds an `.acceptance/next-instruction.md` left by an earlier
+  version removes it and reports that it did so.
+- Starting from a repo that already contains `.acceptance/next-instruction.md`,
+  a clean run leaves the review's own output as the only statement of status.
+- The review's rendered output names the command to run, not a file to open, for
+  every verdict that has gaps.
+- Two retrievals over unchanged review state return byte-identical output.
+- The specification no longer describes the recommendation as a written file.

--- a/tests/fixtures/rating-stability/167-gate2-run3/judgement.md
+++ b/tests/fixtures/rating-stability/167-gate2-run3/judgement.md
@@ -1,18 +1,47 @@
 # Judgement — #167 Gate 2, run 3 (`95b880a`)
 
 Verdict: **INCOMPLETE**. 3 of 12 obligations below `strongly supported` — a
-**third** distinct set.
+**third** distinct set. The diff since run 2 touched only `tests/test_cli.py`.
 
-The diff since run 2 touched **only `tests/test_cli.py`**, replacing the
-default-review test and adding retrieval tests.
+> **This file was rewritten.** My first judgement recorded all three findings as
+> tool defects — "movement with no change in evidence". That was **wrong**. On
+> examination every one was a real gap, including a silent file deletion I had
+> introduced. The original reasoning is kept at the bottom because the error is
+> the most instructive thing in this corpus.
 
-| obligation | run 1 → 2 → 3 | my judgement |
+| obligation | run 1 → 2 → 3 | verified judgement |
 |---|---|---|
-| `remove-stale-next-instruction-file` | STRONG → STRONG → `partial` | **Tool defect, cleanest instance in the corpus.** Neither the behaviour nor its test (`test_a_stale_instruction_file_is_removed_and_the_removal_reported`) changed between runs 2 and 3 — verified: `git diff 7de7d71 95b880a -- tests/test_cli.py` contains no hunk touching that test. Only *other* tests in the same file changed. An obligation cannot lose evidence because a neighbouring test was edited. |
-| `no-speculative-writing` | STRONG → STRONG → `partial` | **Tool defect.** Fell in the very run that **added** `test_retrieval_makes_no_model_call`, which is more evidence for this obligation, not less. |
-| `spec-no-longer-describes-written-file` | STRONG → `partial` → `partial` | **Tool defect.** Its test asserts directly on spec text and never changed across any of the three runs. |
+| `remove-stale-next-instruction-file` | STRONG → STRONG → `partial` | **REAL, and the most serious finding in the corpus.** `--json` mode deleted `.acceptance/next-instruction.md` and printed nothing: the removal notice sat on the text branch only. A silent deletion in the user's repo — precisely what the migration decision said must not happen. Every test covered text mode. Fixed in `52c52b8` (notice moved to stderr, so it appears in both modes). |
+| `no-speculative-writing` | STRONG → STRONG → `partial` | **REAL.** No test snapshotted the repo around `recommendation` itself; `test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo` covers `check` only. `test_retrieval_makes_no_model_call` proves no model call, which is a strictly weaker claim than no write — and "nothing is written speculatively" is the premise of the whole pull model. Fixed in `52c52b8`. |
+| `spec-no-longer-describes-written-file` | STRONG → `partial` → `partial` | **REAL.** The spec still read "the recommendation may surface in the CLI, **a Markdown file**, …" (line 259). My test asserted only that the string `next-instruction.md` was absent — it was, so the test passed while the file-writing framing survived. Fixed in `52c52b8`. |
 
-**No disposition taken.** Each of these is a rating that moved without a
-corresponding change in evidence. Filed rather than chased: continuing to add
-tests in response would be fitting to noise, and would let a run "pass" by
-coincidence rather than because the evidence improved.
+## Why the original judgement was wrong
+
+The reasoning was: *the diff was additive, added tests cannot weaken evidence,
+therefore a rating that fell did so for reasons outside the diff.* The first two
+steps are sound; **the conclusion does not follow.** A rating that falls on an
+additive diff can equally mean the judge has *finally noticed a hole that was
+there all along*. That is what happened in all three cases — and in run 2's
+`default-to-most-recent-review`, which I got right for the same reason I got
+these wrong.
+
+The corpus-wide pattern only became visible after this correction: **in 7 of the
+8 unstable obligations the LOW rating was the correct one.** The instability is
+not symmetric noise. It is biased toward the permissive direction, and the
+`strongly supported` ratings are the unreliable ones. A tool that is wrong in
+the direction of "looks fine" is far more dangerous than one that is merely
+noisy, and it is the opposite of what a first reading of the churn suggests.
+
+The one case I still believe was noise is `byte-identical-retrievals`
+(STRONG → partial → STRONG), whose test invokes twice and compares bytes exactly
+as the recommendation asked. Given the record above, treat even that as unsettled.
+
+## Original judgement, kept for the record
+
+> **No disposition taken.** Each of these is a rating that moved without a
+> corresponding change in evidence. Filed rather than chased: continuing to add
+> tests in response would be fitting to noise, and would let a run "pass" by
+> coincidence rather than because the evidence improved.
+
+The instinct not to chase noise was reasonable. Applied here it suppressed three
+real findings, one of them a silent deletion of a file in the user's repo.

--- a/tests/fixtures/rating-stability/167-gate2-run3/judgement.md
+++ b/tests/fixtures/rating-stability/167-gate2-run3/judgement.md
@@ -1,0 +1,18 @@
+# Judgement — #167 Gate 2, run 3 (`95b880a`)
+
+Verdict: **INCOMPLETE**. 3 of 12 obligations below `strongly supported` — a
+**third** distinct set.
+
+The diff since run 2 touched **only `tests/test_cli.py`**, replacing the
+default-review test and adding retrieval tests.
+
+| obligation | run 1 → 2 → 3 | my judgement |
+|---|---|---|
+| `remove-stale-next-instruction-file` | STRONG → STRONG → `partial` | **Tool defect, cleanest instance in the corpus.** Neither the behaviour nor its test (`test_a_stale_instruction_file_is_removed_and_the_removal_reported`) changed between runs 2 and 3 — verified: `git diff 7de7d71 95b880a -- tests/test_cli.py` contains no hunk touching that test. Only *other* tests in the same file changed. An obligation cannot lose evidence because a neighbouring test was edited. |
+| `no-speculative-writing` | STRONG → STRONG → `partial` | **Tool defect.** Fell in the very run that **added** `test_retrieval_makes_no_model_call`, which is more evidence for this obligation, not less. |
+| `spec-no-longer-describes-written-file` | STRONG → `partial` → `partial` | **Tool defect.** Its test asserts directly on spec text and never changed across any of the three runs. |
+
+**No disposition taken.** Each of these is a rating that moved without a
+corresponding change in evidence. Filed rather than chased: continuing to add
+tests in response would be fitting to noise, and would let a run "pass" by
+coincidence rather than because the evidence improved.

--- a/tests/fixtures/rating-stability/167-gate2-run4/check-output.log
+++ b/tests/fixtures/rating-stability/167-gate2-run4/check-output.log
@@ -1,0 +1,220 @@
+Task completion: INCOMPLETE
+
+3 obligation(s) with non-discriminating test evidence (no-speculative-writing, preserve-prose-structured-fields, empty-result-for-missing-criterion-recommendation).
+
+Obligations:
+
+  1. Replace the written file `.acceptance/next-instruction.md` with the `acceptance recommendation --criterion <id> [--format json|text]` command surface for retrieving a criterion's recommendation on demand, defaulting to JSON.
+       code evidence: addressed
+         1.1  src/acceptance/cli.py#@@ -33,7 +33,9 @@ from acceptance.coverage.open_questions import apply_open_question_resolutions,
+         1.2  src/acceptance/cli.py#@@ -172,26 +174,33 @@ def run_check(
+         1.3  src/acceptance/cli.py#@@ -412,6 +421,23 @@ def build_parser() -> argparse.ArgumentParser:
+         1.4  src/acceptance/cli.py#@@ -491,12 +517,38 @@ def main(argv: list[str] | None = None) -> int:
+         1.5  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+         1.6  src/acceptance/report.py#@@ -84,75 +91,39 @@ def render_report(review: Review) -> str:
+         1.7  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -71,7 +71,7 @@ Used during development, before/while preparing a PR.
+         1.8  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -256,7 +256,7 @@ When evidence is missing/weak, prescribe a test obligation: the criterion; requi
+         1.9  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -264,7 +264,7 @@ Recommendations are emitted in a **structured, machine-readable form** — each
+         1.10  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -439,7 +439,8 @@ Unrequested changes:
+       test evidence: strongly supported  [tier: static]
+         1.11  tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps
+         1.12  tests/test_cli.py::test_json_is_the_default_format_when_none_is_requested
+         1.13  tests/test_cli.py::test_the_spec_names_the_command_the_cli_actually_accepts
+
+  2. Keep the recommendation retrieval command surface fixed to the specified command name and arguments in the specification.
+       code evidence: addressed
+         2.1  src/acceptance/cli.py#@@ -412,6 +421,23 @@ def build_parser() -> argparse.ArgumentParser:
+         2.2  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -256,7 +256,7 @@ When evidence is missing/weak, prescribe a test obligation: the criterion; requi
+         2.3  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -264,7 +264,7 @@ Recommendations are emitted in a **structured, machine-readable form** — each
+         2.4  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -439,7 +439,8 @@ Unrequested changes:
+       test evidence: strongly supported  [tier: static]
+         2.5  tests/test_cli.py::test_a_command_name_the_spec_does_not_document_is_rejected
+         2.6  tests/test_cli.py::test_an_undocumented_format_is_rejected
+         2.7  tests/test_cli.py::test_criterion_is_required
+         2.8  tests/test_cli.py::test_render_decomposition_lists_obligations_and_open_questions
+         2.9  tests/test_cli.py::test_the_spec_does_not_frame_the_recommendation_as_a_written_artifact
+         2.10  tests/test_cli.py::test_the_spec_names_the_command_the_cli_actually_accepts
+
+  3. Ensure recommendation retrieval performs no speculative writes so nothing can go stale.
+       code evidence: addressed
+         3.1  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+         3.2  src/acceptance/cli.py#@@ -172,26 +174,33 @@ def run_check(
+         3.3  src/acceptance/cli.py#@@ -491,12 +517,38 @@ def main(argv: list[str] | None = None) -> int:
+         3.4  tests/test_cli.py#@@ -511,21 +511,15 @@ def test_check_without_a_head_reviews_the_working_tree(
+         3.5  tests/test_cli.py#@@ -549,33 +543,390 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+       test evidence: partially supported  [tier: static]
+         3.6  tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo
+         3.7  tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps
+         3.8  tests/test_cli.py::test_retrieval_makes_no_model_call
+         3.9  tests/test_cli.py::test_retrieval_writes_nothing_into_the_repo
+
+  4. Return a recommendation from stored review state on demand without re-running the review.
+       code evidence: addressed
+         4.1  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+         4.2  src/acceptance/review_store.py#@@ -37,3 +37,18 @@ class ReviewStore:
+         4.3  src/acceptance/cli.py#@@ -491,12 +517,38 @@ def main(argv: list[str] | None = None) -> int:
+       test evidence: strongly supported  [tier: static]
+         4.4  tests/test_cli.py::test_check_persists_the_review_to_the_store
+         4.5  tests/test_cli.py::test_recommendation_returns_the_stored_prescription_for_a_criterion
+         4.6  tests/test_cli.py::test_retrieval_makes_no_model_call
+         4.7  tests/test_cli.py::test_retrieval_reads_the_named_revision_and_not_a_recomputation
+         4.8  tests/test_cli.py::test_retrieval_without_a_revision_uses_the_newest_stored_review
+         4.9  tests/test_cli.py::test_the_newest_review_wins_regardless_of_filename_order
+         4.10  tests/test_cli.py::test_two_retrievals_over_unchanged_state_are_byte_identical
+         4.11  tests/test_review_store.py::test_rerun_over_the_same_head_overwrites_in_place
+         4.12  tests/test_review_store.py::test_review_round_trips_through_the_store
+
+  5. Keep the recommendation's structured fields as discrete keys with their prose values intact.
+       code evidence: addressed
+         5.1  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+       test evidence: partially supported  [tier: static]
+         5.2  tests/benchmark/test_coverage.py::test_the_shared_pipeline_runs_every_stage
+         5.3  tests/test_cli.py::test_recommendation_returns_the_stored_prescription_for_a_criterion
+         5.4  tests/test_report.py::test_every_test_evidence_line_shows_a_tier
+         5.5  tests/test_report.py::test_open_questions_and_recommendations_are_numbered
+
+  6. Make the review's own output tell a reader how to obtain the recommendation detail.
+       code evidence: addressed
+         6.1  src/acceptance/report.py#@@ -76,6 +76,13 @@ def render_report(review: Review) -> str:
+         6.2  src/acceptance/report.py#@@ -84,75 +91,39 @@ def render_report(review: Review) -> str:
+       test evidence: strongly supported  [tier: static]
+         6.3  tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps
+         6.4  tests/test_cli.py::test_render_classify_output
+         6.5  tests/test_cli.py::test_report_shell_renders_all_sections_present_and_empty
+         6.6  tests/test_report.py::test_a_carried_forward_obligation_says_so_and_names_the_revision
+         6.7  tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered
+
+  7. Remove any pre-existing `.acceptance/next-instruction.md` left by an earlier version and report that it was removed.
+       code evidence: addressed
+         7.1  src/acceptance/cli.py#@@ -172,26 +174,33 @@ def run_check(
+         7.2  src/acceptance/cli.py#@@ -491,12 +517,38 @@ def main(argv: list[str] | None = None) -> int:
+         7.3  tests/test_cli.py#@@ -511,21 +511,15 @@ def test_check_without_a_head_reviews_the_working_tree(
+         7.4  tests/test_cli.py#@@ -549,33 +543,390 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+       test evidence: strongly supported  [tier: static]
+         7.5  tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo
+         7.6  tests/test_cli.py::test_a_stale_instruction_file_is_removed_and_the_removal_reported
+         7.7  tests/test_cli.py::test_the_removal_is_reported_in_json_mode_too
+         7.8  tests/test_cli.py::test_the_removal_leaves_the_report_as_the_only_statement_of_status
+         7.9  tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered
+
+  8. Leave the review's own output as the only statement of status when starting from a repo that already contains `.acceptance/next-instruction.md`.
+       code evidence: addressed
+         8.1  src/acceptance/cli.py#@@ -172,26 +174,33 @@ def run_check(
+         8.2  src/acceptance/cli.py#@@ -491,12 +517,38 @@ def main(argv: list[str] | None = None) -> int:
+         8.3  src/acceptance/report.py#@@ -84,75 +91,39 @@ def render_report(review: Review) -> str:
+         8.4  tests/test_cli.py#@@ -549,33 +543,390 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+       test evidence: strongly supported  [tier: static]
+         8.5  tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo
+         8.6  tests/test_cli.py::test_a_stale_instruction_file_is_removed_and_the_removal_reported
+         8.7  tests/test_cli.py::test_report_shell_renders_all_sections_present_and_empty
+         8.8  tests/test_cli.py::test_the_removal_is_reported_in_json_mode_too
+         8.9  tests/test_cli.py::test_the_removal_leaves_the_report_as_the_only_statement_of_status
+         8.10  tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered
+
+  9. Return an empty result when a criterion has no recommendation.
+       code evidence: addressed
+         9.1  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+         9.2  src/acceptance/cli.py#@@ -491,12 +517,38 @@ def main(argv: list[str] | None = None) -> int:
+         9.3  tests/test_cli.py#@@ -511,21 +511,15 @@ def test_check_without_a_head_reviews_the_working_tree(
+       test evidence: partially supported  [tier: static]
+         9.4  tests/test_cli.py::test_recommendation_for_an_unknown_criterion_is_empty_not_an_error
+         9.5  tests/test_report.py::test_empty_review_renders_the_full_shell
+         9.6  tests/test_review_store.py::test_read_missing_revision_returns_none
+
+  10. Default retrieval to the most recently stored review when the caller does not name one.
+       code evidence: addressed
+         10.1  src/acceptance/review_store.py#@@ -37,3 +37,18 @@ class ReviewStore:
+         10.2  src/acceptance/cli.py#@@ -491,12 +517,38 @@ def main(argv: list[str] | None = None) -> int:
+       test evidence: strongly supported  [tier: static]
+         10.3  tests/test_cli.py::test_retrieval_without_a_revision_uses_the_newest_stored_review
+         10.4  tests/test_cli.py::test_the_newest_review_wins_regardless_of_filename_order
+         10.5  tests/test_review_store.py::test_rerun_over_the_same_head_overwrites_in_place
+
+  11. Produce byte-identical output for repeated retrievals over unchanged review state.
+       code evidence: addressed
+         11.1  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+       test evidence: strongly supported  [tier: static]
+         11.2  tests/test_cli.py::test_two_retrievals_over_unchanged_state_are_byte_identical
+         11.3  tests/test_cli.py::test_two_runs_over_the_same_input_are_byte_identical
+         11.4  tests/test_review_store.py::test_rerun_over_the_same_head_overwrites_in_place
+
+  12. Keep the specification from describing the recommendation as a written file.
+       code evidence: addressed
+         12.1  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -71,7 +71,7 @@ Used during development, before/while preparing a PR.
+         12.2  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -256,7 +256,7 @@ When evidence is missing/weak, prescribe a test obligation: the criterion; requi
+         12.3  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -264,7 +264,7 @@ Recommendations are emitted in a **structured, machine-readable form** — each
+         12.4  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -439,7 +439,8 @@ Unrequested changes:
+       test evidence: strongly supported  [tier: static]
+         12.5  tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps
+         12.6  tests/test_cli.py::test_the_spec_does_not_frame_the_recommendation_as_a_written_artifact
+         12.7  tests/test_cli.py::test_the_spec_no_longer_names_a_written_file
+         12.8  tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered
+
+Unrequested changes:
+  1. [in_service] The CLI now deletes `.acceptance/next-instruction.md` during `check` and emits a removal notice on stderr. The obligations require removing the stale file and making retrieval on-demand, but they do not require changing the normal `check` command to perform this deletion as part of its output path or to add a new status message.
+       src/acceptance/cli.py#@@ -172,26 +174,33 @@ def run_check(
+       src/acceptance/cli.py#@@ -491,12 +517,38 @@ def main(argv: list[str] | None = None) -> int:
+       tests/test_cli.py#@@ -511,21 +511,15 @@ def test_check_without_a_head_reviews_the_working_tree(
+       tests/test_cli.py#@@ -549,33 +543,390 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+  2. [in_service] `src/acceptance/recommendation.py` introduces a new helper module with `_FIELDS`, `lookup`, `render_json`, `render_text`, and `render` helpers. The retrieval command is requested, but this specific module split and helper factoring are implementation choices not explicitly required by the obligations.
+       src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+       src/acceptance/cli.py#@@ -33,7 +33,9 @@ from acceptance.coverage.open_questions import apply_open_question_resolutions,
+       src/acceptance/cli.py#@@ -412,6 +421,23 @@ def build_parser() -> argparse.ArgumentParser:
+       src/acceptance/cli.py#@@ -491,12 +517,38 @@ def main(argv: list[str] | None = None) -> int:
+  3. [in_service] `ReviewStore.latest()` selects the newest review by filesystem mtime. The task requires defaulting to the most recently stored review, but it does not specify mtime-based selection or require adding this method; that is an extra internal policy choice.
+       src/acceptance/review_store.py#@@ -37,3 +37,18 @@ class ReviewStore:
+       src/acceptance/cli.py#@@ -412,6 +421,23 @@ def build_parser() -> argparse.ArgumentParser:
+       src/acceptance/cli.py#@@ -491,12 +517,38 @@ def main(argv: list[str] | None = None) -> int:
+       tests/test_cli.py#@@ -549,33 +543,390 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+  4. [in_service] `render_report` now appends a per-criterion `full detail: acceptance recommendation --criterion <id>` line for each recommendation entry. The obligations require the review output to tell readers how to obtain recommendation detail, but not to add this extra command line to every recommendation item.
+       src/acceptance/report.py#@@ -76,6 +76,13 @@ def render_report(review: Review) -> str:
+       src/acceptance/report.py#@@ -84,75 +91,39 @@ def render_report(review: Review) -> str:
+  5. [separable] The benchmark test was rewritten from asserting the old pipeline/CLI write boundary to asserting that neither path writes into the reviewed repo. The obligations require no speculative writes and stale-file cleanup, but not this broader benchmark behavior change or the removal of the old contrast assertion.
+       tests/benchmark/test_coverage.py#@@ -663,32 +663,32 @@ def test_the_shared_pipeline_partitions_the_mapping_call(tmp_path):
+       tests/benchmark/test_coverage.py#@@ -714,19 +714,5 @@ def test_the_shared_pipeline_writes_nothing_into_the_reviewed_repo(tmp_path):
+  6. [in_service] `tests/test_cli.py` adds many new cases around parser rejection, default format, byte-identical output, named revision selection, and no-model-call behavior. Some retrieval tests are requested, but several of these specific parser-surface and stability assertions go beyond the stated obligations.
+       tests/test_cli.py#@@ -511,21 +511,15 @@ def test_check_without_a_head_reviews_the_working_tree(
+       tests/test_cli.py#@@ -549,33 +543,390 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+  7. [in_service] `tests/test_report.py` removes the old next-instruction rendering coverage and changes report expectations to the new command hint. The obligations require discoverability and spec updates, but not the wholesale deletion of the prior instruction-rendering tests or the exact new report assertions.
+       tests/test_report.py#@@ -17,9 +17,8 @@ from acceptance.review_state import (
+       tests/test_report.py#@@ -88,7 +87,6 @@ def test_report_renders_each_obligation_with_both_axes_numbered():
+       tests/test_report.py#@@ -109,7 +107,10 @@ def test_report_renders_each_obligation_with_both_axes_numbered():
+       tests/test_report.py#@@ -268,192 +269,6 @@ def test_the_two_axes_render_independently_for_the_same_obligation():
+
+Changes since 95b880a8:
+  closed:
+    - Remove any pre-existing `.acceptance/next-instruction.md` left by an earlier version and report that it was removed.
+        code evidence: addressed -> addressed
+        test evidence: partially supported -> strongly supported
+    - Keep the specification from describing the recommendation as a written file.
+        code evidence: addressed -> addressed
+        test evidence: partially supported -> strongly supported
+  moved:
+    - Keep the recommendation's structured fields as discrete keys with their prose values intact.
+        test evidence: strongly supported -> partially supported
+    - Return an empty result when a criterion has no recommendation.
+        test evidence: strongly supported -> partially supported
+
+Open questions:
+  1. [resolved] What exact output shape should `acceptance recommendation --criterion <id> [--format json|text]` use for JSON and text modes, including field names, ordering, and whether empty results are represented as `null`, `{}`, or another form?
+       The diff adds `src/acceptance/recommendation.py` with explicit JSON and text renderers. JSON output is built from a fixed `_FIELDS` tuple and `canonical_json`, and missing recommendations render as `{}`. Text output is defined as `Criterion: ...` followed by the remaining fields in `_FIELDS` order, with list values expanded as bullet lines. The CLI wiring in `src/acceptance/cli.py` sets `--format` to `json|text` with default `json`, making the shape unambiguous.
+
+Recommended tests:
+  1. Running recommendation retrieval does not create or update any recommendation file or other speculative artifact.
+       inputs:  Use a stored review that contains at least one real recommendation, then invoke the on-demand retrieval command (`acceptance recommendation --criterion <id>`) against that stored review while snapshotting the reviewed repo before and after the command. The input must make a hidden write observable by ensuring the correct implementation only reads stored review state, while the defective implementation would create or update a recommendation file or other repo artifact.
+       detects: The command makes a model call during retrieval but does not write anything, or otherwise mutates repo state speculatively without leaving an obvious file artifact.
+       full detail: acceptance recommendation --criterion no-speculative-writing
+  2. The retrieved recommendation includes separate fields for required inputs, boundary conditions, expected output, required assertions, plausible defect, and repo conventions, and each field retains prose text rather than a compressed token.
+       inputs:  Use a stored recommendation whose fields are all populated with distinctive prose sentences, not short codes, and retrieve it via `acceptance recommendation --criterion <id>`. The chosen recommendation should include multi-word text in `required_inputs`, `boundary_conditions`, `expected_output`, `required_assertions`, `plausible_defect`, and `repo_conventions` so a terse-token regression is detectable.
+       detects: Developer preserves the keys but converts prose values into terse tokens or codes, losing the actionable explanation in one or more fields.
+       full detail: acceptance recommendation --criterion preserve-prose-structured-fields
+  3. Querying a criterion without a recommendation yields an empty result instead of an error.
+       inputs:  Use a stored review that exists, but query a criterion id that is definitely absent from that review’s recommendations. The input should exercise the empty-result path of the retrieval command, not the missing-review error path, so the review store is populated and only the criterion lookup is missing.
+       detects: The command returns an empty object for unknown criteria but the report rendering for an empty review is wrong, or the empty-result path is mishandled as an error instead of an ordinary empty answer.
+       full detail: acceptance recommendation --criterion empty-result-for-missing-criterion-recommendation
+
+Evidence limitations:
+  1. Judgments are static inferences unless a higher tier is recorded; the full application was not independently executed.
+
+Next: retrieve a criterion's full recommendation with
+  acceptance recommendation --criterion <id>

--- a/tests/fixtures/rating-stability/167-gate2-run4/current-task.md
+++ b/tests/fixtures/rating-stability/167-gate2-run4/current-task.md
@@ -1,0 +1,56 @@
+# Task
+Stop pushing a recommendation file nobody asked for, and let an agent pull the
+detail when it decides to act. Today a review with gaps writes its next
+instruction to one fixed path in the repo. That path is keyed to no task and no
+revision, so whichever run last found gaps owns it; a later clean run leaves it
+untouched, and the file then contradicts the report while only the report is
+telling the truth. The content is also a second, lossier copy of recommendations
+the review already carries as structured fields. Replace the written file
+`.acceptance/next-instruction.md` with `acceptance recommendation --criterion
+<id> [--format json|text]`, which returns a criterion's recommendation from
+stored review state on demand, defaulting to JSON.
+
+The command surface is fixed here rather than left to implementation: the
+specification has to name a specific command, and a document written against a
+command that later changes would recreate the same two-artifacts-drifting
+failure this task exists to remove.
+
+## Constraints
+- Nothing is written speculatively, so nothing can go stale.
+- A recommendation returned on demand is the one the stored review holds for that
+  criterion — retrieval reads state, it does not re-run the review.
+- The structured fields keep their prose values. Compressing a field to a terse
+  token loses the reasoning that makes the recommendation actionable.
+- A reader of the review's own output can tell how to obtain the detail; if the
+  output does not make the detail's existence known, the pull never happens.
+- A repo that already contains `.acceptance/next-instruction.md` from an
+  earlier version is left in a state where nothing on disk contradicts the
+  review.
+
+## Scope exclusions
+- What the recommendations themselves contain is unchanged; this task moves how
+  they are obtained, not how they are produced.
+- The review-state store's format and the review pipeline are unchanged.
+- Recording that this task supersedes the earlier one belongs to the issue
+  tracker, not to any file in this repo.
+
+## Completion expectations
+- Implementation
+- `acceptance recommendation --criterion <id>` returns that criterion's
+  recommendation from stored review state, without re-running the review.
+- The retrieved recommendation carries each structured field as a discrete key
+  — required inputs, boundary conditions, expected output, required assertions,
+  plausible defect, repo conventions — with their prose values intact.
+- A criterion that has no recommendation returns an empty result rather than an
+  error.
+- Retrieval defaults to the most recently stored review when the caller does not
+  name one.
+- No code path writes `.acceptance/next-instruction.md`.
+- A run that finds an `.acceptance/next-instruction.md` left by an earlier
+  version removes it and reports that it did so.
+- Starting from a repo that already contains `.acceptance/next-instruction.md`,
+  a clean run leaves the review's own output as the only statement of status.
+- The review's rendered output names the command to run, not a file to open, for
+  every verdict that has gaps.
+- Two retrievals over unchanged review state return byte-identical output.
+- The specification no longer describes the recommendation as a written file.

--- a/tests/fixtures/rating-stability/167-gate2-run4/judgement.md
+++ b/tests/fixtures/rating-stability/167-gate2-run4/judgement.md
@@ -1,0 +1,15 @@
+# Judgement — #167 Gate 2, run 4 (`52c52b8`)
+
+Verdict: **INCOMPLETE**. 3 of 12 below `strongly supported`; a fourth distinct set.
+Run after fixing all three of run 3's real gaps.
+
+| obligation | judgement |
+|---|---|
+| `preserve-prose-structured-fields` | **REAL.** The test asserted 4 of the 6 §9.5 fields — `required_inputs` and `repo_conventions` were unasserted, so a regression compressing either to a terse token would pass. Fixing it also exposed that the `repo_conventions` fixture was a bare path (`tests/test_thing.py`), not prose, which made a prose assertion vacuous. Fixed in `dd0a6a5`. |
+| `no-speculative-writing` | **Not real.** Both tests the recommendation asks for now exist and are mapped (`test_retrieval_writes_nothing_into_the_repo` snapshots the tree, `test_retrieval_makes_no_model_call` covers the call). Its `detects` clause is self-contradictory: *"makes a model call during retrieval but does not write anything."* |
+| `empty-result-for-missing-criterion-recommendation` | **Not real.** The recommendation describes exactly what `test_recommendation_for_an_unknown_criterion_is_empty_not_an_error` does — populated store, absent criterion, empty result rather than an error. |
+
+Three of four rounds so far have surfaced at least one real gap, so the churn is
+not pure noise; but two of three findings here were already covered, which is the
+first clear evidence of the **false-positive** direction alongside #180's
+false negatives.

--- a/tests/fixtures/rating-stability/167-gate2-run5/check-output.log
+++ b/tests/fixtures/rating-stability/167-gate2-run5/check-output.log
@@ -1,0 +1,215 @@
+Task completion: INCOMPLETE
+
+1 obligation(s) with non-discriminating test evidence (replace-written-file-with-command).
+
+Obligations:
+
+  1. Replace the written file `.acceptance/next-instruction.md` with the `acceptance recommendation --criterion <id> [--format json|text]` command surface for retrieving a criterion's recommendation on demand, defaulting to JSON.
+       code evidence: addressed
+         1.1  src/acceptance/cli.py#@@ -33,7 +33,9 @@ from acceptance.coverage.open_questions import apply_open_question_resolutions,
+         1.2  src/acceptance/cli.py#@@ -172,26 +174,33 @@ def run_check(
+         1.3  src/acceptance/cli.py#@@ -412,6 +421,23 @@ def build_parser() -> argparse.ArgumentParser:
+         1.4  src/acceptance/cli.py#@@ -491,12 +517,38 @@ def main(argv: list[str] | None = None) -> int:
+         1.5  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+         1.6  src/acceptance/report.py#@@ -76,6 +76,13 @@ def render_report(review: Review) -> str:
+         1.7  src/acceptance/report.py#@@ -84,75 +91,39 @@ def render_report(review: Review) -> str:
+         1.8  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -71,7 +71,7 @@ Used during development, before/while preparing a PR.
+         1.9  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -256,7 +256,7 @@ When evidence is missing/weak, prescribe a test obligation: the criterion; requi
+         1.10  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -264,7 +264,7 @@ Recommendations are emitted in a **structured, machine-readable form** — each
+         1.11  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -439,7 +439,8 @@ Unrequested changes:
+       test evidence: partially supported  [tier: static]
+         1.12  tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps
+         1.13  tests/test_cli.py::test_json_is_the_default_format_when_none_is_requested
+         1.14  tests/test_cli.py::test_the_spec_names_the_command_the_cli_actually_accepts
+
+  2. Keep the recommendation retrieval command surface fixed to the specified command name and arguments in the specification.
+       code evidence: addressed
+         2.1  src/acceptance/cli.py#@@ -412,6 +421,23 @@ def build_parser() -> argparse.ArgumentParser:
+         2.2  src/acceptance/cli.py#@@ -491,12 +517,38 @@ def main(argv: list[str] | None = None) -> int:
+         2.3  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -256,7 +256,7 @@ When evidence is missing/weak, prescribe a test obligation: the criterion; requi
+         2.4  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -264,7 +264,7 @@ Recommendations are emitted in a **structured, machine-readable form** — each
+         2.5  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -439,7 +439,8 @@ Unrequested changes:
+       test evidence: strongly supported  [tier: static]
+         2.6  tests/test_cli.py::test_a_command_name_the_spec_does_not_document_is_rejected
+         2.7  tests/test_cli.py::test_an_undocumented_format_is_rejected
+         2.8  tests/test_cli.py::test_criterion_is_required
+         2.9  tests/test_cli.py::test_json_is_the_default_format_when_none_is_requested
+         2.10  tests/test_cli.py::test_the_spec_does_not_frame_the_recommendation_as_a_written_artifact
+         2.11  tests/test_cli.py::test_the_spec_names_the_command_the_cli_actually_accepts
+
+  3. Ensure recommendation retrieval performs no speculative writes so nothing can go stale.
+       code evidence: addressed
+         3.1  src/acceptance/cli.py#@@ -172,26 +174,33 @@ def run_check(
+         3.2  src/acceptance/cli.py#@@ -491,12 +517,38 @@ def main(argv: list[str] | None = None) -> int:
+         3.3  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+       test evidence: strongly supported  [tier: static]
+         3.4  tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo
+         3.5  tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps
+         3.6  tests/test_cli.py::test_retrieval_makes_no_model_call
+         3.7  tests/test_cli.py::test_retrieval_writes_nothing_into_the_repo
+
+  4. Return a recommendation from stored review state on demand without re-running the review.
+       code evidence: addressed
+         4.1  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+         4.2  src/acceptance/cli.py#@@ -491,12 +517,38 @@ def main(argv: list[str] | None = None) -> int:
+         4.3  src/acceptance/review_store.py#@@ -37,3 +37,18 @@ class ReviewStore:
+       test evidence: strongly supported  [tier: static]
+         4.4  tests/test_cli.py::test_check_persists_the_review_to_the_store
+         4.5  tests/test_cli.py::test_recommendation_returns_the_stored_prescription_for_a_criterion
+         4.6  tests/test_cli.py::test_recommendation_without_a_stored_review_fails_cleanly
+         4.7  tests/test_cli.py::test_retrieval_makes_no_model_call
+         4.8  tests/test_cli.py::test_retrieval_reads_the_named_revision_and_not_a_recomputation
+         4.9  tests/test_cli.py::test_retrieval_without_a_revision_uses_the_newest_stored_review
+         4.10  tests/test_cli.py::test_the_newest_review_wins_regardless_of_filename_order
+         4.11  tests/test_cli.py::test_two_retrievals_over_unchanged_state_are_byte_identical
+         4.12  tests/test_review_store.py::test_rerun_over_the_same_head_overwrites_in_place
+         4.13  tests/test_review_store.py::test_review_round_trips_through_the_store
+
+  5. Keep the recommendation's structured fields as discrete keys with their prose values intact.
+       code evidence: addressed
+         5.1  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+       test evidence: strongly supported  [tier: static]
+         5.2  tests/benchmark/test_coverage.py::test_the_shared_pipeline_runs_every_stage
+         5.3  tests/test_cli.py::test_recommendation_returns_the_stored_prescription_for_a_criterion
+         5.4  tests/test_report.py::test_every_test_evidence_line_shows_a_tier
+         5.5  tests/test_report.py::test_open_questions_and_recommendations_are_numbered
+
+  6. Make the review's own output tell a reader how to obtain the recommendation detail.
+       code evidence: addressed
+         6.1  src/acceptance/report.py#@@ -76,6 +76,13 @@ def render_report(review: Review) -> str:
+         6.2  src/acceptance/report.py#@@ -84,75 +91,39 @@ def render_report(review: Review) -> str:
+       test evidence: strongly supported  [tier: static]
+         6.3  tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps
+         6.4  tests/test_cli.py::test_render_classify_output
+         6.5  tests/test_cli.py::test_report_shell_renders_all_sections_present_and_empty
+         6.6  tests/test_report.py::test_a_carried_forward_obligation_says_so_and_names_the_revision
+         6.7  tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered
+
+  7. Remove any pre-existing `.acceptance/next-instruction.md` left by an earlier version and report that it was removed.
+       code evidence: addressed
+         7.1  src/acceptance/cli.py#@@ -172,26 +174,33 @@ def run_check(
+         7.2  src/acceptance/cli.py#@@ -491,12 +517,38 @@ def main(argv: list[str] | None = None) -> int:
+       test evidence: strongly supported  [tier: static]
+         7.3  tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo
+         7.4  tests/test_cli.py::test_a_stale_instruction_file_is_removed_and_the_removal_reported
+         7.5  tests/test_cli.py::test_the_removal_is_reported_in_json_mode_too
+         7.6  tests/test_cli.py::test_the_removal_leaves_the_report_as_the_only_statement_of_status
+         7.7  tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered
+
+  8. Leave the review's own output as the only statement of status when starting from a repo that already contains `.acceptance/next-instruction.md`.
+       code evidence: addressed
+         8.1  src/acceptance/cli.py#@@ -172,26 +174,33 @@ def run_check(
+         8.2  src/acceptance/cli.py#@@ -491,12 +517,38 @@ def main(argv: list[str] | None = None) -> int:
+         8.3  src/acceptance/report.py#@@ -84,75 +91,39 @@ def render_report(review: Review) -> str:
+         8.4  tests/benchmark/test_coverage.py#@@ -663,32 +663,32 @@ def test_the_shared_pipeline_partitions_the_mapping_call(tmp_path):
+         8.5  tests/benchmark/test_coverage.py#@@ -714,19 +714,5 @@ def test_the_shared_pipeline_writes_nothing_into_the_reviewed_repo(tmp_path):
+       test evidence: strongly supported  [tier: static]
+         8.6  tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo
+         8.7  tests/test_cli.py::test_a_stale_instruction_file_is_removed_and_the_removal_reported
+         8.8  tests/test_cli.py::test_report_shell_renders_all_sections_present_and_empty
+         8.9  tests/test_cli.py::test_the_removal_is_reported_in_json_mode_too
+         8.10  tests/test_cli.py::test_the_removal_leaves_the_report_as_the_only_statement_of_status
+         8.11  tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered
+
+  9. Return an empty result when a criterion has no recommendation.
+       code evidence: addressed
+         9.1  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+         9.2  src/acceptance/cli.py#@@ -491,12 +517,38 @@ def main(argv: list[str] | None = None) -> int:
+       test evidence: strongly supported  [tier: static]
+         9.3  tests/test_cli.py::test_recommendation_for_an_unknown_criterion_is_empty_not_an_error
+         9.4  tests/test_report.py::test_empty_review_renders_the_full_shell
+         9.5  tests/test_review_store.py::test_read_missing_revision_returns_none
+
+  10. Default retrieval to the most recently stored review when the caller does not name one.
+       code evidence: addressed
+         10.1  src/acceptance/review_store.py#@@ -37,3 +37,18 @@ class ReviewStore:
+         10.2  src/acceptance/cli.py#@@ -491,12 +517,38 @@ def main(argv: list[str] | None = None) -> int:
+       test evidence: strongly supported  [tier: static]
+         10.3  tests/test_cli.py::test_retrieval_without_a_revision_uses_the_newest_stored_review
+         10.4  tests/test_cli.py::test_the_newest_review_wins_regardless_of_filename_order
+         10.5  tests/test_review_store.py::test_rerun_over_the_same_head_overwrites_in_place
+
+  11. Produce byte-identical output for repeated retrievals over unchanged review state.
+       code evidence: addressed
+         11.1  src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+       test evidence: strongly supported  [tier: static]
+         11.2  tests/test_cli.py::test_recommendation_returns_the_stored_prescription_for_a_criterion
+         11.3  tests/test_cli.py::test_two_retrievals_over_unchanged_state_are_byte_identical
+         11.4  tests/test_cli.py::test_two_runs_over_the_same_input_are_byte_identical
+         11.5  tests/test_review_store.py::test_rerun_over_the_same_head_overwrites_in_place
+
+  12. Keep the specification from describing the recommendation as a written file.
+       code evidence: addressed
+         12.1  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -71,7 +71,7 @@ Used during development, before/while preparing a PR.
+         12.2  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -256,7 +256,7 @@ When evidence is missing/weak, prescribe a test obligation: the criterion; requi
+         12.3  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -264,7 +264,7 @@ Recommendations are emitted in a **structured, machine-readable form** — each
+         12.4  docs/AI-Assisted-Software-Development-Review-Spec.md#@@ -439,7 +439,8 @@ Unrequested changes:
+       test evidence: strongly supported  [tier: static]
+         12.5  tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps
+         12.6  tests/test_cli.py::test_the_spec_does_not_frame_the_recommendation_as_a_written_artifact
+         12.7  tests/test_cli.py::test_the_spec_no_longer_names_a_written_file
+         12.8  tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered
+
+Unrequested changes:
+  1. [in_service] The CLI now deletes `.acceptance/next-instruction.md` during `check` and emits a removal notice on stderr. The obligations require removing the stale file and making retrieval on-demand, but they do not require changing normal `check` behavior to perform this deletion/reporting path as part of every run.
+       src/acceptance/cli.py#@@ -172,26 +174,33 @@ def run_check(
+       src/acceptance/cli.py#@@ -491,12 +517,38 @@ def main(argv: list[str] | None = None) -> int:
+       tests/benchmark/test_coverage.py#@@ -663,32 +663,32 @@ def test_the_shared_pipeline_partitions_the_mapping_call(tmp_path):
+       tests/benchmark/test_coverage.py#@@ -714,19 +714,5 @@ def test_the_shared_pipeline_writes_nothing_into_the_reviewed_repo(tmp_path):
+       tests/test_cli.py#@@ -511,21 +511,15 @@ def test_check_without_a_head_reviews_the_working_tree(
+       tests/test_cli.py#@@ -546,36 +540,405 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+  2. [in_service] `src/acceptance/recommendation.py` introduces a new helper module with `_FIELDS`, `lookup`, `render_json`, `render_text`, and `render` helpers. The task requires on-demand recommendation retrieval, but not this specific module split or internal factoring.
+       src/acceptance/recommendation.py#@@ -0,0 +1,87 @@
+       src/acceptance/cli.py#@@ -33,7 +33,9 @@ from acceptance.coverage.open_questions import apply_open_question_resolutions,
+       src/acceptance/cli.py#@@ -412,6 +421,23 @@ def build_parser() -> argparse.ArgumentParser:
+       src/acceptance/cli.py#@@ -491,12 +517,38 @@ def main(argv: list[str] | None = None) -> int:
+  3. [in_service] `ReviewStore.latest()` chooses the newest review by filesystem mtime. The obligations require defaulting to the most recently stored review, but they do not specify mtime-based selection, so this adds a concrete ordering policy beyond the stated requirement.
+       src/acceptance/review_store.py#@@ -37,3 +37,18 @@ class ReviewStore:
+       src/acceptance/cli.py#@@ -412,6 +421,23 @@ def build_parser() -> argparse.ArgumentParser:
+       src/acceptance/cli.py#@@ -491,12 +517,38 @@ def main(argv: list[str] | None = None) -> int:
+  4. [in_service] `render_report` now adds a per-recommendation `full detail: acceptance recommendation --criterion <id>` line for each criterion. The obligations require the review output to tell readers how to obtain recommendation detail, but not to add this extra per-item command text inside every recommendation entry.
+       src/acceptance/report.py#@@ -76,6 +76,13 @@ def render_report(review: Review) -> str:
+       src/acceptance/report.py#@@ -84,75 +91,39 @@ def render_report(review: Review) -> str:
+       tests/test_report.py#@@ -109,7 +107,10 @@ def test_report_renders_each_obligation_with_both_axes_numbered():
+  5. [in_service] The benchmark test was rewritten from asserting the old pipeline/CLI write boundary to asserting that neither path writes into the reviewed repo and that the stale file is absent. The obligations require no speculative writes and stale-file removal, but not this broader benchmark behavior change or the removal of the old contrast test.
+       tests/benchmark/test_coverage.py#@@ -663,32 +663,32 @@ def test_the_shared_pipeline_partitions_the_mapping_call(tmp_path):
+       tests/benchmark/test_coverage.py#@@ -714,19 +714,5 @@ def test_the_shared_pipeline_writes_nothing_into_the_reviewed_repo(tmp_path):
+  6. [separable] `tests/test_cli.py` adds many parser-surface and retrieval-behavior tests, including rejection of undocumented command names and formats, named-revision selection, no-model-call checks, and byte-identical output. Some retrieval tests are requested, but several of these specific cases go beyond the obligations as written.
+       tests/test_cli.py#@@ -511,21 +511,15 @@ def test_check_without_a_head_reviews_the_working_tree(
+       tests/test_cli.py#@@ -546,36 +540,405 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
+  7. [in_service] `tests/test_report.py` removes the old `render_next_instruction` coverage and adds assertions about the new command hint and absence of the old filename text. The obligations require discoverability and spec updates, but not the wholesale deletion of the prior instruction-rendering test suite or these exact new report assertions.
+       tests/test_report.py#@@ -17,9 +17,8 @@ from acceptance.review_state import (
+       tests/test_report.py#@@ -88,7 +87,6 @@ def test_report_renders_each_obligation_with_both_axes_numbered():
+       tests/test_report.py#@@ -109,7 +107,10 @@ def test_report_renders_each_obligation_with_both_axes_numbered():
+       tests/test_report.py#@@ -268,192 +269,6 @@ def test_the_two_axes_render_independently_for_the_same_obligation():
+
+Changes since 0f237002:
+  closed:
+    - Ensure recommendation retrieval performs no speculative writes so nothing can go stale.
+        code evidence: addressed -> addressed
+        test evidence: partially supported -> strongly supported
+    - Keep the recommendation's structured fields as discrete keys with their prose values intact.
+        code evidence: addressed -> addressed
+        test evidence: partially supported -> strongly supported
+    - Return an empty result when a criterion has no recommendation.
+        code evidence: addressed -> addressed
+        test evidence: partially supported -> strongly supported
+  moved:
+    - Replace the written file `.acceptance/next-instruction.md` with the `acceptance recommendation --criterion <id> [--format json|text]` command surface for retrieving a criterion's recommendation on demand, defaulting to JSON.
+        test evidence: strongly supported -> partially supported
+
+Open questions:
+  1. [resolved] What exact output shape should `acceptance recommendation --criterion <id> [--format json|text]` use for JSON and text modes, including field names, ordering, and whether empty results are represented as `null`, `{}`, or another form?
+       The diff adds `src/acceptance/recommendation.py`, which explicitly defines the JSON and text renderings. JSON uses the fixed `_FIELDS` tuple and `canonical_json`, and returns `{}` for a missing recommendation. Text mode starts with `Criterion: ...` and then emits the remaining fields in `_FIELDS` order, with list values expanded as bullet lines. `src/acceptance/cli.py` wires `--format json|text` and defaults to JSON.
+
+Recommended tests:
+  1. Users can invoke `acceptance recommendation --criterion <id>` to retrieve a recommendation instead of relying on a generated file, and the default output format is JSON.
+       inputs:  Use a stored review that contains at least one real recommendation, then invoke `acceptance recommendation --criterion <existing-id>` with no `--format` flag. The input must make the old file-based path observable by starting from a repo state where `.acceptance/next-instruction.md` would previously have been the only way to retrieve the recommendation, so a correct implementation returns JSON directly while the defective one still depends on a generated file or defaults to text.
+       detects: Developer keeps writing `.acceptance/next-instruction.md` on `check`, but also adds the new `recommendation` command so retrieval works too; this test must fail if retrieval still relies on the generated file or if the default output is not JSON.
+       full detail: acceptance recommendation --criterion replace-written-file-with-command
+
+Evidence limitations:
+  1. Judgments are static inferences unless a higher tier is recorded; the full application was not independently executed.
+
+Next: retrieve a criterion's full recommendation with
+  acceptance recommendation --criterion <id>

--- a/tests/fixtures/rating-stability/167-gate2-run5/current-task.md
+++ b/tests/fixtures/rating-stability/167-gate2-run5/current-task.md
@@ -1,0 +1,56 @@
+# Task
+Stop pushing a recommendation file nobody asked for, and let an agent pull the
+detail when it decides to act. Today a review with gaps writes its next
+instruction to one fixed path in the repo. That path is keyed to no task and no
+revision, so whichever run last found gaps owns it; a later clean run leaves it
+untouched, and the file then contradicts the report while only the report is
+telling the truth. The content is also a second, lossier copy of recommendations
+the review already carries as structured fields. Replace the written file
+`.acceptance/next-instruction.md` with `acceptance recommendation --criterion
+<id> [--format json|text]`, which returns a criterion's recommendation from
+stored review state on demand, defaulting to JSON.
+
+The command surface is fixed here rather than left to implementation: the
+specification has to name a specific command, and a document written against a
+command that later changes would recreate the same two-artifacts-drifting
+failure this task exists to remove.
+
+## Constraints
+- Nothing is written speculatively, so nothing can go stale.
+- A recommendation returned on demand is the one the stored review holds for that
+  criterion — retrieval reads state, it does not re-run the review.
+- The structured fields keep their prose values. Compressing a field to a terse
+  token loses the reasoning that makes the recommendation actionable.
+- A reader of the review's own output can tell how to obtain the detail; if the
+  output does not make the detail's existence known, the pull never happens.
+- A repo that already contains `.acceptance/next-instruction.md` from an
+  earlier version is left in a state where nothing on disk contradicts the
+  review.
+
+## Scope exclusions
+- What the recommendations themselves contain is unchanged; this task moves how
+  they are obtained, not how they are produced.
+- The review-state store's format and the review pipeline are unchanged.
+- Recording that this task supersedes the earlier one belongs to the issue
+  tracker, not to any file in this repo.
+
+## Completion expectations
+- Implementation
+- `acceptance recommendation --criterion <id>` returns that criterion's
+  recommendation from stored review state, without re-running the review.
+- The retrieved recommendation carries each structured field as a discrete key
+  — required inputs, boundary conditions, expected output, required assertions,
+  plausible defect, repo conventions — with their prose values intact.
+- A criterion that has no recommendation returns an empty result rather than an
+  error.
+- Retrieval defaults to the most recently stored review when the caller does not
+  name one.
+- No code path writes `.acceptance/next-instruction.md`.
+- A run that finds an `.acceptance/next-instruction.md` left by an earlier
+  version removes it and reports that it did so.
+- Starting from a repo that already contains `.acceptance/next-instruction.md`,
+  a clean run leaves the review's own output as the only statement of status.
+- The review's rendered output names the command to run, not a file to open, for
+  every verdict that has gaps.
+- Two retrievals over unchanged review state return byte-identical output.
+- The specification no longer describes the recommendation as a written file.

--- a/tests/fixtures/rating-stability/167-gate2-run5/judgement.md
+++ b/tests/fixtures/rating-stability/167-gate2-run5/judgement.md
@@ -1,0 +1,30 @@
+# Judgement — #167 Gate 2, run 5 (`dd0a6a5`)
+
+Verdict: **INCOMPLETE**. **1** obligation below `strongly supported`.
+
+| obligation | run 1 → 5 | judgement |
+|---|---|---|
+| `replace-written-file-with-command` | UNSUP → STRONG → STRONG → STRONG → `partial` | **Not real — a decomposition artifact, attributed to #144.** |
+
+The obligation is a compound umbrella ("replace the file *with* the command
+surface, *defaulting to JSON*") emitted **alongside** the individual obligations
+covering each of its parts. Every constituent is strongly supported.
+
+Checked rather than assumed, given this corpus's record: the defect the
+recommendation names — a build that keeps writing `next-instruction.md` *and*
+adds the command — **is** caught, by
+`test_check_writes_no_instruction_file_even_when_the_review_has_gaps` and
+`test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo`. The
+evidence exists; it is distributed across three tests because the obligation
+bundles three claims, and no single test targets the conjunction.
+
+Satisfying it would mean writing an artificial test asserting the union of what
+five other tests already prove — fitting the suite to a decomposition artifact.
+Recorded against **#144** instead.
+
+## Where the five rounds landed
+
+Findings per round: 2 → 4 → 3 → 3 → 1. **Seven real gaps were found and fixed**,
+including a `--json` path that deleted a file in the user's repo silently. The
+tool earned its keep here even while being unreliable — which is the strongest
+argument in the corpus against "fixing" #180 by damping the judge.

--- a/tests/fixtures/rating-stability/167-gate2-run5/judgement.md
+++ b/tests/fixtures/rating-stability/167-gate2-run5/judgement.md
@@ -4,23 +4,47 @@ Verdict: **INCOMPLETE**. **1** obligation below `strongly supported`.
 
 | obligation | run 1 → 5 | judgement |
 |---|---|---|
-| `replace-written-file-with-command` | UNSUP → STRONG → STRONG → STRONG → `partial` | **Not real — a decomposition artifact, attributed to #144.** |
+| `replace-written-file-with-command` | UNSUP → STRONG → STRONG → STRONG → `partial` | **A wrong verdict from M5.2. Attributed to #180.** |
+
+> **This file was rewritten.** I first attributed this to #144 (compound umbrella
+> obligation), reasoning that no single test could target the conjunction. That
+> reasoning does not survive checking — see below. It is the **second** time in
+> this corpus I concluded "not a real defect" too quickly.
+
+## The isolation
+
+Runs 4 and 5 are one commit apart and the obligation's mapped tests are
+**byte-identical**. The discrimination stage named the same plausible defect in
+both and judged it oppositely:
+
+| run | `would_be_caught` | reason given |
+|---|---|---|
+| 4 | **true** | "The test explicitly checks that the file does not exist after `check`, so any implementation that still writes it would fail." |
+| 5 | **false** | "The mapped tests mostly check that the command exists and that the file is absent in the exercised run… could slip past." |
+
+**Run 4 is correct.** `test_check_writes_no_instruction_file_even_when_the_review_has_gaps`
+invokes `check` on a review *with gaps* — exactly the case that previously wrote
+the file — and asserts its absence. Run 5's verdict is not a defensible
+difference of judgement; it is wrong about what the test does.
+
+Because M5.3 is a pure deterministic reduce, that single flipped boolean is the
+entire cause of the `partially supported` rating and of the run's verdict.
+
+**What this exonerates:** mapping (identical set both runs, so not #150/#173) and
+the strength reduce (a pure function). The variance is entirely in M5.2's
+per-defect verdict — the sharpest localization in this corpus.
+
+The runs also *worded* the defect differently, so defect enumeration is unstable
+too: pinning verdicts is insufficient if the defect set they range over moves.
 
 The obligation is a compound umbrella ("replace the file *with* the command
 surface, *defaulting to JSON*") emitted **alongside** the individual obligations
 covering each of its parts. Every constituent is strongly supported.
 
-Checked rather than assumed, given this corpus's record: the defect the
-recommendation names — a build that keeps writing `next-instruction.md` *and*
-adds the command — **is** caught, by
-`test_check_writes_no_instruction_file_even_when_the_review_has_gaps` and
-`test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo`. The
-evidence exists; it is distributed across three tests because the obligation
-bundles three claims, and no single test targets the conjunction.
-
-Satisfying it would mean writing an artificial test asserting the union of what
-five other tests already prove — fitting the suite to a decomposition artifact.
-Recorded against **#144** instead.
+The obligation is also a compound umbrella emitted alongside obligations covering
+each of its parts, which is a genuine #144 instance and makes the judge's job
+harder. But it is **not** what produced this finding, and attributing it there
+closed the question prematurely.
 
 ## Where the five rounds landed
 

--- a/tests/fixtures/rating-stability/README.md
+++ b/tests/fixtures/rating-stability/README.md
@@ -42,23 +42,44 @@ Only 4 of 12 held the same rating throughout.
 
 ## How to read it
 
-Ratings moved in both directions, and the corpus separates three distinct causes.
-A fix must handle all three, and must not collapse them:
+Ratings moved in both directions, but the corpus's central finding is that the
+movement is **not symmetric noise**:
 
-1. **Real gaps the tool found correctly.** `fixed-command-surface` (run 1) and
-   `default-to-most-recent-review` (run 2) were genuine — the second caught a
-   test that did not verify its own name. The tool earned these. **A fix that
-   stabilises ratings by making the judge less sensitive would lose them.**
-2. **False negatives.** Run 1 rated `default-to-most-recent-review` STRONG on
-   the evidence run 2 correctly called `nominal`. Instability is not only noise
-   around a true value; at least one run was simply wrong.
-3. **Movement with no change in evidence.** `remove-stale-next-instruction-file`
-   fell STRONG → partial in run 3 while neither the behaviour nor its test
-   changed — only *other* tests in the same file did. `no-speculative-writing`
-   fell in the very run that added a test supporting it.
+> **In 7 of the 8 unstable obligations, the LOW rating was the correct one.**
 
-The cleanest reproduction is run 2 → run 3: the diff is one test file, the
-stale-removal test within it is untouched, and its obligation still moves.
+Every case where a rating fell turned out to be the judge finally noticing a hole
+that had been there all along — including a `--json` code path that deleted a
+file in the user's repo and reported nothing. The `strongly supported` ratings
+are the unreliable ones. The tool errs toward "looks fine", which is far more
+dangerous than noise and is the opposite of what the churn suggests at a glance.
+
+This matters for how a fix is judged. The tempting reading — "ratings bounce
+around, damp them down" — is backwards. Three distinct causes, which a fix must
+not collapse:
+
+1. **Real gaps, correctly found, on both the up and down moves.** `fixed-command-surface`
+   (run 1), `default-to-most-recent-review` (run 2), and all three of run 3's.
+   The second caught a test that stored a single review while claiming to verify
+   "the most recent" — a test that did not verify its own name. **A fix that
+   stabilises ratings by making the judge less sensitive would lose every one of
+   these.**
+2. **False negatives, which are the real defect.** Run 1 rated
+   `default-to-most-recent-review` STRONG on the evidence run 2 correctly called
+   `nominal`; runs 1 and 2 both rated `remove-stale-next-instruction-file` STRONG
+   while a silent deletion sat in the code. The bug is not that ratings move — it
+   is that STRONG is issued when it has not been earned.
+3. **Possible genuine noise.** Only `byte-identical-retrievals` survives as a
+   candidate, and given the record above it should be treated as unsettled
+   rather than as an established example.
+
+### The trap this corpus exists to record
+
+Each run's `judgement.md` holds what I concluded *at the time*, including where I
+was wrong. Run 3's was rewritten: I first dismissed all three findings as noise,
+reasoning that the diff was purely additive and added tests cannot weaken
+evidence. Both premises are true; **the conclusion does not follow**, and acting
+on it would have shipped the silent deletion. That inference is the thing most
+likely to be repeated by whoever picks this up.
 
 ## Caveats
 

--- a/tests/fixtures/rating-stability/README.md
+++ b/tests/fixtures/rating-stability/README.md
@@ -1,0 +1,73 @@
+# Rating-stability corpus
+
+Captured dogfood iterations, kept as **test data for fixing the instability they
+document** (#180). Not currently read by any test — it is the evidence a fix has
+to be measured against, recorded while the judgements were still fresh.
+
+## Why it is checked in
+
+`dogfood-logs/` is gitignored and `current-task.md` is overwritten by the next
+task, so within a day none of this is recoverable. The expensive part is not the
+logs — it is the **judgement** files: whether each finding was a real gap or a
+tool defect. That determination cost a full re-run each to establish and cannot
+be reconstructed from the output alone.
+
+## Layout
+
+```
+<issue>-gate2-run<n>/
+  current-task.md     the exact task file the run was given
+  check-output.log    the full §16 report it produced
+  judgement.md        what was flagged, my disposition, and what happened next
+revisions.txt         the commit each run judged
+```
+
+## The headline
+
+Three consecutive `acceptance check` runs over **the same task file**, on a
+strictly growing test suite, disagreed about **8 of 12 obligations**:
+
+| run 1 | run 2 | run 3 | obligation |
+|---|---|---|---|
+| STRONG | nominal | STRONG | `default-to-most-recent-review` |
+| STRONG | STRONG | partial | `no-speculative-writing` |
+| nominal | STRONG | STRONG | `fixed-command-surface` |
+| STRONG | partial | partial | `spec-no-longer-describes-written-file` |
+| STRONG | partial | STRONG | `byte-identical-retrievals` |
+| STRONG | STRONG | partial | `remove-stale-next-instruction-file` |
+| UNSUP | STRONG | STRONG | `replace-written-file-with-command` |
+| STRONG | partial | STRONG | `retrieve-from-stored-review-state` |
+
+Only 4 of 12 held the same rating throughout.
+
+## How to read it
+
+Ratings moved in both directions, and the corpus separates three distinct causes.
+A fix must handle all three, and must not collapse them:
+
+1. **Real gaps the tool found correctly.** `fixed-command-surface` (run 1) and
+   `default-to-most-recent-review` (run 2) were genuine — the second caught a
+   test that did not verify its own name. The tool earned these. **A fix that
+   stabilises ratings by making the judge less sensitive would lose them.**
+2. **False negatives.** Run 1 rated `default-to-most-recent-review` STRONG on
+   the evidence run 2 correctly called `nominal`. Instability is not only noise
+   around a true value; at least one run was simply wrong.
+3. **Movement with no change in evidence.** `remove-stale-next-instruction-file`
+   fell STRONG → partial in run 3 while neither the behaviour nor its test
+   changed — only *other* tests in the same file did. `no-speculative-writing`
+   fell in the very run that added a test supporting it.
+
+The cleanest reproduction is run 2 → run 3: the diff is one test file, the
+stale-removal test within it is untouched, and its obligation still moves.
+
+## Caveats
+
+- These are **not** recorded transcripts, deliberately. A transcript embeds the
+  full request, so committing dogfood transcripts would put this repo's own
+  diffs and task text into test fixtures (`tests/support.py`). These are rendered
+  reports only.
+- Runs 2 and 3 were **incremental re-runs** (M7.5) building on the prior stored
+  review; run 1 of each issue was a first review. A fix must account for the
+  carry-forward path, not just the fresh one.
+- The `163-gate2-run1` entry is a clean single run, included as a control. One
+  clean run is not evidence of stability.

--- a/tests/fixtures/rating-stability/revisions.txt
+++ b/tests/fixtures/rating-stability/revisions.txt
@@ -2,3 +2,5 @@
 167-gate2-run1  07075a6
 167-gate2-run2  7de7d71
 167-gate2-run3  95b880a
+167-gate2-run4  52c52b8
+167-gate2-run5  dd0a6a5

--- a/tests/fixtures/rating-stability/revisions.txt
+++ b/tests/fixtures/rating-stability/revisions.txt
@@ -1,0 +1,4 @@
+163-gate2-run1  41cd0da
+167-gate2-run1  07075a6
+167-gate2-run2  7de7d71
+167-gate2-run3  95b880a

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -592,8 +592,9 @@ def test_a_stale_instruction_file_is_removed_and_the_removal_reported(
     ]) == 0
 
     assert not stale.exists()
-    # Visible, not silent — it touched a file in the user's repo.
-    assert "Removed a stale" in capsys.readouterr().out
+    # Visible, not silent — it touched a file in the user's repo. On stderr so
+    # the notice appears in every output mode, `--json` included.
+    assert "Removed a stale" in capsys.readouterr().err
 
 
 def test_the_removal_leaves_the_report_as_the_only_statement_of_status(
@@ -868,3 +869,64 @@ def build_parser_parse(argv):
     from acceptance.cli import build_parser
 
     return build_parser().parse_args(argv)
+
+
+def test_the_removal_is_reported_in_json_mode_too(
+    git_repo, fixture_task_path, capsys, stub_model
+):
+    """Deleting a file in the user's repo must never be silent, in any mode.
+
+    The first version printed the notice only on the text branch, so `--json`
+    deleted the file and said nothing — found by the tool's own Gate 2 run. The
+    notice goes to stderr so stdout stays parseable for the agent.
+    """
+    import json
+
+    stale = git_repo["path"] / ".acceptance" / "next-instruction.md"
+    stale.parent.mkdir(parents=True, exist_ok=True)
+    stale.write_text("# Next instruction\n\nStale.\n")
+
+    assert main([
+        "check", "--task", fixture_task_path,
+        "--base", git_repo["base"], "--head", git_repo["head"], "--json",
+    ]) == 0
+
+    captured = capsys.readouterr()
+    assert not stale.exists()
+    assert "Removed a stale" in captured.err
+    json.loads(captured.out)  # stdout is still pure JSON
+
+
+def test_retrieval_writes_nothing_into_the_repo(monkeypatch, tmp_path, capsys):
+    """`no-speculative-writing` covers retrieval, not just `check`.
+
+    Nothing is written speculatively, so nothing can go stale — the premise of
+    the whole pull model. Snapshotting the tree around the command is the only
+    way to assert it; proving no model call happens is a weaker claim.
+    """
+    monkeypatch.chdir(tmp_path)
+    _store_review_with(tmp_path, "a" * 40, "ob-1", "a defect")
+
+    def snapshot():
+        return {p.relative_to(tmp_path): p.stat().st_mtime for p in tmp_path.rglob("*")}
+
+    before = snapshot()
+    assert main(["recommendation", "--criterion", "ob-1"]) == 0
+    capsys.readouterr()
+
+    assert snapshot() == before
+
+
+def test_the_spec_does_not_frame_the_recommendation_as_a_written_artifact():
+    """Stronger than asserting the old filename is gone.
+
+    The spec kept "the recommendation may surface in ... a Markdown file" long
+    after `next-instruction.md` was removed from it, so a filename check passed
+    while the file-writing framing survived — found by the tool's own Gate 2 run.
+    """
+    spec = _spec_text()
+
+    assert "Markdown file" not in spec
+    assert "acceptance recommendation --criterion <id>" in spec
+    # The §10.1 step-12 wording that replaced the pushed artifact.
+    assert "never pushed to a file that outlives the run that wrote it" in spec

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -682,3 +682,92 @@ def test_recommendation_without_a_stored_review_fails_cleanly(
 
     assert main(["recommendation", "--criterion", "anything"]) == 1
     assert "no stored review" in capsys.readouterr().err
+
+
+def test_json_is_the_default_format_when_none_is_requested(
+    git_repo, fixture_task_path, capsys, monkeypatch
+):
+    """JSON by default because the consumer is a coding agent, not a human.
+
+    Asserted by name rather than left implicit in a test that happens to
+    `json.loads` the output: a change of default is the kind of thing that
+    slips through when nothing states the guarantee.
+    """
+    import json
+
+    _run_check_with_gaps(git_repo, fixture_task_path, monkeypatch)
+    capsys.readouterr()
+
+    assert main(["recommendation", "--criterion", "gap-ob"]) == 0
+    default = capsys.readouterr().out
+
+    assert main(["recommendation", "--criterion", "gap-ob", "--format", "json"]) == 0
+    explicit = capsys.readouterr().out
+
+    assert default == explicit
+    assert json.loads(default)["obligation_id"] == "gap-ob"
+
+
+# --- the command surface the spec names must be the one the CLI accepts ------
+#
+# #167 fixed the surface up front precisely so §16 could name a specific
+# command. A doc written against a command that later changes would recreate the
+# two-artifacts-drifting failure the whole task exists to remove — so the spec
+# string and the parser are pinned to each other here.
+
+_DOCUMENTED_COMMAND = "acceptance recommendation --criterion <id>"
+
+
+def _spec_text():
+    from pathlib import Path
+
+    spec = Path(__file__).resolve().parents[1] / "docs" / (
+        "AI-Assisted-Software-Development-Review-Spec.md"
+    )
+    return spec.read_text()
+
+
+def test_the_spec_names_the_command_the_cli_actually_accepts():
+    from acceptance.cli import build_parser
+
+    assert _DOCUMENTED_COMMAND in _spec_text()
+
+    _, _, flags = _DOCUMENTED_COMMAND.partition("acceptance ")
+    command, criterion_flag, _ = flags.split()
+    args = build_parser().parse_args([command, criterion_flag, "some-id"])
+
+    assert args.command == "recommendation"
+    assert args.criterion == "some-id"
+    assert args.format == "json"
+
+
+def test_the_spec_no_longer_names_a_written_file():
+    assert "next-instruction.md" not in _spec_text()
+
+
+def test_a_command_name_the_spec_does_not_document_is_rejected(capsys):
+    import pytest
+
+    for wrong in ("recommend", "recommendations"):
+        with pytest.raises(SystemExit):
+            build_parser_parse([wrong, "--criterion", "x"])
+
+
+def test_criterion_is_required(capsys):
+    import pytest
+
+    with pytest.raises(SystemExit):
+        build_parser_parse(["recommendation"])
+
+
+def test_an_undocumented_format_is_rejected(capsys):
+    import pytest
+
+    with pytest.raises(SystemExit):
+        build_parser_parse(["recommendation", "--criterion", "x", "--format", "yaml"])
+
+
+def build_parser_parse(argv):
+    from acceptance.cli import build_parser
+
+    return build_parser().parse_args(argv)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -540,7 +540,7 @@ def _gap_client():
             "expected_output": "an empty result, not an error",
             "required_assertions": ["assert handle([]) == []"],
             "plausible_defect": "raises IndexError on an empty input",
-            "repo_conventions": "tests/test_thing.py",
+            "repo_conventions": "follow the fixtures in tests/test_thing.py",
         }]},
         "_Mismatches": {"mismatches": []},
     })
@@ -628,11 +628,23 @@ def test_recommendation_returns_the_stored_prescription_for_a_criterion(
 
     payload = json.loads(capsys.readouterr().out)
     assert payload["obligation_id"] == "gap-ob"
-    # Prose values, not flattened tokens: the reasoning is what makes it usable.
-    assert payload["plausible_defect"] == "raises IndexError on an empty input"
-    assert payload["required_assertions"] == ["assert handle([]) == []"]
+    # Every §9.5 field, each holding its prose rather than a flattened token —
+    # the reasoning inside them is what makes a recommendation actionable, and a
+    # regression that compressed only the unasserted ones would otherwise pass.
+    assert payload["required_inputs"] == "an empty collection"
     assert payload["boundary_conditions"] == "zero elements"
     assert payload["expected_output"] == "an empty result, not an error"
+    assert payload["required_assertions"] == ["assert handle([]) == []"]
+    assert payload["plausible_defect"] == "raises IndexError on an empty input"
+    assert payload["repo_conventions"] == "follow the fixtures in tests/test_thing.py"
+    # Prose, not codes: multi-word text survives the round trip.
+    assert all(
+        len(str(payload[field]).split()) > 1
+        for field in (
+            "required_inputs", "boundary_conditions", "expected_output",
+            "plausible_defect", "repo_conventions",
+        )
+    )
 
 
 def test_recommendation_for_an_unknown_criterion_is_empty_not_an_error(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -660,19 +660,116 @@ def test_two_retrievals_over_unchanged_state_are_byte_identical(
     assert first == second
 
 
-def test_recommendation_defaults_to_the_most_recently_stored_review(
-    git_repo, fixture_task_path, capsys, monkeypatch
+def _store_review_with(tmp_path, revision, criterion, defect):
+    """Write a review straight into the store, so a test can control what is
+    stored and in what order without running a review to get it there."""
+    from acceptance.review_state import Review, TestRecommendation
+    from acceptance.review_store import ReviewStore
+
+    review = Review(
+        mode="local",
+        reviewed_revision=revision,
+        recommendations=[
+            TestRecommendation(
+                obligation_id=criterion,
+                criterion="A criterion",
+                required_inputs="inputs",
+                boundary_conditions="edges",
+                expected_output="output",
+                required_assertions=["assert True"],
+                plausible_defect=defect,
+                repo_conventions="conventions",
+            )
+        ],
+    )
+    return ReviewStore(tmp_path / ".acceptance" / "cache" / "reviews").write(review)
+
+
+def test_retrieval_reads_the_named_revision_and_not_a_recomputation(
+    monkeypatch, tmp_path, capsys
 ):
-    """The no-argument form has to be the useful one: run check, then pull the
-    detail on a criterion it just reported."""
-    _run_check_with_gaps(git_repo, fixture_task_path, monkeypatch)
-    capsys.readouterr()
+    """Two stored reviews disagree about the same criterion, so reading the
+    wrong one — or recomputing instead of reading — is observable.
 
-    assert main(["recommendation", "--criterion", "gap-ob", "--format", "text"]) == 0
+    The previous version of this test stored a single review, which cannot
+    distinguish "read the stored state" from "recomputed and happened to agree".
+    """
+    import json
 
-    out = capsys.readouterr().out
-    assert "raises IndexError on an empty input" in out
-    assert "assert handle([]) == []" in out
+    monkeypatch.chdir(tmp_path)
+    _store_review_with(tmp_path, "a" * 40, "ob-1", "the OLDER defect")
+    _store_review_with(tmp_path, "b" * 40, "ob-1", "the NEWER defect")
+
+    assert main(["recommendation", "--criterion", "ob-1", "--revision", "a" * 40]) == 0
+    assert json.loads(capsys.readouterr().out)["plausible_defect"] == "the OLDER defect"
+
+    assert main(["recommendation", "--criterion", "ob-1", "--revision", "b" * 40]) == 0
+    assert json.loads(capsys.readouterr().out)["plausible_defect"] == "the NEWER defect"
+
+
+def test_retrieval_makes_no_model_call(monkeypatch, tmp_path, capsys):
+    """Retrieval reads state; it never re-runs the review. That is the whole
+    reason the pull is cheap, so it is asserted rather than assumed."""
+    from acceptance import cli
+    from acceptance.config import RunConfig
+
+    monkeypatch.chdir(tmp_path)
+    _store_review_with(tmp_path, "a" * 40, "ob-1", "a defect")
+
+    def explode(self, completion_fn=None):
+        raise AssertionError("retrieval built a model client")
+
+    monkeypatch.setattr(RunConfig, "build_client", explode)
+    monkeypatch.setattr(
+        cli, "run_review", lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("retrieval re-ran the review pipeline")
+        )
+    )
+
+    assert main(["recommendation", "--criterion", "ob-1"]) == 0
+    assert "a defect" in capsys.readouterr().out
+
+
+def test_retrieval_without_a_revision_uses_the_newest_stored_review(
+    monkeypatch, tmp_path, capsys
+):
+    """Oldest-vs-newest has to be observable, so the store holds two reviews
+    that disagree, written in a known order."""
+    import json
+    import os
+
+    monkeypatch.chdir(tmp_path)
+    older = _store_review_with(tmp_path, "a" * 40, "ob-1", "the OLDER defect")
+    newer = _store_review_with(tmp_path, "b" * 40, "ob-1", "the NEWER defect")
+    # Pin write order explicitly rather than trusting filesystem timestamp
+    # resolution, which is coarse enough on some platforms to make two writes
+    # in the same test look simultaneous.
+    os.utime(older, (1_000_000, 1_000_000))
+    os.utime(newer, (2_000_000, 2_000_000))
+
+    assert main(["recommendation", "--criterion", "ob-1"]) == 0
+
+    assert json.loads(capsys.readouterr().out)["plausible_defect"] == "the NEWER defect"
+
+
+def test_the_newest_review_wins_regardless_of_filename_order(
+    monkeypatch, tmp_path, capsys
+):
+    """Reviews are keyed by revision, and revisions carry no order. A store that
+    sorted by name would pass the test above by accident, so here the newest
+    review is the alphabetically FIRST filename."""
+    import json
+    import os
+
+    monkeypatch.chdir(tmp_path)
+    older = _store_review_with(tmp_path, "z" * 40, "ob-1", "the OLDER defect")
+    newer = _store_review_with(tmp_path, "a" * 40, "ob-1", "the NEWER defect")
+    os.utime(older, (1_000_000, 1_000_000))
+    os.utime(newer, (2_000_000, 2_000_000))
+
+    assert main(["recommendation", "--criterion", "ob-1"]) == 0
+
+    assert json.loads(capsys.readouterr().out)["plausible_defect"] == "the NEWER defect"
 
 
 def test_recommendation_without_a_stored_review_fails_cleanly(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -511,21 +511,15 @@ def test_check_without_a_head_reviews_the_working_tree(
     assert "uncommitted.py" in changed  # the working tree, not the HEAD commit
 
 
-# --- M7.3: the next-instruction file ---
+# --- M7.3.r1 (#167): on-demand recommendation retrieval, no pushed file ---
 
 
-def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
-    git_repo, fixture_task_path, capsys, monkeypatch
-):
-    """§10.1 step 12: when the review has gaps, `check` writes
-    .acceptance/next-instruction.md and the §16 report points at it instead of
-    printing "(none)"."""
-    from acceptance.config import RunConfig
+def _gap_client():
+    """A checker that finds one uncovered obligation and recommends a test for
+    it — i.e. a review with real gaps, and so a real recommendation to pull."""
     from tests.support import client_dispatching
 
-    # A checker that finds one obligation, leaves it uncovered, and recommends
-    # a discriminating test for it — i.e. a review with real gaps.
-    monkeypatch.setattr(RunConfig, "build_client", lambda self, completion_fn=None: client_dispatching({
+    return client_dispatching({
         "_Decomposition": {"obligations": [{
             "id": "gap-ob", "description": "Handle the empty case",
             "type": "functional", "importance": "critical", "explicit": True,
@@ -549,33 +543,142 @@ def test_check_writes_a_next_instruction_file_and_points_the_report_at_it(
             "repo_conventions": "tests/test_thing.py",
         }]},
         "_Mismatches": {"mismatches": []},
-    }))
+    })
 
+
+def _run_check_with_gaps(git_repo, fixture_task_path, monkeypatch):
+    from acceptance.config import RunConfig
+
+    monkeypatch.setattr(
+        RunConfig, "build_client", lambda self, completion_fn=None: _gap_client()
+    )
     assert main([
         "check", "--task", fixture_task_path,
         "--base", git_repo["base"], "--head", git_repo["head"],
     ]) == 0
 
-    instruction_file = git_repo["path"] / ".acceptance" / "next-instruction.md"
-    assert instruction_file.is_file()
-    written = instruction_file.read_text()
-    assert "Handle the empty case" in written  # the gap
-    assert "Must fail if: raises IndexError on an empty input" in written  # its test
-    assert "Update the builder declaration after the changes." in written
-    # The §16 report's pointer now names the file rather than "(none)".
-    out = capsys.readouterr().out
-    assert ".acceptance/next-instruction.md" in out
 
-
-def test_check_writes_no_instruction_file_when_nothing_is_wrong(
-    git_repo, fixture_task_path, capsys, stub_model
+def test_check_writes_no_instruction_file_even_when_the_review_has_gaps(
+    git_repo, fixture_task_path, capsys, monkeypatch
 ):
-    """A checker that finds nothing has nothing to instruct, so no file is
-    written and the report still reads "(none)"."""
-    assert main([
-        "check", "--task", fixture_task_path,
-        "--base", git_repo["base"], "--head", git_repo["head"],
-    ]) == 0
+    """The push is gone. This is exactly the case that used to write the file."""
+    _run_check_with_gaps(git_repo, fixture_task_path, monkeypatch)
 
     assert not (git_repo["path"] / ".acceptance" / "next-instruction.md").exists()
+    out = capsys.readouterr().out
+    assert "acceptance recommendation --criterion gap-ob" in out
+    assert "next-instruction.md" not in out
+
+
+def test_a_stale_instruction_file_is_removed_and_the_removal_reported(
+    git_repo, fixture_task_path, capsys, stub_model
+):
+    """The case the old `test_cli.py:565` missed, and the point of the migration.
+
+    That test asserted the file was absent after a clean run, but passed only
+    because the fixture repo was fresh — it never had one. Here the repo ALREADY
+    contains a stale file, which is the state every repo that ran the previous
+    version is in. Left alone it keeps asserting gaps that no longer exist,
+    contradicting a clean report; both cannot be true and only the report is
+    entitled to speak.
+    """
+    stale = git_repo["path"] / ".acceptance" / "next-instruction.md"
+    stale.parent.mkdir(parents=True, exist_ok=True)
+    stale.write_text("# Next instruction\n\nSomething that is no longer true.\n")
+
+    assert main([
+        "check", "--task", fixture_task_path,
+        "--base", git_repo["base"], "--head", git_repo["head"],
+    ]) == 0
+
+    assert not stale.exists()
+    # Visible, not silent — it touched a file in the user's repo.
+    assert "Removed a stale" in capsys.readouterr().out
+
+
+def test_the_removal_leaves_the_report_as_the_only_statement_of_status(
+    git_repo, fixture_task_path, capsys, stub_model
+):
+    """A clean run starting from a repo that already contains the file: nothing
+    is left on disk to contradict the report."""
+    stale = git_repo["path"] / ".acceptance" / "next-instruction.md"
+    stale.parent.mkdir(parents=True, exist_ok=True)
+    stale.write_text("# Next instruction\n\nStale gaps.\n")
+
+    assert main([
+        "check", "--task", fixture_task_path,
+        "--base", git_repo["base"], "--head", git_repo["head"],
+    ]) == 0
+
+    assert not stale.exists()
     assert "Recommended next instruction: (none)" in capsys.readouterr().out
+
+
+def test_recommendation_returns_the_stored_prescription_for_a_criterion(
+    git_repo, fixture_task_path, capsys, monkeypatch
+):
+    """Retrieval reads review state — no re-run, no model call."""
+    import json
+
+    _run_check_with_gaps(git_repo, fixture_task_path, monkeypatch)
+    capsys.readouterr()
+
+    assert main(["recommendation", "--criterion", "gap-ob"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["obligation_id"] == "gap-ob"
+    # Prose values, not flattened tokens: the reasoning is what makes it usable.
+    assert payload["plausible_defect"] == "raises IndexError on an empty input"
+    assert payload["required_assertions"] == ["assert handle([]) == []"]
+    assert payload["boundary_conditions"] == "zero elements"
+    assert payload["expected_output"] == "an empty result, not an error"
+
+
+def test_recommendation_for_an_unknown_criterion_is_empty_not_an_error(
+    git_repo, fixture_task_path, capsys, monkeypatch
+):
+    """A strongly-supported obligation earns no recommendation, and asking about
+    one is a reasonable thing for an agent to do."""
+    _run_check_with_gaps(git_repo, fixture_task_path, monkeypatch)
+    capsys.readouterr()
+
+    assert main(["recommendation", "--criterion", "no-such-obligation"]) == 0
+    assert capsys.readouterr().out.strip() == "{}"
+
+
+def test_two_retrievals_over_unchanged_state_are_byte_identical(
+    git_repo, fixture_task_path, capsys, monkeypatch
+):
+    _run_check_with_gaps(git_repo, fixture_task_path, monkeypatch)
+    capsys.readouterr()
+
+    assert main(["recommendation", "--criterion", "gap-ob"]) == 0
+    first = capsys.readouterr().out
+    assert main(["recommendation", "--criterion", "gap-ob"]) == 0
+    second = capsys.readouterr().out
+
+    assert first == second
+
+
+def test_recommendation_defaults_to_the_most_recently_stored_review(
+    git_repo, fixture_task_path, capsys, monkeypatch
+):
+    """The no-argument form has to be the useful one: run check, then pull the
+    detail on a criterion it just reported."""
+    _run_check_with_gaps(git_repo, fixture_task_path, monkeypatch)
+    capsys.readouterr()
+
+    assert main(["recommendation", "--criterion", "gap-ob", "--format", "text"]) == 0
+
+    out = capsys.readouterr().out
+    assert "raises IndexError on an empty input" in out
+    assert "assert handle([]) == []" in out
+
+
+def test_recommendation_without_a_stored_review_fails_cleanly(
+    monkeypatch, tmp_path, capsys
+):
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["recommendation", "--criterion", "anything"]) == 1
+    assert "no stored review" in capsys.readouterr().err

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -17,9 +17,8 @@ from acceptance.review_state import (
     TestRecommendation,
     UnrequestedChangeDisposition,
 )
-import re
 
-from acceptance.report import render_next_instruction, render_report
+from acceptance.report import render_report
 
 
 def test_empty_review_renders_the_full_shell():
@@ -88,7 +87,6 @@ def test_report_renders_each_obligation_with_both_axes_numbered():
             rationale="1 obligation(s) not fully implemented.",
             limitations=["Judgments are static inferences unless a higher tier is recorded."],
         ),
-        recommendation=".acceptance/next-instruction.md",
     )
 
     report = render_report(review)
@@ -109,7 +107,10 @@ def test_report_renders_each_obligation_with_both_axes_numbered():
     # Unrequested changes are advisory, numbered, with their disposition.
     assert "  1. [separable] Export filename behavior changed" in report
     assert "Evidence limitations:" in report
-    assert "Recommended next instruction: .acceptance/next-instruction.md" in report
+    # A command, not a file (M7.3.r1): the file was written speculatively by
+    # whichever run last found gaps and outlived it.
+    assert "acceptance recommendation --criterion" in report
+    assert "next-instruction.md" not in report
 
 
 def test_status_is_stated_in_words_not_symbols():
@@ -266,192 +267,6 @@ def test_the_two_axes_render_independently_for_the_same_obligation():
 
     assert "code evidence: addressed" in report
     assert "test evidence: nominally supported" in report
-
-
-# --- M7.3: the §10.1 step-12 next instruction ---
-
-
-def _gap_finding(obligation_description: str) -> Finding:
-    return Finding(
-        type="coverage_gap", severity="high", description="missing",
-        evidence_tier=EvidenceTier.STATIC, produced_by=Component.STATIC_ANALYZER,
-        links=[Link(kind="requirement", ref="x", text="x")],
-        related_obligation=obligation_description,
-    )
-
-
-def _recommendation(criterion: str, defect: str) -> TestRecommendation:
-    return TestRecommendation(
-        obligation_id=criterion.lower().replace(" ", "-")[:20],
-        criterion=criterion,
-        required_inputs="a non-30-day month",
-        boundary_conditions="0 days used, a full month",
-        expected_output="price/days_in_month * days, rounded",
-        required_assertions=["assert prorate(280, 14, 28) == 140.0"],
-        plausible_defect=defect,
-        repo_conventions="test_billing.py",
-    )
-
-
-def test_multi_gap_review_names_each_gap_and_its_distinguishing_test():
-    """M7.3 acceptance: on a multi-gap review the instruction names each gap
-    and the discriminating test that closes it (§10.1 style)."""
-    review = Review(
-        mode="local",
-        reviewed_revision="abc",
-        obligation_map=[_obligation("Daily rate", "not_addressed", "unsupported")],
-        findings=[
-            _gap_finding("Daily rate is monthly_price divided by days_in_month"),
-            _gap_finding("Round the result to two decimals"),
-        ],
-        recommendations=[
-            _recommendation("Daily rate uses days_in_month", "hard-codes price/30"),
-            _recommendation("Rounding to two decimals", "drops the round() call"),
-        ],
-        completion=CompletionResult(
-            verdict=CompletionVerdict.INCOMPLETE, rationale="2 gaps.",
-        ),
-    )
-
-    instruction = render_next_instruction(review)
-
-    # Each gap is named...
-    assert "Daily rate is monthly_price divided by days_in_month" in instruction
-    assert "Round the result to two decimals" in instruction
-    # ...and each distinguishing test, with the defect it must catch.
-    assert "Daily rate uses days_in_month" in instruction
-    assert "Must fail if: hard-codes price/30" in instruction
-    assert "Must fail if: drops the round() call" in instruction
-    assert "assert prorate(280, 14, 28) == 140.0" in instruction
-    # §10.1 closes by asking for the declaration to be refreshed.
-    assert "Update the builder declaration after the changes." in instruction
-
-
-def test_no_instruction_when_there_are_no_material_gaps():
-    """§10.1 step 12 produces an instruction only WHEN GAPS EXIST.
-
-    Carries leftover recommendations deliberately: with an empty review the
-    "nothing actionable" guard would return None on its own and the verdict
-    gate would never be exercised. Recommendations present + a positive
-    verdict isolates the gate as the only thing that can suppress output.
-    """
-    review = Review(
-        mode="local",
-        reviewed_revision="abc",
-        obligation_map=[_obligation("A", "addressed", "strongly_supported")],
-        recommendations=[_recommendation("Some criterion", "some defect")],
-        completion=CompletionResult(
-            verdict=CompletionVerdict.NO_MATERIAL_GAPS, rationale="all good",
-        ),
-    )
-
-    assert render_next_instruction(review) is None
-
-
-def test_unresolved_open_questions_lead_the_instruction():
-    """A needs-clarification review can't be closed by writing code, so the
-    questions come first (#113)."""
-    review = Review(
-        mode="local",
-        reviewed_revision="abc",
-        open_questions=[
-            OpenQuestion(id="q-1", question="Minus sign or parentheses?"),
-            OpenQuestion(id="q-2", question="Already answered", resolved=True),
-        ],
-        completion=CompletionResult(
-            verdict=CompletionVerdict.NEEDS_CLARIFICATION, rationale="1 open question.",
-        ),
-    )
-
-    instruction = render_next_instruction(review)
-
-    assert "Answer these first" in instruction
-    assert "Minus sign or parentheses?" in instruction
-    assert "Already answered" not in instruction  # resolved questions are not asked again
-
-
-def test_no_instruction_when_a_non_positive_verdict_has_nothing_actionable():
-    """unable-to-determine with no gaps, recommendations or open questions has
-    nothing to instruct — better silence than an empty template."""
-    review = Review(
-        mode="local",
-        reviewed_revision="abc",
-        completion=CompletionResult(
-            verdict=CompletionVerdict.UNABLE_TO_DETERMINE, rationale="nothing analyzed",
-        ),
-    )
-
-    assert render_next_instruction(review) is None
-
-
-def test_instruction_contains_only_review_content_and_invents_nothing():
-    """Obligation 4's real test: the instruction is a PROJECTION, so it must
-    contain exactly the review's own gaps and recommendations and nothing more.
-
-    Compares the FULL SET of rendered items against the review's own content.
-    An earlier version enumerated expected prefixes ("1. ", "2. ") and so
-    missed an injected "0. " line -- a superset check that could not detect a
-    superset. Set equality is what actually closes that."""
-    review = Review(
-        mode="local",
-        reviewed_revision="abc",
-        findings=[_gap_finding("Only gap A")],
-        recommendations=[_recommendation("Only criterion A", "defect A")],
-        completion=CompletionResult(
-            verdict=CompletionVerdict.INCOMPLETE, rationale="1 gap.",
-        ),
-    )
-
-    instruction = render_next_instruction(review)
-
-    def numbered_items(section: str) -> set[str]:
-        """Every `<n>. <text>` item in a section, regardless of its number."""
-        return {
-            re.sub(r"\*\*", "", m.group(1)).strip()
-            for m in (re.match(r"^\d+\.\s+(.*)$", ln) for ln in section.splitlines())
-            if m
-        }
-
-    implement = instruction.split("## Implement")[1].split("## ")[0]
-    tests_section = instruction.split("## Add these tests")[1]
-
-    # EXACTLY the review's own content -- nothing invented, nothing dropped.
-    assert numbered_items(implement) == {"Only gap A"}
-    assert numbered_items(tests_section) == {"Only criterion A"}
-
-
-def test_instruction_omits_satisfied_obligations_and_advisory_items():
-    """Obligation 6: the instruction SELECTS. A review deliberately mixing an
-    actionable gap with a satisfied obligation, an advisory unrequested change
-    and an evidence limitation must surface only the gap."""
-    review = Review(
-        mode="local",
-        reviewed_revision="abc",
-        obligation_map=[
-            _obligation("A satisfied obligation", "addressed", "strongly_supported"),
-        ],
-        findings=[
-            _gap_finding("A real remaining gap"),
-            Finding(
-                type=UNREQUESTED_CHANGE, severity="medium",
-                description="An advisory unrequested change",
-                evidence_tier=EvidenceTier.STATIC, produced_by=Component.STATIC_ANALYZER,
-                links=[Link(kind="code", ref="x.py#@@ -1 +1 @@")],
-                disposition=UnrequestedChangeDisposition.SEPARABLE,
-            ),
-        ],
-        completion=CompletionResult(
-            verdict=CompletionVerdict.INCOMPLETE, rationale="1 gap.",
-            limitations=["An evidence limitation note"],
-        ),
-    )
-
-    instruction = render_next_instruction(review)
-
-    assert "A real remaining gap" in instruction
-    assert "A satisfied obligation" not in instruction
-    assert "An advisory unrequested change" not in instruction
-    assert "An evidence limitation note" not in instruction
 
 
 # --- incremental re-run rendering (M7.5) ------------------------------------


### PR DESCRIPTION
Closes #167.

M7.3 wrote `.acceptance/next-instruction.md` on any run that found gaps. The path
was keyed to no task and no revision, so whichever run last had gaps owned it, and
nothing ever unlinked it: a later clean run printed `(none)` while a stale file on
disk still asserted gaps — and only the report was telling the truth.

Moving from push to pull removes the class of defect rather than the instance.
Nothing is written speculatively, so nothing can go stale.

## What changed

- **`acceptance recommendation --criterion <id> [--format json|text]`** returns a
  criterion's §9.5 recommendation from the M0 review-state store. It never re-runs
  analysis, so no model call and no cost. JSON by default (the consumer is a coding
  agent), canonical so two retrievals over unchanged state are byte-identical, with
  each field as a discrete key holding its **prose** — flattening `plausible_defect`
  to a token is what makes a recommendation unactionable. A criterion with no
  recommendation returns `{}`, not an error.
- Retrieval defaults to the **most recently written** review — what a caller who
  names none means: run `check`, then pull detail on what it just reported.
- `render_next_instruction`, the write path, and the `.gitignore` entry are gone.
- The §16 report names the command per recommendation, so the pull happens at the
  moment the reader decides to act on that criterion.
- Spec §5.1/§10.1/§10.2 updated to the pull model.

**Migration** (decided rather than defaulted): a run deletes a `next-instruction.md`
left by an older version and reports it on **stderr** — so the notice appears in
every output mode while stdout stays parseable.

## Dogfooding: five Gate 2 rounds, seven real gaps

Findings per round: **2 → 4 → 3 → 3 → 1**. Every round but the last surfaced real
defects in this PR's own work:

- **`--json` deleted the stale file and reported nothing** — a silent deletion in the
  user's repo, the exact thing the migration decision forbade. Every test covered
  text mode only.
- The spec still read *"the recommendation may surface in … a Markdown file"*; the
  filename check passed while the file-writing framing survived.
- `test_recommendation_defaults_to_the_most_recently_stored_review` stored a **single**
  review — it could not distinguish "the newest" from "the only one", i.e. did not
  verify its own name.
- Nothing snapshotted the repo around `recommendation` itself.
- Two of the six §9.5 fields were unasserted, so a terse-token regression would pass.

The replacement CLI test starts from a repo that **already contains** the file.
`tests/test_cli.py:565` asserted its absence after a clean run but passed only because
the fixture was fresh — precisely the case #167 called out.

`test_the_shared_pipeline_writes_nothing_into_the_reviewed_repo` proved its isolation
was non-vacuous by showing the CLI *did* write; that contrast is gone, so it now makes
the stronger claim that neither path writes into the repo.

## Residue, tracked not waved off

One finding remains: `replace-written-file-with-command` at `partially supported`.
Attributed to **#180** (under umbrella #183), not fixed here.

It is a **tool defect, verified**: runs 4 and 5 are one commit apart with a
byte-identical mapped test set, and the same plausible defect was judged
`would_be_caught` **true** then **false** — with the false verdict factually wrong
about what the test does. `strength.py` is a pure reduce and mapping was unchanged,
so the variance is entirely in M5.2's per-defect verdict.

Also landed here: `tests/fixtures/rating-stability/`, the corpus behind #180 — five
runs' task files, reports and my judgement of every finding, including two I got
wrong and corrected.

580 tests green, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)