### PR TITLE
Add DR-163 and DR-180

### DIFF
--- a/docs/DR-163-supplied-id-constraint.md
+++ b/docs/DR-163-supplied-id-constraint.md
@@ -1,0 +1,152 @@
+# Decision Record 163 — Constraining ids to the set actually supplied
+
+*Relates to issue #163 (delivered in `#179`, merged as `839ea47`) and issue #164.
+Status: **implemented**, all six model stages. Track: checker. Stage: 1.*
+
+---
+
+## Context — a valid answer to a different question
+
+Every stage that asks the model to echo back an id we supplied typed that id as
+a free-form `str`. Nothing in the schema said "this must be one of the ids I just
+gave you", so **an id that does not exist was valid output**.
+
+Observed dogfooding #36: the mapping call returned 96 entries; 80 had empty
+obligation lists and the other 16 named `show-fields`, `line-total`,
+`money-format`, `returns-in-parens` — obligations belonging to the **archetype-1
+fixture**, which appears in the body of `tests/benchmark/test_coverage.py`, one
+of the candidate test files pasted into the prompt. The prompt is 96% test
+source, so it is full of obligation-id-shaped strings.
+
+The model was not judging our 17 obligations and finding no match. It was
+answering about obligations it had read out of the test sources. `mapping.py`
+then filtered those foreign ids out **silently**, leaving a result
+indistinguishable from "no test evidences any obligation" — so the review told
+the reader their change was untested when the truth was that the reviewer had
+answered a different question.
+
+Four of the six id-echoing stages discarded a wrong answer without trace. Two
+(`classify.py`, `open_questions.py`) already recorded a *missing* answer
+honestly; none constrained the id.
+
+---
+
+## Decision 1 — the constraint goes in the schema, built per call
+
+Each id-bearing response field becomes an **enum of the ids that call actually
+supplied**, so a foreign id is not merely detected but **unrepresentable**: under
+constrained decoding the tokens are not available.
+
+This is the #158 lesson applied one level further. There we learned that enum
+values must be *inline* rather than behind a `$ref` for the model to honour them,
+and that the representation changed the answers. Same principle: encode the
+constraint where the model is bound by it, not in the prose.
+
+Built per call, never from a fixed list — so a partitioned stage constrains each
+call to its own partition (mapping supplies that batch's tests, but every
+obligation, because every batch judges all of them).
+
+## Decision 2 — a local per-item check as well, and it is not redundant
+
+`supplied_ids.scan` re-checks every returned id against the supplied set.
+
+The two mechanisms answer different questions:
+
+| | mechanism | purpose | binds |
+|---|---|---|---|
+| Schema enum, per call | `constrain` | **prevention** | providers honouring strict mode |
+| Per-item local check | `scan` | **detection** | always |
+
+The harness routes through LiteLLM with `drop_params=True` *specifically* so the
+model can be swapped to compare quality and cost (M0.4) — Anthropic refuses
+`seed` outright, OpenAI accepts it. A constraint that binds only one provider is
+not a constraint on the tool. The local check is what makes the guarantee
+provider-independent.
+
+It also covers a case the schema cannot: a field whose supplied set is **empty**
+is left unconstrained, because `Literal[]` is not a type. There the guarantee
+degrades to detection rather than vanishing.
+
+## Decision 3 — `parse_as`: what we ask for is not what we accept
+
+**This is the non-obvious one.**
+
+`ModelClient._validate` parses the *whole response object*. Validating against
+the constrained model would therefore turn one bad id in a 96-entry mapping batch
+into a `SchemaValidationError` that aborts the entire review — discarding 95
+usable judgments to punish one.
+
+So `complete()` gained a seam: `response_model` is what we **ask** for (it goes
+into the request and is hashed into the request key), `parse_as` is what we
+**accept**. They differ only where a stage constrains ids.
+
+Two traps found while building it, both worth recording:
+
+- **`_persist_live_call` re-validated with the constrained model**, silently
+  defeating the seam on the RECORD path while REPLAY worked correctly. Gating on
+  the constraint would also refuse to *record* the very replies that prove a
+  provider ignores it. The gate is now `parse_as`.
+- **Pydantic renders a one-value `Literal` as `const`, not `enum`.** Providers
+  honour `enum` under strict decoding. Without normalising (`_const_to_enum` in
+  `inline_schema_refs`), the one case where the constraint silently stopped
+  binding would be a call supplying exactly one id — a one-obligation task, or a
+  final partition. A defect that appears only at the boundary.
+
+## Decision 4 — an unusable answer is `indeterminate`, never a negative
+
+An obligation whose judgment could not be honoured is recorded as
+`indeterminate`, **not** as `unmapped` / lacking evidence.
+
+"No test evidences this obligation" is a substantive claim, and we forfeit it
+when the answer that would have mapped the obligation is exactly the one we could
+not read. Every batch judges every obligation, so a single unusable answer taints
+the whole unmapped set for that run.
+
+This required **no new type**: `evidence_class == "indeterminate"` already routes
+through `verdict.py` to `UNABLE_TO_DETERMINE` and lists the obligation as an
+escalation candidate. A review that could not read part of its own reviewer
+cannot come back clean — the "uncertainty is first-class" invariant applied to
+the tool's own machinery.
+
+The finding is typed `unusable_answer` and is **not advisory**. An unrequested
+change or a declaration overclaim is about the delivered work and leaves the
+verdict alone; this is about the review failing to answer a question it asked,
+which is precisely what a reader must not mistake for a clean result.
+
+---
+
+## Rejected
+
+**Hard-fail the run on any foreign id.** Loudest possible signal, and it can never
+be mistaken for a substantive answer. Rejected because one bad id out of ~1,600
+judgments aborts an entire review, and a provider with weak strict-mode support
+would make the tool unusable against it — defeating the provider-agnosticism the
+harness exists to provide.
+
+**Strict parse with per-batch recovery.** Catch the error at the batch boundary
+and record the whole batch as unanswered. Rejected as too coarse: it discards the
+good judgments that merely shared a batch with the bad one.
+
+**Constraining `_DecomposedObligation.id`.** The model *invents* these; there is
+no supplied set to constrain them to. Correct as-is.
+
+**Verifying `source_quote` appears in the task text.** Same family — a claim about
+supplied input we could verify — but a different check: the quote must appear in
+a text, not belong to a set. Deferred, not rejected.
+
+**Detecting empty answers.** A model returning an empty list is schema-valid and
+indistinguishable from a correct "no test covers this". That is a judgment the
+reviewer cannot audit. No fix attempted, and none proposed.
+
+---
+
+## Related
+
+- **#158** — enum values must be inline, not behind `$ref`; the representation
+  changes the answer. This decision is that lesson one level further.
+- **#164** / `DR-164` — request partitioning. Sequenced first, deliberately:
+  constrained decoding stops the model answering the *wrong* question, but not
+  answering *thinly* under a call carrying 1,632 judgments. Re-recording the
+  corpus once, after the prompt rework, was cheaper than twice.
+- **#183** — evidence judgement umbrella. Constraining ids removes one source of
+  unreliable output; it does not address whether the judgment itself is stable.

--- a/docs/DR-180-evidence-judgement-instability.md
+++ b/docs/DR-180-evidence-judgement-instability.md
@@ -1,0 +1,147 @@
+# Decision Record 180 — Evidence-judgement instability, and where it lives
+
+*Relates to issue #180 (open, under umbrella #183). Status: **findings recorded,
+localized, unresolved.** Track: checker. Stage: 1.*
+
+*A findings record, not a resolved decision. It exists because the measurement
+took five dogfood rounds and two corrected judgements to produce, and none of it
+is recoverable from the logs alone — `dogfood-logs/` is gitignored and
+`current-task.md` is overwritten by the next task. One design decision **is**
+settled here: what a fix must not do.*
+
+---
+
+## The measurement
+
+Three consecutive `acceptance check` runs over a **byte-identical** task file,
+against a **strictly growing** test suite, disagreed about **8 of 12
+obligations**. Commits `07075a6` → `7de7d71` → `95b880a`.
+
+| run 1 | run 2 | run 3 | obligation |
+|---|---|---|---|
+| STRONG | nominal | STRONG | `default-to-most-recent-review` |
+| STRONG | STRONG | partial | `no-speculative-writing` |
+| nominal | STRONG | STRONG | `fixed-command-surface` |
+| STRONG | partial | partial | `spec-no-longer-describes-written-file` |
+| STRONG | partial | STRONG | `byte-identical-retrievals` |
+| STRONG | STRONG | partial | `remove-stale-next-instruction-file` |
+| UNSUP | STRONG | STRONG | `replace-written-file-with-command` |
+| STRONG | partial | STRONG | `retrieve-from-stored-review-state` |
+
+Only 4 of 12 held their rating throughout. Full corpus — each run's task file,
+report, and the judgement made at the time — in `tests/fixtures/rating-stability/`.
+
+## The asymmetry — the load-bearing finding
+
+> **In 7 of the 8 unstable obligations, the LOW rating was the correct one.**
+
+Every rating that fell turned out to be the judge finally noticing a hole that
+had been there all along. The most serious: `remove-stale-next-instruction-file`
+was `strongly supported` in runs 1 and 2 while the `--json` code path **deleted a
+file in the user's repo and reported nothing**. Run 3 dropped it to `partial` and
+was right.
+
+So the defect is **not that ratings move**. It is that `strongly supported` is
+issued when it has not been earned. The tool errs toward "looks fine", which is
+considerably worse than noise: a permissive false negative is invisible, and
+Gate 2 is a shipping gate.
+
+**This inverts the obvious fix.** Damping the judge to stabilise ratings would
+make the symptom disappear while making the tool worse.
+
+## The localization — M5.2, not mapping, not the reduce
+
+#167 Gate 2 runs 4 (`52c52b8`) and 5 (`dd0a6a5`), one commit apart. Obligation
+`replace-written-file-with-command`, **byte-identical mapped test set** in both:
+`test_check_writes_no_instruction_file_even_when_the_review_has_gaps`,
+`test_json_is_the_default_format_when_none_is_requested`,
+`test_the_spec_names_the_command_the_cli_actually_accepts`.
+
+The discrimination stage named essentially the same plausible defect in both runs
+and judged it **oppositely**:
+
+| run | `would_be_caught` | reason given |
+|---|---|---|
+| 4 | **true** | "The test explicitly checks that the file does not exist after `check`, so any implementation that still writes it would fail." |
+| 5 | **false** | "The mapped tests mostly check that the command exists and that the file is absent in the exercised run… could slip past." |
+
+**Run 4 is correct.** `test_check_writes_no_instruction_file_even_when_the_review_has_gaps`
+invokes `check` on a review *with gaps* — exactly the case that previously wrote
+the file — and asserts its absence. Run 5's verdict is not a defensible
+difference of judgement; it is wrong about what the test does.
+
+What this exonerates:
+
+- **Mapping** (#182). The mapped set was byte-identical across the two runs, so
+  #150/#173 are not the cause here.
+- **`strength.py`** (M5.3). It is a pure deterministic reduce — `all caught →
+  strongly_supported`, `some → partially_supported`. It cannot introduce variance.
+
+The variance is **entirely in M5.2's per-defect `would_be_caught` verdict**. One
+flipped boolean moved the obligation from `strongly_supported` to
+`partially_supported`, and with it the run's verdict.
+
+A second-order finding: the two runs also *worded the defect differently*
+("…but also adds the new `recommendation` command so retrieval works too" vs
+"…and only adds the new `recommendation` command as an extra way to view it").
+**Defect enumeration is itself unstable**, so pinning verdicts is not enough — the
+defect set they range over has to be stable first.
+
+---
+
+## Decision — what a fix must not do
+
+Settled, and recorded here because the corpus makes it non-obvious:
+
+**Stability must not be bought by blunting the judge.** Across five dogfood rounds
+this stage found **seven real gaps** in the work under review, including the
+silent file deletion, a test that stored a single review while claiming to verify
+"the most recent" (it did not verify its own name), and two §9.5 fields that were
+never asserted. Those are exactly what the tool exists to find.
+
+Consequently #180's acceptance criterion *"adding a test never lowers any
+obligation's rating"* was **struck**. Every falling rating in the corpus was
+correct, so that criterion is satisfied by a permanently permissive judge — it
+encodes the bug. The criterion that matters is: **`strongly supported` is not
+issued on evidence that does not earn it.** The corpus supplies six worked cases
+where it was.
+
+## The inference to avoid
+
+The most reusable thing here, because it was made twice and would have shipped a
+silent file deletion:
+
+> *The diff was purely additive; added tests cannot weaken evidence; therefore a
+> rating that fell did so for reasons outside the diff.*
+
+Both premises are true. **The conclusion does not follow.** A rating that falls on
+an additive diff can equally mean the judge has finally noticed a pre-existing
+hole — which is what happened every time it was checked.
+
+Corollary for dogfooding: instability is not a licence to dismiss a finding.
+Check the finding on its merits first; attribute to instability only after.
+
+## Open
+
+- Whether stabilising defect **enumeration** is a precondition for stabilising the
+  verdicts, or whether both can be addressed together.
+- Whether the fix belongs in the determinism component (#184) as a general
+  "same evidence → same result" guarantee, or in the discrimination prompt/schema
+  specifically (#183). The component work touches the request key and so forces a
+  transcript re-record; sequence accordingly.
+- `byte-identical-retrievals` (STRONG → partial → STRONG) is the one case still
+  believed to be genuine noise. Given the record above, treat it as unsettled
+  rather than as an established example.
+- Whether #150 (mapping instability) and #154 (idempotent findings) close into
+  #180 or remain the narrower halves.
+
+## Related
+
+- **#183** — evidence judgement umbrella; owns the fix.
+- **#184** — determinism as an owned component; the human's design direction is to
+  extend it from byte-identical *replay* to *judgement* stability.
+- **#144** — the compound umbrella obligation involved in the localized instance.
+  A real defect, and it makes the judge's job harder, but **not** the cause; an
+  early attribution of the finding there was wrong and has been corrected.
+- `tests/fixtures/rating-stability/` — the corpus, including two judgements I made
+  wrong and rewrote. The errors are kept deliberately.

--- a/tests/fixtures/rating-stability/README.md
+++ b/tests/fixtures/rating-stability/README.md
@@ -1,8 +1,14 @@
 # Rating-stability corpus
 
 Captured dogfood iterations, kept as **test data for fixing the instability they
-document** (#180). Not currently read by any test — it is the evidence a fix has
-to be measured against, recorded while the judgements were still fresh.
+document** (#180, umbrella #183). Not currently read by any test — it is the
+evidence a fix has to be measured against, recorded while the judgements were
+still fresh.
+
+**The reasoning lives in `docs/DR-180-evidence-judgement-instability.md`**; this
+README covers the layout and how to read the runs. The DR owns the analysis — the
+asymmetry, the M5.2 localization, and the constraint on any fix — so the two do
+not drift.
 
 ## Why it is checked in
 


### PR DESCRIPTION
Docs only. No code or test changes.

Both Decision Records were written while #187 was open, but pushed **after** it had
already squash-merged — so they never reached `main`. This lands them.

- **`DR-163-supplied-id-constraint.md`** — settled design for #163. Why the schema
  enum and the local check are two mechanisms rather than redundancy (the enum binds
  only strict-mode providers; the harness runs `drop_params=True` precisely so the
  model can be swapped). Why `parse_as` exists: `_validate` parses the whole response
  object, so a strict `Literal` there aborts a 96-entry batch over one bad id. Two
  traps recorded — `_persist_live_call` re-validating with the constrained model, and
  pydantic rendering a one-value `Literal` as `const` rather than `enum`. Four
  rejected alternatives with reasons.

- **`DR-180-evidence-judgement-instability.md`** — a *findings* record for an open
  issue, per CLAUDE.md's "or when a non-obvious finding changes the design". Captures
  what took five dogfood rounds to establish: the asymmetry (in 7 of 8 unstable
  obligations the **low** rating was correct, so the tool errs permissive), the
  localization to M5.2's per-defect verdict with mapping and the strength reduce both
  exonerated, the one settled decision (stability must not be bought by blunting a
  judge that found seven real gaps), and the faulty inference that would have shipped
  a silent file deletion.

The corpus README now points at DR-180 for the reasoning and keeps the layout itself,
so the two cannot drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)