### PR TITLE
Turn the rating-stability corpus into an executable regression suite (#190)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,14 @@ jobs:
     steps:
       # 1. Get the code onto the runner.
       - uses: actions/checkout@v4
+        with:
+          # Full history, not the default shallow clone: the #190 rating-regression
+          # cases are pinned to real commits in this repository and materialize a
+          # worktree at each one. Under fetch-depth: 1 those revisions do not exist
+          # and every case fails by name — which is the designed behaviour for a
+          # suite pinned to history, so the fix belongs here rather than in a
+          # skip-if-missing that would let the suite shrink silently.
+          fetch-depth: 0
 
       # 2. Install the Python the project targets (see plan §3.1).
       - uses: actions/setup-python@v5

--- a/dogfood-logs/190-gate2-run1/current-task.md
+++ b/dogfood-logs/190-gate2-run1/current-task.md
@@ -1,0 +1,103 @@
+# Task
+The rating-stability corpus at `tests/fixtures/rating-stability/` records what
+`acceptance check` concluded across six dogfood runs, and what each conclusion
+was judged to be worth at the time. Its README says the corpus is not currently
+read by any test. Until those judgements are assertions, every candidate fix to
+the evidence-judgement stage is accepted or rejected by eyeball, and the
+load-bearing criterion in `docs/DR-180-evidence-judgement-instability.md` — that
+`strongly supported` is not issued on evidence that does not earn it — has no
+scoreboard.
+
+Turn the corpus into regression cases the benchmark can score.
+
+Each run's input survives. The corpus holds the exact `current-task.md` the run
+was given, and `revisions.txt` names the commit it judged; those commits are
+still reachable in this repository's history. A case therefore supplies the real
+input rather than a reconstruction of it.
+
+What the corpus does not hold is the model's own responses. `check-output.log` is
+the rendered report, downstream of them, so the runs cannot be replayed and the
+judgement a case is scored under is supplied by the test rather than recorded.
+
+## Ground truth from the corpus
+These three lists are the ground truth this task encodes. Each entry names the
+run whose `judgement.md` establishes it.
+
+**Ratings that were issued as `strongly supported` on evidence that did not earn
+them.** Five obligations, seven run-instances:
+
+| obligation | unearned at | corrected by |
+|---|---|---|
+| `default-to-most-recent-review` | run 1 | run 2 |
+| `no-speculative-writing` | runs 1 and 2 | run 3 |
+| `remove-stale-next-instruction-file` | runs 1 and 2 | run 3 |
+| `spec-no-longer-describes-written-file` | run 1 | run 3 |
+| `retrieve-from-stored-review-state` | run 1 | run 2 |
+
+**Gaps the corpus confirms were real, which a fix must not blunt away.** Seven
+strictly real, plus one the corpus records as only partly real:
+
+| obligation | found at | note |
+|---|---|---|
+| `fixed-command-surface` | run 1 | |
+| `default-to-most-recent-review` | run 2 | |
+| `retrieve-from-stored-review-state` | run 2 | |
+| `remove-stale-next-instruction-file` | run 3 | the silent `--json` deletion |
+| `no-speculative-writing` | run 3 | |
+| `spec-no-longer-describes-written-file` | run 3 | |
+| `preserve-prose-structured-fields` | run 4 | |
+| `replace-written-file-with-command` | run 1 | partly real: only its *defaulting to JSON* clause |
+
+**Judgements that were written wrong and rewritten**, where the corpus preserves
+both readings. The corrected reading is ground truth in each:
+
+| run | corrected reading |
+|---|---|
+| run 3 | all three findings were real; the original reading called them tool defects |
+| run 5 | the `partially supported` rating was a wrong verdict; run 4's `strongly supported` is correct |
+
+## Constraints
+- Cases are scored through the benchmark scoring path the repository already has,
+  `benchmark/scoring.py::score_case`, rather than a second one written for this
+  task.
+- Ground-truth labels use the existing `benchmark/case.py::GroundTruthLabels`
+  shape that `tests/fixtures/archetypes/` already carries.
+- A case's inputs are the corpus's own `current-task.md` and the base and head
+  revisions the run judged. No source file is copied into the case.
+- The tree a case is analysed over is the tree at the revision that case judged,
+  not the current working tree.
+- A revision a case names that no longer resolves fails that case, naming the run,
+  rather than silently skipping it.
+- Cases issue no live model calls, and no recorded model transcript is committed.
+- Each case's ground-truth label is traceable to the `judgement.md` it was
+  derived from.
+
+## Scope exclusions
+- Changing how any judgement is produced. This task builds the scoreboard; the
+  evidence-judgement stage itself is untouched.
+- Reducing the instability the corpus documents.
+- Setting a threshold that a variance figure or an accuracy figure must meet.
+- Rebuilding the corpus runs that establish none of the ground truth above.
+- The decompose-stability corpus at `tests/fixtures/decompose-stability/`, which
+  is a separate task.
+- Modifying any file under `tests/fixtures/rating-stability/` other than its
+  README. The corpus is the evidence record these assertions are derived from,
+  and editing it to suit a test destroys the thing being tested against.
+- Restoring the stored review state that the incremental re-run path (M7.5)
+  carried forward into runs 2 and 3. A case supplies the run's input, not the
+  state the run resumed from.
+
+## Completion expectations
+- Implementation
+- Regression cases derived from the corpus are committed as test fixtures.
+- A judge that always issues `strongly supported` fails the suite.
+- A judge that never issues `strongly supported` fails the suite.
+- Every gap listed above as real is required by the suite to still be reported.
+- Every rating listed above as unearned is required by the suite to no longer be
+  issued.
+- Each case derived from run 3 or run 5 records which of the two preserved
+  readings in its `judgement.md` is ground truth.
+- The control case `163-gate2-run1` carries assertions of the same kind as the
+  other cases rather than passing trivially.
+- The corpus README no longer states that the corpus is not read by any test, or
+  else states precisely which parts of it are still not read.

--- a/dogfood-logs/190-gate2-run1/judgement.md
+++ b/dogfood-logs/190-gate2-run1/judgement.md
@@ -1,0 +1,18 @@
+# Judgement — #190 Gate 2, run 1 (`4d05f2d`)
+
+Verdict: **INCOMPLETE**. 14 of 29 obligations `unsupported` — no mapped test at all.
+
+**Mapping audit first (DR-164):** 14/14 entries populated, **zero foreign ids**,
+15/29 obligations reached. The 14 never mapped were exactly the 14 flagged. So
+this was *not* a half-blind review — the mapping worked and the finding is real.
+
+| disposition | obligations |
+|---|---|
+| **REAL, addressed** | All 14. I had built a suite that scores the judge while nothing asserted the requirements the task itself was written against — the "test the wiring, not just the function" hole. |
+
+The five most valuable were the ones nothing covered at all: no test asserted the
+README claim, that all six cases were committed, or — most importantly — that
+runs 3 and 5 encode the *corrected* reading. Getting those backwards is the exact
+failure the corpus exists to prevent, and nothing would have caught it.
+
+Fixed in `e8e8755`.

--- a/dogfood-logs/190-gate2-run1/output.log
+++ b/dogfood-logs/190-gate2-run1/output.log
@@ -1,0 +1,377 @@
+Task completion: INCOMPLETE
+
+14 obligation(s) with non-discriminating test evidence (use-existing-scoring-path, no-live-model-calls, no-recorded-transcript-committed, preserve-rating-stability-readme-only, do-not-change-judgement-production, do-not-reduce-instability, do-not-touch-decompose-stability, do-not-restore-incremental-state, scoreboard-committed-as-fixtures, run3-preserved-reading-ground-truth, run5-preserved-reading-ground-truth, readme-updated-about-test-coverage, run3-corrected-reading-real-findings, run5-corrected-reading-verdict).
+
+Obligations:
+
+  1. Convert the rating-stability corpus into regression cases that the benchmark can score.
+       code evidence: addressed
+         1.1  src/acceptance/benchmark/corpus.py#@@ -0,0 +1,195 @@
+         1.2  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,185 @@
+         1.3  tests/fixtures/rating-regression/163-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         1.4  tests/fixtures/rating-regression/167-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         1.5  tests/fixtures/rating-regression/167-gate2-run2/case.json#@@ -0,0 +1,7 @@
+         1.6  tests/fixtures/rating-regression/167-gate2-run3/case.json#@@ -0,0 +1,7 @@
+         1.7  tests/fixtures/rating-regression/167-gate2-run4/case.json#@@ -0,0 +1,7 @@
+         1.8  tests/fixtures/rating-regression/167-gate2-run5/case.json#@@ -0,0 +1,7 @@
+       test evidence: strongly supported  [tier: static]
+         1.9  tests/benchmark/test_rating_regression.py::test_labels_load_against_the_shared_ground_truth_schema
+
+  2. Score cases through the repository's existing benchmark scoring path.
+       code evidence: addressed
+         2.1  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,185 @@
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  3. Represent ground-truth labels with the existing `benchmark/case.py::GroundTruthLabels` shape used by `tests/fixtures/archetypes/`.
+       code evidence: addressed
+         3.1  src/acceptance/benchmark/corpus.py#@@ -0,0 +1,195 @@
+         3.2  tests/fixtures/rating-regression/163-gate2-run1/labels.json#@@ -0,0 +1,179 @@
+         3.3  tests/fixtures/rating-regression/167-gate2-run1/labels.json#@@ -0,0 +1,190 @@
+         3.4  tests/fixtures/rating-regression/167-gate2-run2/labels.json#@@ -0,0 +1,181 @@
+         3.5  tests/fixtures/rating-regression/167-gate2-run3/labels.json#@@ -0,0 +1,173 @@
+         3.6  tests/fixtures/rating-regression/167-gate2-run4/labels.json#@@ -0,0 +1,175 @@
+         3.7  tests/fixtures/rating-regression/167-gate2-run5/labels.json#@@ -0,0 +1,170 @@
+       test evidence: strongly supported  [tier: static]
+         3.8  tests/benchmark/test_rating_regression.py::test_labels_load_against_the_shared_ground_truth_schema
+
+  4. Use each run's own `current-task.md` together with the base and head revisions the run judged as the case inputs.
+       code evidence: addressed
+         4.1  src/acceptance/benchmark/corpus.py#@@ -0,0 +1,195 @@
+         4.2  tests/benchmark/test_corpus.py#@@ -0,0 +1,123 @@
+         4.3  tests/fixtures/rating-regression/163-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         4.4  tests/fixtures/rating-regression/167-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         4.5  tests/fixtures/rating-regression/167-gate2-run2/case.json#@@ -0,0 +1,7 @@
+         4.6  tests/fixtures/rating-regression/167-gate2-run3/case.json#@@ -0,0 +1,7 @@
+         4.7  tests/fixtures/rating-regression/167-gate2-run4/case.json#@@ -0,0 +1,7 @@
+         4.8  tests/fixtures/rating-regression/167-gate2-run5/case.json#@@ -0,0 +1,7 @@
+       test evidence: strongly supported  [tier: static]
+         4.9  tests/benchmark/test_corpus.py::test_every_case_names_a_corpus_run_that_exists
+         4.10  tests/benchmark/test_corpus.py::test_every_case_names_a_revision_this_repository_still_has
+         4.11  tests/benchmark/test_corpus.py::test_the_case_carries_the_task_file_the_run_was_actually_given
+
+  5. Keep source files out of the case payload; the case references the corpus inputs instead of copying them.
+       code evidence: addressed
+         5.1  src/acceptance/benchmark/corpus.py#@@ -0,0 +1,195 @@
+         5.2  tests/benchmark/test_corpus.py#@@ -0,0 +1,123 @@
+       test evidence: strongly supported  [tier: static]
+         5.3  tests/benchmark/test_corpus.py::test_the_case_carries_the_task_file_the_run_was_actually_given
+
+  6. Analyze the tree at the revision each case judged, not the current working tree.
+       code evidence: addressed
+         6.1  src/acceptance/benchmark/corpus.py#@@ -0,0 +1,195 @@
+         6.2  tests/benchmark/test_corpus.py#@@ -0,0 +1,123 @@
+       test evidence: strongly supported  [tier: static]
+         6.3  tests/benchmark/test_corpus.py::test_every_case_names_a_revision_this_repository_still_has
+         6.4  tests/benchmark/test_corpus.py::test_the_worktree_holds_the_tree_as_it_was_not_as_it_is
+
+  7. Treat a case that names a revision that no longer resolves as a failing case that names the run.
+       code evidence: addressed
+         7.1  src/acceptance/benchmark/corpus.py#@@ -0,0 +1,195 @@
+         7.2  tests/benchmark/test_corpus.py#@@ -0,0 +1,123 @@
+       test evidence: strongly supported  [tier: static]
+         7.3  tests/benchmark/test_corpus.py::test_a_revision_that_no_longer_resolves_fails_by_name
+
+  8. Run cases without live model calls.
+       code evidence: addressed
+         8.1  tests/benchmark/degenerate_judges.py#@@ -0,0 +1,156 @@
+         8.2  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,185 @@
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  9. Keep recorded model transcripts out of the committed test data.
+       code evidence: addressed
+         9.1  tests/benchmark/degenerate_judges.py#@@ -0,0 +1,156 @@
+         9.2  tests/fixtures/rating-stability/README.md#@@ -1,9 +1,29 @@
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  10. Make each case's ground-truth label traceable to the `judgement.md` it was derived from.
+       code evidence: addressed
+         10.1  tests/fixtures/rating-regression/163-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         10.2  tests/fixtures/rating-regression/167-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         10.3  tests/fixtures/rating-regression/167-gate2-run2/case.json#@@ -0,0 +1,7 @@
+         10.4  tests/fixtures/rating-regression/167-gate2-run3/case.json#@@ -0,0 +1,7 @@
+         10.5  tests/fixtures/rating-regression/167-gate2-run4/case.json#@@ -0,0 +1,7 @@
+         10.6  tests/fixtures/rating-regression/167-gate2-run5/case.json#@@ -0,0 +1,7 @@
+         10.7  tests/fixtures/rating-stability/README.md#@@ -1,9 +1,29 @@
+       test evidence: strongly supported  [tier: static]
+         10.8  tests/benchmark/test_corpus.py::test_every_case_is_traceable_to_the_judgement_it_came_from
+
+  11. Limit modifications under `tests/fixtures/rating-stability/` to the README.
+       code evidence: addressed
+         11.1  tests/fixtures/rating-stability/README.md#@@ -1,9 +1,29 @@
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  12. Leave the judgement-production stage untouched.
+       code evidence: addressed
+         (no corresponding change)
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  13. Preserve the instability documented by the corpus.
+       code evidence: addressed
+         13.1  tests/fixtures/rating-regression/167-gate2-run1/labels.json#@@ -0,0 +1,190 @@
+         13.2  tests/fixtures/rating-regression/167-gate2-run2/labels.json#@@ -0,0 +1,181 @@
+         13.3  tests/fixtures/rating-regression/167-gate2-run3/labels.json#@@ -0,0 +1,173 @@
+         13.4  tests/fixtures/rating-regression/167-gate2-run4/labels.json#@@ -0,0 +1,175 @@
+         13.5  tests/fixtures/rating-regression/167-gate2-run5/labels.json#@@ -0,0 +1,170 @@
+         13.6  tests/fixtures/rating-stability/README.md#@@ -1,9 +1,29 @@
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  14. Avoid introducing a required variance threshold or accuracy threshold.
+       code evidence: addressed
+         14.1  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,185 @@
+       test evidence: strongly supported  [tier: static]
+         14.2  tests/benchmark/test_rating_regression.py::test_no_case_passes_trivially
+
+  15. Leave untouched the corpus runs that establish none of the listed ground truth.
+       code evidence: addressed
+         15.1  tests/fixtures/rating-regression/163-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         15.2  tests/fixtures/rating-regression/167-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         15.3  tests/fixtures/rating-regression/167-gate2-run2/case.json#@@ -0,0 +1,7 @@
+         15.4  tests/fixtures/rating-regression/167-gate2-run3/case.json#@@ -0,0 +1,7 @@
+         15.5  tests/fixtures/rating-regression/167-gate2-run4/case.json#@@ -0,0 +1,7 @@
+         15.6  tests/fixtures/rating-regression/167-gate2-run5/case.json#@@ -0,0 +1,7 @@
+       test evidence: strongly supported  [tier: static]
+         15.7  tests/benchmark/test_corpus.py::test_a_revision_that_no_longer_resolves_fails_by_name
+         15.8  tests/benchmark/test_corpus.py::test_every_case_names_a_corpus_run_that_exists
+
+  16. Keep the decompose-stability corpus out of this task.
+       code evidence: addressed
+         (no corresponding change)
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  17. Preserve the rating-stability corpus as the evidence record the assertions are derived from.
+       code evidence: addressed
+         17.1  tests/fixtures/rating-stability/README.md#@@ -1,9 +1,29 @@
+         17.2  tests/fixtures/rating-regression/163-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         17.3  tests/fixtures/rating-regression/167-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         17.4  tests/fixtures/rating-regression/167-gate2-run2/case.json#@@ -0,0 +1,7 @@
+         17.5  tests/fixtures/rating-regression/167-gate2-run3/case.json#@@ -0,0 +1,7 @@
+         17.6  tests/fixtures/rating-regression/167-gate2-run4/case.json#@@ -0,0 +1,7 @@
+         17.7  tests/fixtures/rating-regression/167-gate2-run5/case.json#@@ -0,0 +1,7 @@
+       test evidence: strongly supported  [tier: static]
+         17.8  tests/benchmark/test_corpus.py::test_every_case_is_traceable_to_the_judgement_it_came_from
+         17.9  tests/benchmark/test_corpus.py::test_the_case_carries_the_task_file_the_run_was_actually_given
+         17.10  tests/benchmark/test_rating_regression.py::test_every_real_gap_is_required_to_still_be_reported
+         17.11  tests/benchmark/test_rating_regression.py::test_every_unearned_rating_is_required_to_no_longer_be_issued
+
+  18. Keep the incremental re-run path's carried-forward stored review state out of the case inputs.
+       code evidence: addressed
+         18.1  src/acceptance/benchmark/corpus.py#@@ -0,0 +1,195 @@
+         18.2  tests/benchmark/test_corpus.py#@@ -0,0 +1,123 @@
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  19. Commit the regression cases derived from the corpus as test fixtures.
+       code evidence: addressed
+         19.1  tests/fixtures/rating-regression/163-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         19.2  tests/fixtures/rating-regression/163-gate2-run1/labels.json#@@ -0,0 +1,179 @@
+         19.3  tests/fixtures/rating-regression/167-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         19.4  tests/fixtures/rating-regression/167-gate2-run1/labels.json#@@ -0,0 +1,190 @@
+         19.5  tests/fixtures/rating-regression/167-gate2-run2/case.json#@@ -0,0 +1,7 @@
+         19.6  tests/fixtures/rating-regression/167-gate2-run2/labels.json#@@ -0,0 +1,181 @@
+         19.7  tests/fixtures/rating-regression/167-gate2-run3/case.json#@@ -0,0 +1,7 @@
+         19.8  tests/fixtures/rating-regression/167-gate2-run3/labels.json#@@ -0,0 +1,173 @@
+         19.9  tests/fixtures/rating-regression/167-gate2-run4/case.json#@@ -0,0 +1,7 @@
+         19.10  tests/fixtures/rating-regression/167-gate2-run4/labels.json#@@ -0,0 +1,175 @@
+         19.11  tests/fixtures/rating-regression/167-gate2-run5/case.json#@@ -0,0 +1,7 @@
+         19.12  tests/fixtures/rating-regression/167-gate2-run5/labels.json#@@ -0,0 +1,170 @@
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  20. A judge that always issues `strongly supported` fails the suite.
+       code evidence: addressed
+         20.1  tests/benchmark/degenerate_judges.py#@@ -0,0 +1,156 @@
+         20.2  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,185 @@
+       test evidence: strongly supported  [tier: static]
+         20.3  tests/benchmark/test_rating_regression.py::test_a_judge_that_always_issues_strongly_supported_fails_the_suite
+         20.4  tests/benchmark/test_rating_regression.py::test_the_case_set_can_catch_a_judge_erring_either_way
+         20.5  tests/benchmark/test_rating_regression.py::test_the_two_degenerate_judges_disagree_about_the_ratings
+
+  21. A judge that never issues `strongly supported` fails the suite.
+       code evidence: addressed
+         21.1  tests/benchmark/degenerate_judges.py#@@ -0,0 +1,156 @@
+         21.2  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,185 @@
+       test evidence: strongly supported  [tier: static]
+         21.3  tests/benchmark/test_rating_regression.py::test_a_judge_that_never_issues_strongly_supported_fails_the_suite
+         21.4  tests/benchmark/test_rating_regression.py::test_the_case_set_can_catch_a_judge_erring_either_way
+         21.5  tests/benchmark/test_rating_regression.py::test_the_two_degenerate_judges_disagree_about_the_ratings
+
+  22. Require every gap listed as real to still be reported by the suite.
+       code evidence: addressed
+         22.1  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,185 @@
+         22.2  tests/fixtures/rating-regression/167-gate2-run1/labels.json#@@ -0,0 +1,190 @@
+         22.3  tests/fixtures/rating-regression/167-gate2-run2/labels.json#@@ -0,0 +1,181 @@
+         22.4  tests/fixtures/rating-regression/167-gate2-run3/labels.json#@@ -0,0 +1,173 @@
+         22.5  tests/fixtures/rating-regression/167-gate2-run4/labels.json#@@ -0,0 +1,175 @@
+       test evidence: strongly supported  [tier: static]
+         22.6  tests/benchmark/test_rating_regression.py::test_a_judge_that_always_issues_strongly_supported_fails_the_suite
+         22.7  tests/benchmark/test_rating_regression.py::test_every_real_gap_is_required_to_still_be_reported
+
+  23. Require every rating listed as unearned to no longer be issued.
+       code evidence: addressed
+         23.1  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,185 @@
+         23.2  tests/fixtures/rating-regression/163-gate2-run1/labels.json#@@ -0,0 +1,179 @@
+         23.3  tests/fixtures/rating-regression/167-gate2-run1/labels.json#@@ -0,0 +1,190 @@
+         23.4  tests/fixtures/rating-regression/167-gate2-run2/labels.json#@@ -0,0 +1,181 @@
+       test evidence: strongly supported  [tier: static]
+         23.5  tests/benchmark/test_rating_regression.py::test_a_judge_that_never_issues_strongly_supported_fails_the_suite
+         23.6  tests/benchmark/test_rating_regression.py::test_every_unearned_rating_is_required_to_no_longer_be_issued
+
+  24. Mark run 3's preserved reading as the ground truth for its case.
+       code evidence: addressed
+         24.1  tests/fixtures/rating-regression/167-gate2-run3/case.json#@@ -0,0 +1,7 @@
+         24.2  tests/fixtures/rating-regression/167-gate2-run3/labels.json#@@ -0,0 +1,173 @@
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  25. Mark run 5's preserved reading as the ground truth for its case.
+       code evidence: addressed
+         25.1  tests/fixtures/rating-regression/167-gate2-run5/case.json#@@ -0,0 +1,7 @@
+         25.2  tests/fixtures/rating-regression/167-gate2-run5/labels.json#@@ -0,0 +1,170 @@
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  26. Give control case `163-gate2-run1` assertions of the same kind as the other cases.
+       code evidence: addressed
+         26.1  tests/fixtures/rating-regression/163-gate2-run1/labels.json#@@ -0,0 +1,179 @@
+         26.2  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,185 @@
+       test evidence: strongly supported  [tier: static]
+         26.3  tests/benchmark/test_rating_regression.py::test_no_case_passes_trivially
+
+  27. Update the corpus README so it no longer says the corpus is not read by any test, or else states precisely which parts are still not read.
+       code evidence: addressed
+         27.1  tests/fixtures/rating-stability/README.md#@@ -1,9 +1,29 @@
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  28. Record run 3's corrected reading that all three findings were real and the original reading called them tool defects.
+       code evidence: addressed
+         28.1  tests/fixtures/rating-regression/167-gate2-run3/case.json#@@ -0,0 +1,7 @@
+         28.2  tests/fixtures/rating-regression/167-gate2-run3/labels.json#@@ -0,0 +1,173 @@
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  29. Record run 5's corrected reading that the `partially supported` rating was a wrong verdict and run 4's `strongly supported` is correct.
+       code evidence: addressed
+         29.1  tests/fixtures/rating-regression/167-gate2-run5/case.json#@@ -0,0 +1,7 @@
+         29.2  tests/fixtures/rating-regression/167-gate2-run5/labels.json#@@ -0,0 +1,170 @@
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+Unrequested changes:
+  1. [separable] The session-state note adds a long implementation-status section, metrics table, and design commentary that are not required by any obligation; the only docs obligation is to update the corpus README, not this planning log.
+       session-state.md#@@ -99,12 +99,52 @@ the real diff, with `7de7d71` as a negative control (missed all 4 hunks):
+  2. [in_service] `src/acceptance/benchmark/corpus.py` introduces a new corpus materializer and helpers, but it also adds extra explanatory docstrings and helper structure beyond what the obligations require. The core file is requested, yet these specific internal design details are not separately called for.
+       src/acceptance/benchmark/corpus.py#@@ -0,0 +1,195 @@
+  3. [in_service] `tests/benchmark/degenerate_judges.py` includes a custom enum-walking helper and schema-inspection logic that are implementation choices, not something any obligation explicitly requires. The suite needs stub judges, but not this particular internal mechanism.
+       tests/benchmark/degenerate_judges.py#@@ -0,0 +1,156 @@
+  4. [in_service] The new corpus tests assert extra filesystem details such as the absence of `src/acceptance/benchmark/corpus.py` in the worktree and the nonexistence of `current-task.md` under the case directory. Those checks go beyond the stated requirements to analyze the judged revision and keep source files out of the case payload.
+       tests/benchmark/test_corpus.py#@@ -0,0 +1,123 @@
+  5. [in_service] `tests/benchmark/test_rating_regression.py` hard-codes specific sets of unearned ratings and real gaps, plus extra scoring assertions about degenerate judges. The obligations require regression cases and suite behavior, but not these additional enumerations and metric-specific checks in this form.
+       tests/benchmark/test_rating_regression.py#@@ -0,0 +1,185 @@
+  6. [in_service] The new `case.json` for `163-gate2-run1` adds a detailed summary and judgement prose beyond the required ground-truth label shape and traceability. The case fixture itself is requested, but this extra narrative content is not explicitly required.
+       tests/fixtures/rating-regression/163-gate2-run1/case.json#@@ -0,0 +1,7 @@
+  7. [in_service] The `labels.json` fixture for `163-gate2-run1` contains a large number of obligation entries and candidate tests, including control-case assertions and detailed rationale text. While labels are requested, this specific expanded content is not directly mandated by the obligations as written.
+       tests/fixtures/rating-regression/163-gate2-run1/labels.json#@@ -0,0 +1,179 @@
+  8. [in_service] The `case.json` for `167-gate2-run1` includes extra explanatory summary text and retrospective commentary. The obligations require regression cases and traceability, but not this additional narrative detail.
+       tests/fixtures/rating-regression/167-gate2-run1/case.json#@@ -0,0 +1,7 @@
+  9. [in_service] The `labels.json` for `167-gate2-run1` encodes a very specific decomposition of obligations, gaps, and retrospective commentary. The task requires labels in the existing shape, but not this particular expanded set of narrative annotations and gap IDs.
+       tests/fixtures/rating-regression/167-gate2-run1/labels.json#@@ -0,0 +1,190 @@
+  10. [in_service] The `case.json` for `167-gate2-run2` adds summary prose and retrospective notes beyond the requested case metadata. Those additions are not separately required by any obligation.
+       tests/fixtures/rating-regression/167-gate2-run2/case.json#@@ -0,0 +1,7 @@
+  11. [in_service] The `labels.json` for `167-gate2-run2` contains detailed rationale text and gap records that go beyond merely representing ground-truth labels in the existing shape. The obligations do not specifically require this level of narrative expansion.
+       tests/fixtures/rating-regression/167-gate2-run2/labels.json#@@ -0,0 +1,181 @@
+  12. [in_service] The `case.json` for `167-gate2-run3` adds a long summary and corrected-reading commentary. The obligations require preserving the corrected reading, but not this extra prose in the case metadata.
+       tests/fixtures/rating-regression/167-gate2-run3/case.json#@@ -0,0 +1,7 @@
+  13. [in_service] The `labels.json` for `167-gate2-run3` includes extensive rationale and gap descriptions, including explicit claims about later runs. The obligations require traceability and corrected readings, but not this much additional annotation.
+       tests/fixtures/rating-regression/167-gate2-run3/labels.json#@@ -0,0 +1,173 @@
+  14. [in_service] The `case.json` for `167-gate2-run4` adds summary commentary about false positives and anchors. That narrative is not required by the listed obligations.
+       tests/fixtures/rating-regression/167-gate2-run4/case.json#@@ -0,0 +1,7 @@
+  15. [in_service] The `labels.json` for `167-gate2-run4` contains detailed verdict commentary and a gap record that are more specific than the obligations require. The task asks for regression cases and labels, not this particular explanatory framing.
+       tests/fixtures/rating-regression/167-gate2-run4/labels.json#@@ -0,0 +1,175 @@
+  16. [in_service] The `case.json` for `167-gate2-run5` adds summary prose about the sharpest localization and byte-identical mapped tests. The obligations require the corrected ground truth, but not this extra narrative in the fixture.
+       tests/fixtures/rating-regression/167-gate2-run5/case.json#@@ -0,0 +1,7 @@
+  17. [in_service] The `labels.json` for `167-gate2-run5` includes detailed corrected-verdict commentary and extra candidate-test lists. The obligations require the existing label shape and corrected reading, but not this expanded explanatory content.
+       tests/fixtures/rating-regression/167-gate2-run5/labels.json#@@ -0,0 +1,170 @@
+  18. [in_service] The rating-stability README now adds a detailed matrix of what files are read by tests and what are not, plus a strong statement about when findings reach the suite. The README update is requested, but this specific level of detail and wording is not explicitly required and may go beyond the obligation to state precisely what is still not read.
+       tests/fixtures/rating-stability/README.md#@@ -1,9 +1,29 @@
+
+Open questions:
+  1. [resolved] Which specific fixture files should be created or updated under `tests/fixtures/rating-stability/` to represent the regression cases, and what naming/layout should they use?
+       The diff adds a full `tests/fixtures/rating-regression/` case layout for all six runs, with one `case.json` and one `labels.json` per run, and the README now says the regression cases live under `tests/fixtures/rating-regression/` and are scored by `tests/benchmark/test_rating_regression.py`.
+  2. [resolved] How should the six runs in the corpus map to benchmark cases, especially for runs with multiple preserved readings or multiple run-instances per obligation?
+       The new regression fixtures map each corpus run to exactly one benchmark case directory named after the run (`163-gate2-run1`, `167-gate2-run1` through `run5`), and the labels show how preserved readings are handled: runs 3 and 5 carry rewritten judgements in `case.json`, while the labels explicitly encode the chosen ground-truth reading for each obligation. The suite then iterates those case dirs directly in `test_rating_regression.py`.
+  3. [resolved] How should the suite represent the note that `replace-written-file-with-command` is only partly real, with only its defaulting-to-JSON clause confirmed?
+       The diff resolves the partly-real note by encoding the obligation as `partially_supported` in the run-1 and run-2 labels, with `evidence_rationale` explicitly saying only the defaulting-to-JSON clause was the real finding and that the rest was a compound umbrella artifact. Run 3 then upgrades the same obligation to `strongly_supported` and says that clause is now covered by a specific test.
+  4. [resolved] What exact README wording should replace the current statement about the corpus not being read by any test?
+       The README text is replaced with explicit wording: the corpus is now read by `tests/benchmark/test_rating_regression.py`, the cases live under `tests/fixtures/rating-regression/`, and the old 'Not currently read by any test' statement is removed. That makes the intended replacement wording unambiguous in the diff.
+
+Recommended tests:
+  1. Case evaluation flows through `benchmark/scoring.py::score_case` rather than a separate scoring implementation.
+       inputs:  A corpus case whose scoring outcome is observable through the public regression suite, plus a deliberately degenerate judge that would still produce a score if the test bypassed `benchmark/scoring.py::score_case`. Use one case with mixed ground-truth labels so the score depends on the shared scoring path, not just on a trivial all-pass/all-fail result.
+       detects: Case evaluation uses a separate scoring implementation instead of `benchmark/scoring.py::score_case`, so the regression suite could diverge from the canonical scoring logic.
+       full detail: acceptance recommendation --criterion use-existing-scoring-path
+  2. Test execution completes using only recorded fixture data and repository state, with no outbound model invocation.
+       inputs:  A regression run using the degenerate judges from `tests/benchmark/degenerate_judges.py`, with the client configured so any real outbound model call would be observable as a failure. Use a case set large enough to exercise decomposition, mapping, discrimination, and coverage stages.
+       detects: The test suite silently reaches out to a live model provider instead of staying on recorded fixture data and repository state.
+       full detail: acceptance recommendation --criterion no-live-model-calls
+  3. The repository changes for the task do not add committed model transcripts to the fixtures.
+       inputs:  A repository-state assertion over `tests/fixtures/rating-stability/` and `tests/fixtures/rating-regression/` that inspects committed fixture contents for transcript-like artifacts. Use a fixture directory containing only `case.json`, `labels.json`, and the original corpus prose files.
+       detects: The repository accidentally commits model transcripts into fixture directories, violating the corpus design and leaking prompt content into versioned test data.
+       full detail: acceptance recommendation --criterion no-recorded-transcript-committed
+  4. The corpus files remain unchanged except for README edits.
+       inputs:  A diff-level test that compares the corpus fixture tree before and after the task, with the README edit allowed but all other corpus files expected unchanged. Use the current repository state as the baseline and inspect `tests/fixtures/rating-stability/` recursively.
+       detects: The task accidentally edits corpus data files instead of limiting changes to the README, which would invalidate the evidence record.
+       full detail: acceptance recommendation --criterion preserve-rating-stability-readme-only
+  5. The implementation adds scoreboard coverage without altering how judgements are generated.
+       inputs:  A regression test that exercises the scoreboard/coverage path while comparing the generated judgement outputs against the existing ground truth labels. Use at least one case where the judge’s verdict is intentionally wrong in one direction and one where it is intentionally right, so the test can detect if judgement generation itself changed.
+       detects: The implementation changes how judgements are generated instead of merely adding scoreboard coverage, so the suite would no longer be testing the same production behavior.
+       full detail: acceptance recommendation --criterion do-not-change-judgement-production
+  6. The new tests do not mask or normalize the corpus's documented instability.
+       inputs:  A pair of runs from the corpus that are documented as unstable or contradictory, especially the preserved run 3/run 5 readings where the corpus explicitly notes corrected interpretations. Use those cases to ensure the test still observes the documented disagreement rather than smoothing it away.
+       detects: The new tests normalize or mask the corpus’s documented instability, making the regression suite look stable when the evidence record says it is not.
+       full detail: acceptance recommendation --criterion do-not-reduce-instability
+  7. No fixtures or logic under `tests/fixtures/decompose-stability/` are modified for this task.
+       inputs:  A filesystem assertion over `tests/fixtures/decompose-stability/` that compares its contents before and after the task. Use a recursive directory snapshot so even small fixture edits are detected.
+       detects: The task accidentally modifies decompose-stability fixtures or logic, which would contaminate an unrelated stability corpus.
+       full detail: acceptance recommendation --criterion do-not-touch-decompose-stability
+  8. Cases use the run's input data without inheriting the resumed state from runs 2 and 3.
+       inputs:  Two corpus cases that differ only by run input data, not by any resumed state, especially the incremental runs around 2 and 3. Materialize each case from its own `case.json` and ensure the worktree starts from the named revision only.
+       detects: Cases accidentally inherit resumed state from runs 2 and 3, so the regression suite is no longer evaluating the run’s own inputs.
+       full detail: acceptance recommendation --criterion do-not-restore-incremental-state
+  9. The repository contains committed fixture files for the new regression cases.
+       inputs:  A repository scan that expects the new regression cases to exist as committed files under `tests/fixtures/rating-regression/`, with each case containing `case.json` and `labels.json`. Use all six runs so the test can detect missing or partial fixture commits.
+       detects: The scoreboard cases are not actually committed as fixtures, so the regression suite depends on generated or ephemeral data.
+       full detail: acceptance recommendation --criterion scoreboard-committed-as-fixtures
+  10. The run 3 fixture records which of the two preserved readings is authoritative.
+       inputs:  The `167-gate2-run3` regression fixture, which explicitly records both the original and corrected readings in `case.json`. Use the run 3 labels and the judgement text that says the corrected reading governs.
+       detects: Run 3’s preserved readings are misinterpreted, so the original reading is treated as authoritative instead of the corrected one.
+       full detail: acceptance recommendation --criterion run3-preserved-reading-ground-truth
+  11. The run 5 fixture records which of the two preserved readings is authoritative.
+       inputs:  The `167-gate2-run5` regression fixture, which also has a rewritten judgement and a corrected reading. Use the run 5 case where the corrected reading says the run 4 strong label is correct.
+       detects: Run 5’s preserved reading is not honored, so the fixture uses the original mistaken interpretation instead of the corrected ground truth.
+       full detail: acceptance recommendation --criterion run5-preserved-reading-ground-truth
+  12. The README text reflects that the corpus is now used by tests, or precisely scopes any remaining unread parts.
+       inputs:  The corpus README text plus the new regression fixture tree. The test should compare the README’s claims against the actual presence of `tests/benchmark/test_rating_regression.py` and the committed regression cases.
+       detects: The README is left stale or overstated, so it no longer matches how the corpus is actually used by tests.
+       full detail: acceptance recommendation --criterion readme-updated-about-test-coverage
+  13. The run 3 case preserves the corrected interpretation of the three findings.
+       inputs:  The `167-gate2-run3` case and its labels, focusing on the three findings the corpus says were real gaps. Use the corrected reading from the rewritten judgement, not the original tool-defect reading.
+       detects: The run 3 case loses the corrected interpretation of its three findings, reverting to the original mistaken reading that they were tool defects.
+       full detail: acceptance recommendation --criterion run3-corrected-reading-real-findings
+  14. The run 5 case preserves the corrected interpretation of the verdict.
+       inputs:  The `167-gate2-run5` case and its labels, especially the single partially supported rating that the rewritten judgement says was a wrong verdict. Use the run 4/run 5 one-commit-apart relationship to make the defect observable.
+       detects: Run 5’s corrected verdict is not preserved, so the fixture still encodes the mistaken partial rating instead of the corrected strong one.
+       full detail: acceptance recommendation --criterion run5-corrected-reading-verdict
+
+Evidence limitations:
+  1. Judgments are static inferences unless a higher tier is recorded; the full application was not independently executed.
+
+Next: retrieve a criterion's full recommendation with
+  acceptance recommendation --criterion <id>

--- a/dogfood-logs/190-gate2-run1/revisions.txt
+++ b/dogfood-logs/190-gate2-run1/revisions.txt
@@ -1,0 +1,1 @@
+190-gate2-run1  base=7e337f7  head=4d05f2d

--- a/dogfood-logs/190-gate2-run2/current-task.md
+++ b/dogfood-logs/190-gate2-run2/current-task.md
@@ -1,0 +1,103 @@
+# Task
+The rating-stability corpus at `tests/fixtures/rating-stability/` records what
+`acceptance check` concluded across six dogfood runs, and what each conclusion
+was judged to be worth at the time. Its README says the corpus is not currently
+read by any test. Until those judgements are assertions, every candidate fix to
+the evidence-judgement stage is accepted or rejected by eyeball, and the
+load-bearing criterion in `docs/DR-180-evidence-judgement-instability.md` — that
+`strongly supported` is not issued on evidence that does not earn it — has no
+scoreboard.
+
+Turn the corpus into regression cases the benchmark can score.
+
+Each run's input survives. The corpus holds the exact `current-task.md` the run
+was given, and `revisions.txt` names the commit it judged; those commits are
+still reachable in this repository's history. A case therefore supplies the real
+input rather than a reconstruction of it.
+
+What the corpus does not hold is the model's own responses. `check-output.log` is
+the rendered report, downstream of them, so the runs cannot be replayed and the
+judgement a case is scored under is supplied by the test rather than recorded.
+
+## Ground truth from the corpus
+These three lists are the ground truth this task encodes. Each entry names the
+run whose `judgement.md` establishes it.
+
+**Ratings that were issued as `strongly supported` on evidence that did not earn
+them.** Five obligations, seven run-instances:
+
+| obligation | unearned at | corrected by |
+|---|---|---|
+| `default-to-most-recent-review` | run 1 | run 2 |
+| `no-speculative-writing` | runs 1 and 2 | run 3 |
+| `remove-stale-next-instruction-file` | runs 1 and 2 | run 3 |
+| `spec-no-longer-describes-written-file` | run 1 | run 3 |
+| `retrieve-from-stored-review-state` | run 1 | run 2 |
+
+**Gaps the corpus confirms were real, which a fix must not blunt away.** Seven
+strictly real, plus one the corpus records as only partly real:
+
+| obligation | found at | note |
+|---|---|---|
+| `fixed-command-surface` | run 1 | |
+| `default-to-most-recent-review` | run 2 | |
+| `retrieve-from-stored-review-state` | run 2 | |
+| `remove-stale-next-instruction-file` | run 3 | the silent `--json` deletion |
+| `no-speculative-writing` | run 3 | |
+| `spec-no-longer-describes-written-file` | run 3 | |
+| `preserve-prose-structured-fields` | run 4 | |
+| `replace-written-file-with-command` | run 1 | partly real: only its *defaulting to JSON* clause |
+
+**Judgements that were written wrong and rewritten**, where the corpus preserves
+both readings. The corrected reading is ground truth in each:
+
+| run | corrected reading |
+|---|---|
+| run 3 | all three findings were real; the original reading called them tool defects |
+| run 5 | the `partially supported` rating was a wrong verdict; run 4's `strongly supported` is correct |
+
+## Constraints
+- Cases are scored through the benchmark scoring path the repository already has,
+  `benchmark/scoring.py::score_case`, rather than a second one written for this
+  task.
+- Ground-truth labels use the existing `benchmark/case.py::GroundTruthLabels`
+  shape that `tests/fixtures/archetypes/` already carries.
+- A case's inputs are the corpus's own `current-task.md` and the base and head
+  revisions the run judged. No source file is copied into the case.
+- The tree a case is analysed over is the tree at the revision that case judged,
+  not the current working tree.
+- A revision a case names that no longer resolves fails that case, naming the run,
+  rather than silently skipping it.
+- Cases issue no live model calls, and no recorded model transcript is committed.
+- Each case's ground-truth label is traceable to the `judgement.md` it was
+  derived from.
+
+## Scope exclusions
+- Changing how any judgement is produced. This task builds the scoreboard; the
+  evidence-judgement stage itself is untouched.
+- Reducing the instability the corpus documents.
+- Setting a threshold that a variance figure or an accuracy figure must meet.
+- Rebuilding the corpus runs that establish none of the ground truth above.
+- The decompose-stability corpus at `tests/fixtures/decompose-stability/`, which
+  is a separate task.
+- Modifying any file under `tests/fixtures/rating-stability/` other than its
+  README. The corpus is the evidence record these assertions are derived from,
+  and editing it to suit a test destroys the thing being tested against.
+- Restoring the stored review state that the incremental re-run path (M7.5)
+  carried forward into runs 2 and 3. A case supplies the run's input, not the
+  state the run resumed from.
+
+## Completion expectations
+- Implementation
+- Regression cases derived from the corpus are committed as test fixtures.
+- A judge that always issues `strongly supported` fails the suite.
+- A judge that never issues `strongly supported` fails the suite.
+- Every gap listed above as real is required by the suite to still be reported.
+- Every rating listed above as unearned is required by the suite to no longer be
+  issued.
+- Each case derived from run 3 or run 5 records which of the two preserved
+  readings in its `judgement.md` is ground truth.
+- The control case `163-gate2-run1` carries assertions of the same kind as the
+  other cases rather than passing trivially.
+- The corpus README no longer states that the corpus is not read by any test, or
+  else states precisely which parts of it are still not read.

--- a/dogfood-logs/190-gate2-run2/judgement.md
+++ b/dogfood-logs/190-gate2-run2/judgement.md
@@ -1,0 +1,18 @@
+# Judgement — #190 Gate 2, run 2 (`e8e8755`)
+
+Verdict: **INCOMPLETE**. 9 of 29 below `strongly supported` (7 partial, 2 unsupported),
+down from 14. 20 `strongly supported`.
+
+| obligation | disposition |
+|---|---|
+| `use-existing-scoring-path` | **REAL.** `score_case_set` aggregates via `_all_counts` and never calls `score_case`, so the stated constraint was satisfied only in spirit. Fixed in `c5620ae`. |
+| `no-live-model-calls` | **REAL.** Counting stub invocations is weaker than proving no provider is reached. Now patches `litellm.completion` to raise. Fixed in `c5620ae`. |
+| `no-recorded-transcript-committed` | **REAL.** The check covered two directories; the stated defect was a transcript stored elsewhere. Now walks the whole fixture tree. Fixed in `c5620ae`. |
+| six scope exclusions | **Attributed to #153**, recorded there. `do-not-set-thresholds`, `do-not-rebuild-unlisted-runs`, `do-not-change-judgement-production`, `do-not-touch-decompose-stability`, `preserve-corpus-evidence-record`, `do-not-restore-incremental-state`. |
+
+All six exclusions show #153's documented signature: `code evidence: addressed`,
+test evidence demanded and missing. The code evidence is right in each case.
+Writing tests anyway moved several from `unsupported` to `partially supported`
+but never to strong — **an exclusion cannot be discharged by testing**, which
+makes #153's fix the only exit and means this gate cannot come back clean while
+it is open.

--- a/dogfood-logs/190-gate2-run2/output.log
+++ b/dogfood-logs/190-gate2-run2/output.log
@@ -1,0 +1,394 @@
+Task completion: INCOMPLETE
+
+9 obligation(s) with non-discriminating test evidence (use-existing-scoring-path, no-live-model-calls, no-recorded-transcript-committed, do-not-change-judgement-production, do-not-set-thresholds, do-not-rebuild-unlisted-runs, do-not-touch-decompose-stability, preserve-corpus-evidence-record, do-not-restore-incremental-state).
+
+Obligations:
+
+  1. Convert the rating-stability corpus into regression cases that the benchmark can score.
+       code evidence: addressed
+         1.1  src/acceptance/benchmark/corpus.py#@@ -0,0 +1,195 @@
+         1.2  tests/benchmark/test_corpus.py#@@ -0,0 +1,123 @@
+         1.3  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,412 @@
+         1.4  tests/fixtures/rating-regression/163-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         1.5  tests/fixtures/rating-regression/163-gate2-run1/labels.json#@@ -0,0 +1,179 @@
+         1.6  tests/fixtures/rating-regression/167-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         1.7  tests/fixtures/rating-regression/167-gate2-run1/labels.json#@@ -0,0 +1,190 @@
+         1.8  tests/fixtures/rating-regression/167-gate2-run2/case.json#@@ -0,0 +1,7 @@
+         1.9  tests/fixtures/rating-regression/167-gate2-run2/labels.json#@@ -0,0 +1,181 @@
+         1.10  tests/fixtures/rating-regression/167-gate2-run3/case.json#@@ -0,0 +1,7 @@
+         1.11  tests/fixtures/rating-regression/167-gate2-run3/labels.json#@@ -0,0 +1,173 @@
+         1.12  tests/fixtures/rating-regression/167-gate2-run4/case.json#@@ -0,0 +1,7 @@
+         1.13  tests/fixtures/rating-regression/167-gate2-run4/labels.json#@@ -0,0 +1,175 @@
+         1.14  tests/fixtures/rating-regression/167-gate2-run5/case.json#@@ -0,0 +1,7 @@
+         1.15  tests/fixtures/rating-regression/167-gate2-run5/labels.json#@@ -0,0 +1,170 @@
+       test evidence: strongly supported  [tier: static]
+         1.16  tests/benchmark/test_corpus.py::test_every_case_names_a_corpus_run_that_exists
+
+  2. Score cases through the repository's existing benchmark scoring path.
+       code evidence: addressed
+         2.1  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,412 @@
+       test evidence: partially supported  [tier: static]
+         2.2  tests/benchmark/test_rating_regression.py::test_scoring_goes_through_the_shared_benchmark_path
+         2.3  tests/benchmark/test_rating_regression.py::test_the_two_degenerate_judges_disagree_about_the_ratings
+
+  3. Represent ground-truth labels with the existing `benchmark/case.py::GroundTruthLabels` shape used by `tests/fixtures/archetypes/`.
+       code evidence: addressed
+         3.1  src/acceptance/benchmark/corpus.py#@@ -0,0 +1,195 @@
+         3.2  tests/benchmark/test_corpus.py#@@ -0,0 +1,123 @@
+         3.3  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,412 @@
+         3.4  tests/fixtures/rating-regression/163-gate2-run1/labels.json#@@ -0,0 +1,179 @@
+         3.5  tests/fixtures/rating-regression/167-gate2-run1/labels.json#@@ -0,0 +1,190 @@
+         3.6  tests/fixtures/rating-regression/167-gate2-run2/labels.json#@@ -0,0 +1,181 @@
+         3.7  tests/fixtures/rating-regression/167-gate2-run3/labels.json#@@ -0,0 +1,173 @@
+         3.8  tests/fixtures/rating-regression/167-gate2-run4/labels.json#@@ -0,0 +1,175 @@
+         3.9  tests/fixtures/rating-regression/167-gate2-run5/labels.json#@@ -0,0 +1,170 @@
+       test evidence: strongly supported  [tier: static]
+         3.10  tests/benchmark/test_rating_regression.py::test_labels_load_against_the_shared_ground_truth_schema
+
+  4. Use each run's own `current-task.md` together with the base and head revisions the run judged as the case inputs.
+       code evidence: addressed
+         4.1  src/acceptance/benchmark/corpus.py#@@ -0,0 +1,195 @@
+         4.2  tests/benchmark/test_corpus.py#@@ -0,0 +1,123 @@
+       test evidence: strongly supported  [tier: static]
+         4.3  tests/benchmark/test_corpus.py::test_every_case_names_a_revision_this_repository_still_has
+         4.4  tests/benchmark/test_corpus.py::test_the_case_carries_the_task_file_the_run_was_actually_given
+
+  5. Keep source files out of the case payload; the case references the corpus inputs instead of copying them.
+       code evidence: addressed
+         5.1  src/acceptance/benchmark/corpus.py#@@ -0,0 +1,195 @@
+         5.2  tests/benchmark/test_corpus.py#@@ -0,0 +1,123 @@
+       test evidence: strongly supported  [tier: static]
+         5.3  tests/benchmark/test_corpus.py::test_the_case_carries_the_task_file_the_run_was_actually_given
+
+  6. Analyze the tree at the revision each case judged, not the current working tree.
+       code evidence: addressed
+         6.1  src/acceptance/benchmark/corpus.py#@@ -0,0 +1,195 @@
+         6.2  tests/benchmark/test_corpus.py#@@ -0,0 +1,123 @@
+       test evidence: strongly supported  [tier: static]
+         6.3  tests/benchmark/test_corpus.py::test_the_worktree_holds_the_tree_as_it_was_not_as_it_is
+
+  7. Treat a case that names a revision that no longer resolves as a failing case that names the run.
+       code evidence: addressed
+         7.1  src/acceptance/benchmark/corpus.py#@@ -0,0 +1,195 @@
+         7.2  tests/benchmark/test_corpus.py#@@ -0,0 +1,123 @@
+       test evidence: strongly supported  [tier: static]
+         7.3  tests/benchmark/test_corpus.py::test_a_revision_that_no_longer_resolves_fails_by_name
+
+  8. Run cases without live model calls.
+       code evidence: addressed
+         8.1  tests/benchmark/degenerate_judges.py#@@ -0,0 +1,156 @@
+         8.2  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,412 @@
+       test evidence: partially supported  [tier: static]
+         8.3  tests/benchmark/test_rating_regression.py::test_no_case_issues_a_live_model_call
+
+  9. Keep recorded model transcripts out of the committed test data.
+       code evidence: addressed
+         9.1  tests/fixtures/rating-stability/README.md#@@ -1,9 +1,29 @@
+         9.2  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,412 @@
+       test evidence: partially supported  [tier: static]
+         9.3  tests/benchmark/test_rating_regression.py::test_no_model_transcript_is_committed_into_the_fixtures
+
+  10. Make each case's ground-truth label traceable to the `judgement.md` it was derived from.
+       code evidence: addressed
+         10.1  tests/fixtures/rating-regression/163-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         10.2  tests/fixtures/rating-regression/167-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         10.3  tests/fixtures/rating-regression/167-gate2-run2/case.json#@@ -0,0 +1,7 @@
+         10.4  tests/fixtures/rating-regression/167-gate2-run3/case.json#@@ -0,0 +1,7 @@
+         10.5  tests/fixtures/rating-regression/167-gate2-run4/case.json#@@ -0,0 +1,7 @@
+         10.6  tests/fixtures/rating-regression/167-gate2-run5/case.json#@@ -0,0 +1,7 @@
+         10.7  tests/fixtures/rating-stability/README.md#@@ -1,9 +1,29 @@
+       test evidence: strongly supported  [tier: static]
+         10.8  tests/benchmark/test_corpus.py::test_every_case_is_traceable_to_the_judgement_it_came_from
+
+  11. Limit modifications under `tests/fixtures/rating-stability/` to the README.
+       code evidence: addressed
+         11.1  tests/fixtures/rating-stability/README.md#@@ -1,9 +1,29 @@
+       test evidence: strongly supported  [tier: static]
+         11.2  tests/benchmark/test_rating_regression.py::test_the_corpus_itself_is_untouched_apart_from_its_readme
+
+  12. Leave the judgement-production stage untouched.
+       code evidence: addressed
+         (no corresponding change)
+       test evidence: partially supported  [tier: static]
+         12.1  tests/benchmark/test_rating_regression.py::test_running_the_suite_does_not_alter_the_judgement_stage
+
+  13. Preserve the instability documented by the corpus.
+       code evidence: addressed
+         13.1  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,412 @@
+         13.2  tests/fixtures/rating-regression/167-gate2-run1/labels.json#@@ -0,0 +1,190 @@
+         13.3  tests/fixtures/rating-regression/167-gate2-run2/labels.json#@@ -0,0 +1,181 @@
+         13.4  tests/fixtures/rating-regression/167-gate2-run3/labels.json#@@ -0,0 +1,173 @@
+         13.5  tests/fixtures/rating-regression/167-gate2-run4/labels.json#@@ -0,0 +1,175 @@
+         13.6  tests/fixtures/rating-regression/167-gate2-run5/labels.json#@@ -0,0 +1,170 @@
+       test evidence: strongly supported  [tier: static]
+         13.7  tests/benchmark/test_rating_regression.py::test_the_labels_still_show_the_instability_rather_than_smoothing_it
+
+  14. Avoid introducing a required variance threshold or accuracy threshold.
+       code evidence: addressed
+         14.1  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,412 @@
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  15. Leave untouched the corpus runs that establish none of the listed ground truth.
+       code evidence: addressed
+         15.1  tests/fixtures/rating-regression/163-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         15.2  tests/fixtures/rating-regression/167-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         15.3  tests/fixtures/rating-regression/167-gate2-run2/case.json#@@ -0,0 +1,7 @@
+         15.4  tests/fixtures/rating-regression/167-gate2-run3/case.json#@@ -0,0 +1,7 @@
+         15.5  tests/fixtures/rating-regression/167-gate2-run4/case.json#@@ -0,0 +1,7 @@
+         15.6  tests/fixtures/rating-regression/167-gate2-run5/case.json#@@ -0,0 +1,7 @@
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  16. Keep the decompose-stability corpus out of this task.
+       code evidence: addressed
+         16.1  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,412 @@
+       test evidence: partially supported  [tier: static]
+         16.2  tests/benchmark/test_rating_regression.py::test_the_decompose_stability_corpus_gains_no_regression_artifacts
+
+  17. Preserve the rating-stability corpus as the evidence record the assertions are derived from.
+       code evidence: addressed
+         17.1  tests/fixtures/rating-stability/README.md#@@ -1,9 +1,29 @@
+         17.2  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,412 @@
+       test evidence: partially supported  [tier: static]
+         17.3  tests/benchmark/test_rating_regression.py::test_the_corpus_itself_is_untouched_apart_from_its_readme
+
+  18. Keep the incremental re-run path's carried-forward stored review state out of the case inputs.
+       code evidence: addressed
+         18.1  src/acceptance/benchmark/corpus.py#@@ -0,0 +1,195 @@
+         18.2  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,412 @@
+       test evidence: partially supported  [tier: static]
+         18.3  tests/benchmark/test_rating_regression.py::test_cases_carry_only_their_run_input_not_resumed_state
+
+  19. Commit the regression cases derived from the corpus as test fixtures.
+       code evidence: addressed
+         19.1  tests/fixtures/rating-regression/163-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         19.2  tests/fixtures/rating-regression/163-gate2-run1/labels.json#@@ -0,0 +1,179 @@
+         19.3  tests/fixtures/rating-regression/167-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         19.4  tests/fixtures/rating-regression/167-gate2-run1/labels.json#@@ -0,0 +1,190 @@
+         19.5  tests/fixtures/rating-regression/167-gate2-run2/case.json#@@ -0,0 +1,7 @@
+         19.6  tests/fixtures/rating-regression/167-gate2-run2/labels.json#@@ -0,0 +1,181 @@
+         19.7  tests/fixtures/rating-regression/167-gate2-run3/case.json#@@ -0,0 +1,7 @@
+         19.8  tests/fixtures/rating-regression/167-gate2-run3/labels.json#@@ -0,0 +1,173 @@
+         19.9  tests/fixtures/rating-regression/167-gate2-run4/case.json#@@ -0,0 +1,7 @@
+         19.10  tests/fixtures/rating-regression/167-gate2-run4/labels.json#@@ -0,0 +1,175 @@
+         19.11  tests/fixtures/rating-regression/167-gate2-run5/case.json#@@ -0,0 +1,7 @@
+         19.12  tests/fixtures/rating-regression/167-gate2-run5/labels.json#@@ -0,0 +1,170 @@
+       test evidence: strongly supported  [tier: static]
+         19.13  tests/benchmark/test_rating_regression.py::test_no_model_transcript_is_committed_into_the_fixtures
+         19.14  tests/benchmark/test_rating_regression.py::test_the_scoreboard_is_committed_as_fixtures_for_every_run
+
+  20. A judge that always issues `strongly supported` fails the suite.
+       code evidence: addressed
+         20.1  tests/benchmark/degenerate_judges.py#@@ -0,0 +1,156 @@
+         20.2  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,412 @@
+       test evidence: strongly supported  [tier: static]
+         20.3  tests/benchmark/test_rating_regression.py::test_a_judge_that_always_issues_strongly_supported_fails_the_suite
+         20.4  tests/benchmark/test_rating_regression.py::test_the_case_set_can_catch_a_judge_erring_either_way
+         20.5  tests/benchmark/test_rating_regression.py::test_the_two_degenerate_judges_disagree_about_the_ratings
+
+  21. A judge that never issues `strongly supported` fails the suite.
+       code evidence: addressed
+         21.1  tests/benchmark/degenerate_judges.py#@@ -0,0 +1,156 @@
+         21.2  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,412 @@
+       test evidence: strongly supported  [tier: static]
+         21.3  tests/benchmark/test_rating_regression.py::test_a_judge_that_never_issues_strongly_supported_fails_the_suite
+         21.4  tests/benchmark/test_rating_regression.py::test_the_case_set_can_catch_a_judge_erring_either_way
+         21.5  tests/benchmark/test_rating_regression.py::test_the_two_degenerate_judges_disagree_about_the_ratings
+
+  22. Require every gap listed as real to still be reported by the suite.
+       code evidence: addressed
+         22.1  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,412 @@
+         22.2  tests/fixtures/rating-regression/167-gate2-run1/labels.json#@@ -0,0 +1,190 @@
+         22.3  tests/fixtures/rating-regression/167-gate2-run2/labels.json#@@ -0,0 +1,181 @@
+         22.4  tests/fixtures/rating-regression/167-gate2-run3/labels.json#@@ -0,0 +1,173 @@
+         22.5  tests/fixtures/rating-regression/167-gate2-run4/labels.json#@@ -0,0 +1,175 @@
+       test evidence: strongly supported  [tier: static]
+         22.6  tests/benchmark/test_rating_regression.py::test_every_real_gap_is_required_to_still_be_reported
+         22.7  tests/benchmark/test_rating_regression.py::test_run3_encodes_the_corrected_reading_that_all_three_findings_were_real
+
+  23. Require every rating listed as unearned to no longer be issued.
+       code evidence: addressed
+         23.1  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,412 @@
+         23.2  tests/fixtures/rating-regression/163-gate2-run1/labels.json#@@ -0,0 +1,179 @@
+         23.3  tests/fixtures/rating-regression/167-gate2-run1/labels.json#@@ -0,0 +1,190 @@
+         23.4  tests/fixtures/rating-regression/167-gate2-run2/labels.json#@@ -0,0 +1,181 @@
+       test evidence: strongly supported  [tier: static]
+         23.5  tests/benchmark/test_rating_regression.py::test_every_unearned_rating_is_required_to_no_longer_be_issued
+         23.6  tests/benchmark/test_rating_regression.py::test_run5_encodes_the_corrected_reading_that_run4s_strong_was_right
+
+  24. Mark run 3's preserved reading as the ground truth for its case.
+       code evidence: addressed
+         24.1  tests/fixtures/rating-regression/167-gate2-run3/case.json#@@ -0,0 +1,7 @@
+         24.2  tests/fixtures/rating-regression/167-gate2-run3/labels.json#@@ -0,0 +1,173 @@
+         24.3  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,412 @@
+       test evidence: strongly supported  [tier: static]
+         24.4  tests/benchmark/test_rating_regression.py::test_run3_encodes_the_corrected_reading_that_all_three_findings_were_real
+
+  25. Mark run 5's preserved reading as the ground truth for its case.
+       code evidence: addressed
+         25.1  tests/fixtures/rating-regression/167-gate2-run5/case.json#@@ -0,0 +1,7 @@
+         25.2  tests/fixtures/rating-regression/167-gate2-run5/labels.json#@@ -0,0 +1,170 @@
+         25.3  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,412 @@
+       test evidence: strongly supported  [tier: static]
+         25.4  tests/benchmark/test_rating_regression.py::test_run5_encodes_the_corrected_reading_that_run4s_strong_was_right
+
+  26. Give control case `163-gate2-run1` assertions of the same kind as the other cases.
+       code evidence: addressed
+         26.1  tests/fixtures/rating-regression/163-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         26.2  tests/fixtures/rating-regression/163-gate2-run1/labels.json#@@ -0,0 +1,179 @@
+         26.3  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,412 @@
+       test evidence: strongly supported  [tier: static]
+         26.4  tests/benchmark/test_rating_regression.py::test_no_case_passes_trivially
+
+  27. Update the corpus README so it no longer says the corpus is not read by any test, or else states precisely which parts are still not read.
+       code evidence: addressed
+         27.1  tests/fixtures/rating-stability/README.md#@@ -1,9 +1,29 @@
+       test evidence: strongly supported  [tier: static]
+         27.2  tests/benchmark/test_rating_regression.py::test_the_readme_states_what_is_and_is_not_read
+
+  28. Record run 3's corrected reading that all three findings were real and the original reading called them tool defects.
+       code evidence: addressed
+         28.1  tests/fixtures/rating-regression/167-gate2-run3/case.json#@@ -0,0 +1,7 @@
+         28.2  tests/fixtures/rating-regression/167-gate2-run3/labels.json#@@ -0,0 +1,173 @@
+         28.3  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,412 @@
+       test evidence: strongly supported  [tier: static]
+         28.4  tests/benchmark/test_rating_regression.py::test_run3_encodes_the_corrected_reading_that_all_three_findings_were_real
+
+  29. Record run 5's corrected reading that the `partially supported` rating was a wrong verdict and run 4's `strongly supported` is correct.
+       code evidence: addressed
+         29.1  tests/fixtures/rating-regression/167-gate2-run5/case.json#@@ -0,0 +1,7 @@
+         29.2  tests/fixtures/rating-regression/167-gate2-run5/labels.json#@@ -0,0 +1,170 @@
+         29.3  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,412 @@
+       test evidence: strongly supported  [tier: static]
+         29.4  tests/benchmark/test_rating_regression.py::test_run5_encodes_the_corrected_reading_that_run4s_strong_was_right
+
+Unrequested changes:
+  1. [in_service] Added a new `tests/fixtures/rating-stability/README.md` section describing which corpus files are read by tests and how the regression suite works. The obligations only asked to update the README so it no longer says the corpus is not read by any test, or to state precisely which parts are still not read; this extra explanatory content goes beyond that scope.
+       tests/fixtures/rating-stability/README.md#@@ -1,9 +1,29 @@
+  2. [in_service] `src/acceptance/benchmark/corpus.py` introduces new helper classes and functions for materializing corpus runs, resolving revisions, and loading labels. Those implementation details are necessary to support the requested regression-case conversion, but the specific refactor structure and helper decomposition are not separately required by any obligation.
+       src/acceptance/benchmark/corpus.py#@@ -0,0 +1,195 @@
+  3. [in_service] `tests/benchmark/degenerate_judges.py` adds schema-walking logic and stub-client behavior for multiple response shapes. The obligations require stub judges and scoring through the existing path, but not this particular generalized enum extraction or the extra commentary around it.
+       tests/benchmark/degenerate_judges.py#@@ -0,0 +1,156 @@
+  4. [in_service] `tests/benchmark/test_corpus.py` includes several assertions about worktree contents, corpus file presence, and decompose-stability exclusions that are not called for by the listed obligations. The task asked for corpus-to-regression conversion and traceability, not these additional behavioral checks.
+       tests/benchmark/test_corpus.py#@@ -0,0 +1,123 @@
+  5. [in_service] `tests/benchmark/test_rating_regression.py` adds many assertions beyond the required suite properties, including checks for stage immutability, decompose-stability exclusions, and detailed corpus bookkeeping. Those are not explicitly requested by the obligations and therefore count as unrequested scope.
+       tests/benchmark/test_rating_regression.py#@@ -0,0 +1,412 @@
+  6. [in_service] The new regression fixture `tests/fixtures/rating-regression/163-gate2-run1/case.json` and its labels encode a control case and detailed judgment text. The obligations require a control case with nontrivial assertions and regression fixtures, but not this extra narrative content or the specific label wording.
+       tests/fixtures/rating-regression/163-gate2-run1/case.json#@@ -0,0 +1,7 @@
+       tests/fixtures/rating-regression/163-gate2-run1/labels.json#@@ -0,0 +1,179 @@
+  7. [in_service] The new regression fixture `tests/fixtures/rating-regression/167-gate2-run1/case.json` and labels include extensive explanatory prose and extra gap annotations beyond simply representing the ground truth labels in the existing shape. That added narrative is not required by the obligations.
+       tests/fixtures/rating-regression/167-gate2-run1/case.json#@@ -0,0 +1,7 @@
+       tests/fixtures/rating-regression/167-gate2-run1/labels.json#@@ -0,0 +1,190 @@
+  8. [in_service] The new regression fixture `tests/fixtures/rating-regression/167-gate2-run2/case.json` and labels contain detailed retrospective commentary and gap descriptions that exceed the requested case/label conversion. The obligations ask for traceable labels and preserved readings, not this amount of extra annotation.
+       tests/fixtures/rating-regression/167-gate2-run2/case.json#@@ -0,0 +1,7 @@
+       tests/fixtures/rating-regression/167-gate2-run2/labels.json#@@ -0,0 +1,181 @@
+  9. [in_service] The new regression fixture `tests/fixtures/rating-regression/167-gate2-run3/case.json` and labels add extensive explanatory text about the rewritten judgement and the silent `--json` deletion. While some of that is related to the requested preserved/corrected reading, the extra narrative and gap commentary are beyond the obligations' minimum requirements.
+       tests/fixtures/rating-regression/167-gate2-run3/case.json#@@ -0,0 +1,7 @@
+       tests/fixtures/rating-regression/167-gate2-run3/labels.json#@@ -0,0 +1,173 @@
+  10. [in_service] The new regression fixture `tests/fixtures/rating-regression/167-gate2-run4/case.json` and labels include detailed justification about false positives and the positive anchor for a STRONG label. The obligations require preserving the corrected reading, but not this additional explanatory framing.
+       tests/fixtures/rating-regression/167-gate2-run4/case.json#@@ -0,0 +1,7 @@
+       tests/fixtures/rating-regression/167-gate2-run4/labels.json#@@ -0,0 +1,175 @@
+  11. [in_service] The new regression fixture `tests/fixtures/rating-regression/167-gate2-run5/case.json` and labels include extensive commentary about the corrected reading and the flipped boolean explanation. The obligations require recording the corrected verdict, but not this extra narrative detail.
+       tests/fixtures/rating-regression/167-gate2-run5/case.json#@@ -0,0 +1,7 @@
+       tests/fixtures/rating-regression/167-gate2-run5/labels.json#@@ -0,0 +1,170 @@
+
+Changes since 4d05f2de:
+  closed:
+    - Limit modifications under `tests/fixtures/rating-stability/` to the README.
+        code evidence: addressed -> addressed
+        test evidence: unsupported -> strongly supported
+    - Preserve the instability documented by the corpus.
+        code evidence: addressed -> addressed
+        test evidence: unsupported -> strongly supported
+    - Commit the regression cases derived from the corpus as test fixtures.
+        code evidence: addressed -> addressed
+        test evidence: unsupported -> strongly supported
+    - Mark run 3's preserved reading as the ground truth for its case.
+        code evidence: addressed -> addressed
+        test evidence: unsupported -> strongly supported
+    - Mark run 5's preserved reading as the ground truth for its case.
+        code evidence: addressed -> addressed
+        test evidence: unsupported -> strongly supported
+    - Update the corpus README so it no longer says the corpus is not read by any test, or else states precisely which parts are still not read.
+        code evidence: addressed -> addressed
+        test evidence: unsupported -> strongly supported
+    - Record run 3's corrected reading that all three findings were real and the original reading called them tool defects.
+        code evidence: addressed -> addressed
+        test evidence: unsupported -> strongly supported
+    - Record run 5's corrected reading that the `partially supported` rating was a wrong verdict and run 4's `strongly supported` is correct.
+        code evidence: addressed -> addressed
+        test evidence: unsupported -> strongly supported
+  moved:
+    - Score cases through the repository's existing benchmark scoring path.
+        test evidence: unsupported -> partially supported
+    - Run cases without live model calls.
+        test evidence: unsupported -> partially supported
+    - Keep recorded model transcripts out of the committed test data.
+        test evidence: unsupported -> partially supported
+    - Leave the judgement-production stage untouched.
+        test evidence: unsupported -> partially supported
+    - Avoid introducing a required variance threshold or accuracy threshold.
+        test evidence: strongly supported -> unsupported
+    - Leave untouched the corpus runs that establish none of the listed ground truth.
+        test evidence: strongly supported -> unsupported
+    - Keep the decompose-stability corpus out of this task.
+        test evidence: unsupported -> partially supported
+    - Preserve the rating-stability corpus as the evidence record the assertions are derived from.
+        test evidence: strongly supported -> partially supported
+    - Keep the incremental re-run path's carried-forward stored review state out of the case inputs.
+        test evidence: unsupported -> partially supported
+
+Open questions:
+  1. [resolved] Which specific fixture files should be created or updated under `tests/fixtures/rating-stability/` to represent the regression cases, and what naming/layout should they use?
+       The diff adds `tests/fixtures/rating-regression/` cases for all six runs, each with `case.json` and `labels.json`, and updates the corpus README to describe that `current-task.md`, `revisions.txt`, `judgement.md`, and `check-output.log` are the relevant source files. The layout is explicit in the added fixture directories and README table.
+  2. [resolved] How should the six runs in the corpus map to benchmark cases, especially for runs with multiple preserved readings or multiple run-instances per obligation?
+       The new regression fixtures map each corpus run to a single benchmark case directory named after the run (`163-gate2-run1`, `167-gate2-run1` ... `run5`). The labels show how multiple preserved readings are handled: runs 3 and 5 have rewritten judgements in `case.json`, and the README says which preserved reading is ground truth. The tests also treat the six runs as the six cases in `CASE_DIRS`, so the mapping is one run per case, not multiple cases per run.
+  3. [resolved] How should the suite represent the note that `replace-written-file-with-command` is only partly real, with only its defaulting-to-JSON clause confirmed?
+       The diff makes the treatment explicit in the regression labels: `replace-written-file-with-command` is marked `unsupported` in run 1 with an evidence rationale saying only the defaulting-to-JSON clause is the real finding, and later runs label the same obligation `strongly_supported` once that clause is covered. The README and tests also refer to the corpus as transcribed human judgements, but the decisive answer is in the run 1 label.
+  4. [resolved] What exact README wording should replace the current statement about the corpus not being read by any test?
+       The README text is changed from 'Not currently read by any test' to a new section headed 'What is read by a test, and what is not (#190)' that states the corpus now backs regression cases and that a finding does not reach the suite until added to a `labels.json`. That is the exact replacement wording chosen by the diff.
+
+Recommended tests:
+  1. Case evaluation flows through `benchmark/scoring.py::score_case` rather than a separate scoring implementation.
+       inputs:  A corpus case whose scoring result would be identical under both the canonical scorer and a plausible alternate scorer for the currently tested cases, plus a monkeypatch/spying setup that can distinguish which scoring function is invoked. Use at least one case from the regression corpus and assert the canonical `acceptance.benchmark.scoring.score_case` path is called during case scoring.
+       detects: Implementation bypasses `benchmark/scoring.py::score_case` and uses a separate scoring routine, but still produces the same report fields for the tested cases.
+       full detail: acceptance recommendation --criterion use-existing-scoring-path
+  2. Test execution completes using only recorded fixture data and repository state, with no outbound model invocation.
+       inputs:  A scored corpus case executed with a stubbed client that records every completion request, plus a guard that would fail on any outbound provider access. Use a case that exercises all pipeline stages so a live call would be observable.
+       detects: Implementation makes an outbound model call during case execution instead of using recorded fixture data.
+       full detail: acceptance recommendation --criterion no-live-model-calls
+  3. The repository changes for the task do not add committed model transcripts to the fixtures.
+       inputs:  A repository-tree inspection over both the corpus fixture directories and the broader fixture subtree, including any newly added regression-case directories. The test should enumerate tracked files and untracked files under `tests/fixtures/` to catch transcripts stored outside the inspected corpus directories.
+       detects: Implementation stores transcripts elsewhere in the repository but not in the inspected fixture directories.
+       full detail: acceptance recommendation --criterion no-recorded-transcript-committed
+  4. The implementation adds scoreboard coverage without altering how judgements are generated.
+       inputs:  A before/after digest of the judgement-production source tree around a representative scoring run, plus a case whose judgement is known to be stable under the current corpus. The test should compare the judgement-production code path, not just the output tree digest.
+       detects: Implementation leaves judgement production logically altered but on the inspected paths the tree digest stays identical.
+       full detail: acceptance recommendation --criterion do-not-change-judgement-production
+  5. The suite does not depend on a minimum variance or accuracy cutoff.
+       inputs:  A suite run with deliberately varied but valid corpus cases that would expose any hidden minimum cutoff if one existed. Use cases spanning both strong and non-strong labels so the test can prove the suite does not require a minimum variance/accuracy threshold.
+       detects: The suite depends on a minimum variance or accuracy cutoff.
+       full detail: acceptance recommendation --criterion do-not-set-thresholds
+  6. Only the runs named in the task are turned into scored regression cases.
+       inputs:  A corpus selection containing both listed and unlisted run directories, with the task’s named runs present alongside at least one extra run directory that should not be converted into a regression case.
+       detects: Additional corpus runs beyond those named in the task are turned into scored regression cases.
+       full detail: acceptance recommendation --criterion do-not-rebuild-unlisted-runs
+  7. No fixtures or logic under `tests/fixtures/decompose-stability/` are modified for this task.
+       inputs:  A filesystem snapshot that includes `tests/fixtures/decompose-stability/` and the new rating-regression corpus. The test should compare the decompose-stability subtree before and after the task’s corpus/scoring operations.
+       detects: Implementation changes logic that indirectly references decompose-stability without adding fixture files there.
+       full detail: acceptance recommendation --criterion do-not-touch-decompose-stability
+  8. The corpus remains the source of truth for the new assertions rather than being rewritten to fit them.
+       inputs:  A corpus case whose labels are compared against the source evidence record, plus a mutation attempt that would rewrite the corpus-derived labels or case metadata while leaving directory names unchanged.
+       detects: Implementation changes the corpus evidence in a way that still leaves the inspected files and run directory names unchanged.
+       full detail: acceptance recommendation --criterion preserve-corpus-evidence-record
+  9. Cases use the run's input data without inheriting the resumed state from runs 2 and 3.
+       inputs:  A case built from a run that had resumed state in the original corpus, plus a repository snapshot containing any persisted incremental-state artifacts. The test should ensure the case uses only the run input data and not resumed state from runs 2 and 3.
+       detects: Implementation preserves some resumed state in a different field not checked by the test.
+       full detail: acceptance recommendation --criterion do-not-restore-incremental-state
+
+Evidence limitations:
+  1. Judgments are static inferences unless a higher tier is recorded; the full application was not independently executed.
+
+Next: retrieve a criterion's full recommendation with
+  acceptance recommendation --criterion <id>

--- a/dogfood-logs/190-gate2-run2/revisions.txt
+++ b/dogfood-logs/190-gate2-run2/revisions.txt
@@ -1,0 +1,1 @@
+190-gate2-run2  base=7e337f7  head=e8e8755

--- a/dogfood-logs/190-gate2-run3/current-task.md
+++ b/dogfood-logs/190-gate2-run3/current-task.md
@@ -1,0 +1,103 @@
+# Task
+The rating-stability corpus at `tests/fixtures/rating-stability/` records what
+`acceptance check` concluded across six dogfood runs, and what each conclusion
+was judged to be worth at the time. Its README says the corpus is not currently
+read by any test. Until those judgements are assertions, every candidate fix to
+the evidence-judgement stage is accepted or rejected by eyeball, and the
+load-bearing criterion in `docs/DR-180-evidence-judgement-instability.md` — that
+`strongly supported` is not issued on evidence that does not earn it — has no
+scoreboard.
+
+Turn the corpus into regression cases the benchmark can score.
+
+Each run's input survives. The corpus holds the exact `current-task.md` the run
+was given, and `revisions.txt` names the commit it judged; those commits are
+still reachable in this repository's history. A case therefore supplies the real
+input rather than a reconstruction of it.
+
+What the corpus does not hold is the model's own responses. `check-output.log` is
+the rendered report, downstream of them, so the runs cannot be replayed and the
+judgement a case is scored under is supplied by the test rather than recorded.
+
+## Ground truth from the corpus
+These three lists are the ground truth this task encodes. Each entry names the
+run whose `judgement.md` establishes it.
+
+**Ratings that were issued as `strongly supported` on evidence that did not earn
+them.** Five obligations, seven run-instances:
+
+| obligation | unearned at | corrected by |
+|---|---|---|
+| `default-to-most-recent-review` | run 1 | run 2 |
+| `no-speculative-writing` | runs 1 and 2 | run 3 |
+| `remove-stale-next-instruction-file` | runs 1 and 2 | run 3 |
+| `spec-no-longer-describes-written-file` | run 1 | run 3 |
+| `retrieve-from-stored-review-state` | run 1 | run 2 |
+
+**Gaps the corpus confirms were real, which a fix must not blunt away.** Seven
+strictly real, plus one the corpus records as only partly real:
+
+| obligation | found at | note |
+|---|---|---|
+| `fixed-command-surface` | run 1 | |
+| `default-to-most-recent-review` | run 2 | |
+| `retrieve-from-stored-review-state` | run 2 | |
+| `remove-stale-next-instruction-file` | run 3 | the silent `--json` deletion |
+| `no-speculative-writing` | run 3 | |
+| `spec-no-longer-describes-written-file` | run 3 | |
+| `preserve-prose-structured-fields` | run 4 | |
+| `replace-written-file-with-command` | run 1 | partly real: only its *defaulting to JSON* clause |
+
+**Judgements that were written wrong and rewritten**, where the corpus preserves
+both readings. The corrected reading is ground truth in each:
+
+| run | corrected reading |
+|---|---|
+| run 3 | all three findings were real; the original reading called them tool defects |
+| run 5 | the `partially supported` rating was a wrong verdict; run 4's `strongly supported` is correct |
+
+## Constraints
+- Cases are scored through the benchmark scoring path the repository already has,
+  `benchmark/scoring.py::score_case`, rather than a second one written for this
+  task.
+- Ground-truth labels use the existing `benchmark/case.py::GroundTruthLabels`
+  shape that `tests/fixtures/archetypes/` already carries.
+- A case's inputs are the corpus's own `current-task.md` and the base and head
+  revisions the run judged. No source file is copied into the case.
+- The tree a case is analysed over is the tree at the revision that case judged,
+  not the current working tree.
+- A revision a case names that no longer resolves fails that case, naming the run,
+  rather than silently skipping it.
+- Cases issue no live model calls, and no recorded model transcript is committed.
+- Each case's ground-truth label is traceable to the `judgement.md` it was
+  derived from.
+
+## Scope exclusions
+- Changing how any judgement is produced. This task builds the scoreboard; the
+  evidence-judgement stage itself is untouched.
+- Reducing the instability the corpus documents.
+- Setting a threshold that a variance figure or an accuracy figure must meet.
+- Rebuilding the corpus runs that establish none of the ground truth above.
+- The decompose-stability corpus at `tests/fixtures/decompose-stability/`, which
+  is a separate task.
+- Modifying any file under `tests/fixtures/rating-stability/` other than its
+  README. The corpus is the evidence record these assertions are derived from,
+  and editing it to suit a test destroys the thing being tested against.
+- Restoring the stored review state that the incremental re-run path (M7.5)
+  carried forward into runs 2 and 3. A case supplies the run's input, not the
+  state the run resumed from.
+
+## Completion expectations
+- Implementation
+- Regression cases derived from the corpus are committed as test fixtures.
+- A judge that always issues `strongly supported` fails the suite.
+- A judge that never issues `strongly supported` fails the suite.
+- Every gap listed above as real is required by the suite to still be reported.
+- Every rating listed above as unearned is required by the suite to no longer be
+  issued.
+- Each case derived from run 3 or run 5 records which of the two preserved
+  readings in its `judgement.md` is ground truth.
+- The control case `163-gate2-run1` carries assertions of the same kind as the
+  other cases rather than passing trivially.
+- The corpus README no longer states that the corpus is not read by any test, or
+  else states precisely which parts of it are still not read.

--- a/dogfood-logs/190-gate2-run3/judgement.md
+++ b/dogfood-logs/190-gate2-run3/judgement.md
@@ -1,0 +1,37 @@
+# Judgement — #190 Gate 2, run 3 (`c5620ae`)
+
+Verdict: **NEEDS-CLARIFICATION**. **3** obligations `strongly supported`, down
+from 20 — on a diff over run 2 that only **added tests**.
+
+## The isolation
+
+| | run 2 | run 3 |
+|---|---|---|
+| `strongly supported` | 20 | **3** |
+| obligations with ≥1 mapped test | 27/29 | 25/29 |
+| total test-evidence links | 36 | **40** |
+| defects enumerated | 55 | 51 |
+| avg defects per obligation | **2.04** | **2.04** |
+| `would_be_caught` | 48/55 (87%) | **29/51 (57%)** |
+
+Mapping did not collapse — there were *more* evidence links in the worse round.
+Defect enumeration did not move: 2.04 both rounds, which was my hypothesis and it
+was wrong. The entire swing is M5.2's per-defect verdict with enumeration held
+constant — a cleaner isolation than the corpus's own run-5 case, where
+enumeration moved too. Recorded against **#191**.
+
+## What this does NOT establish
+
+**Not that round 3 is wrong.** The corpus's central finding is that in 7 of 8
+unstable obligations the LOW rating was correct, and DR-180 names the inference to
+avoid: *the diff was additive, added tests cannot weaken evidence, therefore the
+fall is external.* Both premises true, conclusion false. These lower ratings may
+be right and rounds 1–2 may have been issuing unearned STRONGs on my own tests.
+
+The figures establish **where** the variance lives, not which end of it is correct.
+
+## Open question 1 regressed
+
+`which-corpus-files-to-add` went `[resolved]` in run 2 → `[open]` in run 3, with
+the diff unchanged in that respect. Same #178 question, now oscillating on the
+resolution axis as well as the wording axis. Recorded against #178.

--- a/dogfood-logs/190-gate2-run3/output.log
+++ b/dogfood-logs/190-gate2-run3/output.log
@@ -1,0 +1,475 @@
+Task completion: NEEDS-CLARIFICATION
+
+1 open question(s) remain unresolved by the diff; the delivered behavior cannot be judged until they are answered.
+
+Obligations:
+
+  1. Convert the rating-stability corpus into regression cases that the benchmark can score.
+       code evidence: addressed
+         1.1  src/acceptance/benchmark/corpus.py#@@ -0,0 +1,195 @@
+         1.2  tests/benchmark/test_corpus.py#@@ -0,0 +1,123 @@
+         1.3  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,492 @@
+         1.4  tests/fixtures/rating-regression/163-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         1.5  tests/fixtures/rating-regression/163-gate2-run1/labels.json#@@ -0,0 +1,179 @@
+         1.6  tests/fixtures/rating-regression/167-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         1.7  tests/fixtures/rating-regression/167-gate2-run1/labels.json#@@ -0,0 +1,190 @@
+         1.8  tests/fixtures/rating-regression/167-gate2-run2/case.json#@@ -0,0 +1,7 @@
+         1.9  tests/fixtures/rating-regression/167-gate2-run2/labels.json#@@ -0,0 +1,181 @@
+         1.10  tests/fixtures/rating-regression/167-gate2-run3/case.json#@@ -0,0 +1,7 @@
+         1.11  tests/fixtures/rating-regression/167-gate2-run3/labels.json#@@ -0,0 +1,173 @@
+         1.12  tests/fixtures/rating-regression/167-gate2-run4/case.json#@@ -0,0 +1,7 @@
+         1.13  tests/fixtures/rating-regression/167-gate2-run4/labels.json#@@ -0,0 +1,175 @@
+         1.14  tests/fixtures/rating-regression/167-gate2-run5/case.json#@@ -0,0 +1,7 @@
+         1.15  tests/fixtures/rating-regression/167-gate2-run5/labels.json#@@ -0,0 +1,170 @@
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  2. Score cases through the repository's existing benchmark scoring path.
+       code evidence: addressed
+         2.1  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,492 @@
+       test evidence: partially supported  [tier: static]
+         2.2  tests/benchmark/test_rating_regression.py::test_each_case_is_scored_through_score_case_itself
+         2.3  tests/benchmark/test_rating_regression.py::test_scoring_goes_through_the_shared_benchmark_path
+
+  3. Represent ground-truth labels with the existing `benchmark/case.py::GroundTruthLabels` shape used by `tests/fixtures/archetypes/`.
+       code evidence: addressed
+         3.1  src/acceptance/benchmark/corpus.py#@@ -0,0 +1,195 @@
+         3.2  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,492 @@
+         3.3  tests/fixtures/rating-regression/163-gate2-run1/labels.json#@@ -0,0 +1,179 @@
+         3.4  tests/fixtures/rating-regression/167-gate2-run1/labels.json#@@ -0,0 +1,190 @@
+         3.5  tests/fixtures/rating-regression/167-gate2-run2/labels.json#@@ -0,0 +1,181 @@
+         3.6  tests/fixtures/rating-regression/167-gate2-run3/labels.json#@@ -0,0 +1,173 @@
+         3.7  tests/fixtures/rating-regression/167-gate2-run4/labels.json#@@ -0,0 +1,175 @@
+         3.8  tests/fixtures/rating-regression/167-gate2-run5/labels.json#@@ -0,0 +1,170 @@
+       test evidence: partially supported  [tier: static]
+         3.9  tests/benchmark/test_rating_regression.py::test_labels_load_against_the_shared_ground_truth_schema
+
+  4. Use each run's own `current-task.md` together with the base and head revisions the run judged as the case inputs.
+       code evidence: addressed
+         4.1  src/acceptance/benchmark/corpus.py#@@ -0,0 +1,195 @@
+         4.2  tests/benchmark/test_corpus.py#@@ -0,0 +1,123 @@
+         4.3  tests/fixtures/rating-regression/163-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         4.4  tests/fixtures/rating-regression/167-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         4.5  tests/fixtures/rating-regression/167-gate2-run2/case.json#@@ -0,0 +1,7 @@
+         4.6  tests/fixtures/rating-regression/167-gate2-run3/case.json#@@ -0,0 +1,7 @@
+         4.7  tests/fixtures/rating-regression/167-gate2-run4/case.json#@@ -0,0 +1,7 @@
+         4.8  tests/fixtures/rating-regression/167-gate2-run5/case.json#@@ -0,0 +1,7 @@
+       test evidence: strongly supported  [tier: static]
+         4.9  tests/benchmark/test_corpus.py::test_every_case_names_a_corpus_run_that_exists
+         4.10  tests/benchmark/test_corpus.py::test_every_case_names_a_revision_this_repository_still_has
+         4.11  tests/benchmark/test_corpus.py::test_the_case_carries_the_task_file_the_run_was_actually_given
+         4.12  tests/benchmark/test_rating_regression.py::test_cases_carry_only_their_run_input_not_resumed_state
+
+  5. Keep source files out of the case payload; the case references the corpus inputs instead of copying them.
+       code evidence: addressed
+         5.1  src/acceptance/benchmark/corpus.py#@@ -0,0 +1,195 @@
+         5.2  tests/benchmark/test_corpus.py#@@ -0,0 +1,123 @@
+       test evidence: partially supported  [tier: static]
+         5.3  tests/benchmark/test_corpus.py::test_the_case_carries_the_task_file_the_run_was_actually_given
+
+  6. Analyze the tree at the revision each case judged, not the current working tree.
+       code evidence: addressed
+         6.1  src/acceptance/benchmark/corpus.py#@@ -0,0 +1,195 @@
+         6.2  tests/benchmark/test_corpus.py#@@ -0,0 +1,123 @@
+       test evidence: strongly supported  [tier: static]
+         6.3  tests/benchmark/test_corpus.py::test_every_case_names_a_revision_this_repository_still_has
+         6.4  tests/benchmark/test_corpus.py::test_the_worktree_holds_the_tree_as_it_was_not_as_it_is
+
+  7. Treat a case that names a revision that no longer resolves as a failing case that names the run.
+       code evidence: addressed
+         7.1  src/acceptance/benchmark/corpus.py#@@ -0,0 +1,195 @@
+         7.2  tests/benchmark/test_corpus.py#@@ -0,0 +1,123 @@
+       test evidence: strongly supported  [tier: static]
+         7.3  tests/benchmark/test_corpus.py::test_a_revision_that_no_longer_resolves_fails_by_name
+
+  8. Run cases without live model calls.
+       code evidence: addressed
+         8.1  tests/benchmark/degenerate_judges.py#@@ -0,0 +1,156 @@
+         8.2  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,492 @@
+       test evidence: partially supported  [tier: static]
+         8.3  tests/benchmark/test_rating_regression.py::test_no_case_issues_a_live_model_call
+         8.4  tests/benchmark/test_rating_regression.py::test_no_provider_is_ever_contacted
+
+  9. Keep recorded model transcripts out of the committed test data.
+       code evidence: addressed
+         9.1  tests/fixtures/rating-stability/README.md#@@ -1,9 +1,29 @@
+         9.2  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,492 @@
+       test evidence: partially supported  [tier: static]
+         9.3  tests/benchmark/test_rating_regression.py::test_no_model_transcript_is_committed_into_the_fixtures
+         9.4  tests/benchmark/test_rating_regression.py::test_no_transcript_lives_anywhere_under_the_fixture_tree
+
+  10. Make each case's ground-truth label traceable to the `judgement.md` it was derived from.
+       code evidence: addressed
+         10.1  tests/fixtures/rating-regression/163-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         10.2  tests/fixtures/rating-regression/167-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         10.3  tests/fixtures/rating-regression/167-gate2-run2/case.json#@@ -0,0 +1,7 @@
+         10.4  tests/fixtures/rating-regression/167-gate2-run3/case.json#@@ -0,0 +1,7 @@
+         10.5  tests/fixtures/rating-regression/167-gate2-run4/case.json#@@ -0,0 +1,7 @@
+         10.6  tests/fixtures/rating-regression/167-gate2-run5/case.json#@@ -0,0 +1,7 @@
+         10.7  tests/fixtures/rating-stability/README.md#@@ -1,9 +1,29 @@
+       test evidence: partially supported  [tier: static]
+         10.8  tests/benchmark/test_corpus.py::test_every_case_is_traceable_to_the_judgement_it_came_from
+
+  11. Limit modifications under `tests/fixtures/rating-stability/` to the README.
+       code evidence: addressed
+         11.1  tests/fixtures/rating-stability/README.md#@@ -1,9 +1,29 @@
+       test evidence: partially supported  [tier: static]
+         11.2  tests/benchmark/test_rating_regression.py::test_the_corpus_itself_is_untouched_apart_from_its_readme
+
+  12. Leave the judgement-production stage untouched.
+       code evidence: addressed
+         (no corresponding change)
+       test evidence: partially supported  [tier: static]
+         12.1  tests/benchmark/test_rating_regression.py::test_running_the_suite_does_not_alter_the_judgement_stage
+
+  13. Preserve the instability documented by the corpus.
+       code evidence: addressed
+         13.1  tests/fixtures/rating-regression/167-gate2-run1/labels.json#@@ -0,0 +1,190 @@
+         13.2  tests/fixtures/rating-regression/167-gate2-run2/labels.json#@@ -0,0 +1,181 @@
+         13.3  tests/fixtures/rating-regression/167-gate2-run3/labels.json#@@ -0,0 +1,173 @@
+         13.4  tests/fixtures/rating-regression/167-gate2-run4/labels.json#@@ -0,0 +1,175 @@
+         13.5  tests/fixtures/rating-regression/167-gate2-run5/labels.json#@@ -0,0 +1,170 @@
+         13.6  tests/fixtures/rating-stability/README.md#@@ -1,9 +1,29 @@
+       test evidence: partially supported  [tier: static]
+         13.7  tests/benchmark/test_rating_regression.py::test_the_labels_still_show_the_instability_rather_than_smoothing_it
+
+  14. Avoid introducing a required variance threshold or accuracy threshold.
+       code evidence: addressed
+         14.1  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,492 @@
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  15. Leave untouched the corpus runs that establish none of the listed ground truth.
+       code evidence: addressed
+         15.1  tests/fixtures/rating-regression/163-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         15.2  tests/fixtures/rating-regression/167-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         15.3  tests/fixtures/rating-regression/167-gate2-run2/case.json#@@ -0,0 +1,7 @@
+         15.4  tests/fixtures/rating-regression/167-gate2-run3/case.json#@@ -0,0 +1,7 @@
+         15.5  tests/fixtures/rating-regression/167-gate2-run4/case.json#@@ -0,0 +1,7 @@
+         15.6  tests/fixtures/rating-regression/167-gate2-run5/case.json#@@ -0,0 +1,7 @@
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  16. Keep the decompose-stability corpus out of this task.
+       code evidence: addressed
+         (no corresponding change)
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  17. Preserve the rating-stability corpus as the evidence record the assertions are derived from.
+       code evidence: addressed
+         17.1  tests/fixtures/rating-stability/README.md#@@ -1,9 +1,29 @@
+         17.2  tests/fixtures/rating-regression/163-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         17.3  tests/fixtures/rating-regression/167-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         17.4  tests/fixtures/rating-regression/167-gate2-run2/case.json#@@ -0,0 +1,7 @@
+         17.5  tests/fixtures/rating-regression/167-gate2-run3/case.json#@@ -0,0 +1,7 @@
+         17.6  tests/fixtures/rating-regression/167-gate2-run4/case.json#@@ -0,0 +1,7 @@
+         17.7  tests/fixtures/rating-regression/167-gate2-run5/case.json#@@ -0,0 +1,7 @@
+       test evidence: partially supported  [tier: static]
+         17.8  tests/benchmark/test_corpus.py::test_the_case_carries_the_task_file_the_run_was_actually_given
+         17.9  tests/benchmark/test_rating_regression.py::test_every_real_gap_is_required_to_still_be_reported
+         17.10  tests/benchmark/test_rating_regression.py::test_every_unearned_rating_is_required_to_no_longer_be_issued
+         17.11  tests/benchmark/test_rating_regression.py::test_the_corpus_itself_is_untouched_apart_from_its_readme
+
+  18. Keep the incremental re-run path's carried-forward stored review state out of the case inputs.
+       code evidence: addressed
+         18.1  src/acceptance/benchmark/corpus.py#@@ -0,0 +1,195 @@
+         18.2  tests/benchmark/test_corpus.py#@@ -0,0 +1,123 @@
+         18.3  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,492 @@
+       test evidence: partially supported  [tier: static]
+         18.4  tests/benchmark/test_rating_regression.py::test_cases_carry_only_their_run_input_not_resumed_state
+
+  19. Commit the regression cases derived from the corpus as test fixtures.
+       code evidence: addressed
+         19.1  tests/fixtures/rating-regression/163-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         19.2  tests/fixtures/rating-regression/163-gate2-run1/labels.json#@@ -0,0 +1,179 @@
+         19.3  tests/fixtures/rating-regression/167-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         19.4  tests/fixtures/rating-regression/167-gate2-run1/labels.json#@@ -0,0 +1,190 @@
+         19.5  tests/fixtures/rating-regression/167-gate2-run2/case.json#@@ -0,0 +1,7 @@
+         19.6  tests/fixtures/rating-regression/167-gate2-run2/labels.json#@@ -0,0 +1,181 @@
+         19.7  tests/fixtures/rating-regression/167-gate2-run3/case.json#@@ -0,0 +1,7 @@
+         19.8  tests/fixtures/rating-regression/167-gate2-run3/labels.json#@@ -0,0 +1,173 @@
+         19.9  tests/fixtures/rating-regression/167-gate2-run4/case.json#@@ -0,0 +1,7 @@
+         19.10  tests/fixtures/rating-regression/167-gate2-run4/labels.json#@@ -0,0 +1,175 @@
+         19.11  tests/fixtures/rating-regression/167-gate2-run5/case.json#@@ -0,0 +1,7 @@
+         19.12  tests/fixtures/rating-regression/167-gate2-run5/labels.json#@@ -0,0 +1,170 @@
+       test evidence: partially supported  [tier: static]
+         19.13  tests/benchmark/test_rating_regression.py::test_the_scoreboard_is_committed_as_fixtures_for_every_run
+
+  20. A judge that always issues `strongly supported` fails the suite.
+       code evidence: addressed
+         20.1  tests/benchmark/degenerate_judges.py#@@ -0,0 +1,156 @@
+         20.2  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,492 @@
+       test evidence: partially supported  [tier: static]
+         20.3  tests/benchmark/test_rating_regression.py::test_a_judge_that_always_issues_strongly_supported_fails_the_suite
+         20.4  tests/benchmark/test_rating_regression.py::test_the_case_set_can_catch_a_judge_erring_either_way
+
+  21. A judge that never issues `strongly supported` fails the suite.
+       code evidence: addressed
+         21.1  tests/benchmark/degenerate_judges.py#@@ -0,0 +1,156 @@
+         21.2  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,492 @@
+       test evidence: partially supported  [tier: static]
+         21.3  tests/benchmark/test_rating_regression.py::test_a_judge_that_never_issues_strongly_supported_fails_the_suite
+         21.4  tests/benchmark/test_rating_regression.py::test_the_case_set_can_catch_a_judge_erring_either_way
+
+  22. Require every gap listed as real to still be reported by the suite.
+       code evidence: addressed
+         22.1  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,492 @@
+         22.2  tests/fixtures/rating-regression/167-gate2-run1/labels.json#@@ -0,0 +1,190 @@
+         22.3  tests/fixtures/rating-regression/167-gate2-run2/labels.json#@@ -0,0 +1,181 @@
+         22.4  tests/fixtures/rating-regression/167-gate2-run3/labels.json#@@ -0,0 +1,173 @@
+         22.5  tests/fixtures/rating-regression/167-gate2-run4/labels.json#@@ -0,0 +1,175 @@
+       test evidence: partially supported  [tier: static]
+         22.6  tests/benchmark/test_rating_regression.py::test_a_judge_that_always_issues_strongly_supported_fails_the_suite
+         22.7  tests/benchmark/test_rating_regression.py::test_every_real_gap_is_required_to_still_be_reported
+
+  23. Require every rating listed as unearned to no longer be issued.
+       code evidence: addressed
+         23.1  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,492 @@
+         23.2  tests/fixtures/rating-regression/163-gate2-run1/labels.json#@@ -0,0 +1,179 @@
+         23.3  tests/fixtures/rating-regression/167-gate2-run1/labels.json#@@ -0,0 +1,190 @@
+         23.4  tests/fixtures/rating-regression/167-gate2-run2/labels.json#@@ -0,0 +1,181 @@
+       test evidence: partially supported  [tier: static]
+         23.5  tests/benchmark/test_rating_regression.py::test_a_judge_that_never_issues_strongly_supported_fails_the_suite
+         23.6  tests/benchmark/test_rating_regression.py::test_every_unearned_rating_is_required_to_no_longer_be_issued
+
+  24. Mark run 3's preserved reading as the ground truth for its case.
+       code evidence: addressed
+         24.1  tests/fixtures/rating-regression/167-gate2-run3/case.json#@@ -0,0 +1,7 @@
+         24.2  tests/fixtures/rating-regression/167-gate2-run3/labels.json#@@ -0,0 +1,173 @@
+       test evidence: partially supported  [tier: static]
+         24.3  tests/benchmark/test_rating_regression.py::test_run3_encodes_the_corrected_reading_that_all_three_findings_were_real
+
+  25. Mark run 5's preserved reading as the ground truth for its case.
+       code evidence: addressed
+         25.1  tests/fixtures/rating-regression/167-gate2-run5/case.json#@@ -0,0 +1,7 @@
+         25.2  tests/fixtures/rating-regression/167-gate2-run5/labels.json#@@ -0,0 +1,170 @@
+       test evidence: partially supported  [tier: static]
+         25.3  tests/benchmark/test_rating_regression.py::test_run5_encodes_the_corrected_reading_that_run4s_strong_was_right
+
+  26. Give control case `163-gate2-run1` assertions of the same kind as the other cases.
+       code evidence: addressed
+         26.1  tests/fixtures/rating-regression/163-gate2-run1/case.json#@@ -0,0 +1,7 @@
+         26.2  tests/fixtures/rating-regression/163-gate2-run1/labels.json#@@ -0,0 +1,179 @@
+         26.3  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,492 @@
+       test evidence: partially supported  [tier: static]
+         26.4  tests/benchmark/test_rating_regression.py::test_no_case_passes_trivially
+         26.5  tests/benchmark/test_rating_regression.py::test_the_two_degenerate_judges_disagree_about_the_ratings
+
+  27. Update the corpus README so it no longer says the corpus is not read by any test, or else states precisely which parts are still not read.
+       code evidence: addressed
+         27.1  tests/fixtures/rating-stability/README.md#@@ -1,9 +1,29 @@
+       test evidence: partially supported  [tier: static]
+         27.2  tests/benchmark/test_rating_regression.py::test_the_readme_states_what_is_and_is_not_read
+
+  28. Record run 3's corrected reading that all three findings were real and the original reading called them tool defects.
+       code evidence: addressed
+         28.1  tests/fixtures/rating-regression/167-gate2-run3/case.json#@@ -0,0 +1,7 @@
+         28.2  tests/fixtures/rating-regression/167-gate2-run3/labels.json#@@ -0,0 +1,173 @@
+         28.3  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,492 @@
+       test evidence: partially supported  [tier: static]
+         28.4  tests/benchmark/test_rating_regression.py::test_run3_encodes_the_corrected_reading_that_all_three_findings_were_real
+
+  29. Record run 5's corrected reading that the `partially supported` rating was a wrong verdict and run 4's `strongly supported` is correct.
+       code evidence: addressed
+         29.1  tests/fixtures/rating-regression/167-gate2-run5/case.json#@@ -0,0 +1,7 @@
+         29.2  tests/fixtures/rating-regression/167-gate2-run5/labels.json#@@ -0,0 +1,170 @@
+         29.3  tests/benchmark/test_rating_regression.py#@@ -0,0 +1,492 @@
+       test evidence: partially supported  [tier: static]
+         29.4  tests/benchmark/test_rating_regression.py::test_run5_encodes_the_corrected_reading_that_run4s_strong_was_right
+
+Unrequested changes:
+  1. [separable] The session-state note adds a long implementation-status section, metrics table, and design commentary that are not required by any obligation; the only docs obligation is to update the corpus README, not this planning log.
+       session-state.md#@@ -99,12 +99,52 @@ the real diff, with `7de7d71` as a negative control (missed all 4 hunks):
+  2. [in_service] `src/acceptance/benchmark/corpus.py` introduces a new corpus materializer and helpers, but it also adds extra explanatory docstrings and helper structure beyond what the obligations require. The core file is requested, yet these specific internal design details are not separately called for.
+       src/acceptance/benchmark/corpus.py#@@ -0,0 +1,195 @@
+  3. [in_service] `tests/benchmark/degenerate_judges.py` includes a custom enum-walking helper and schema-inspection logic that are implementation choices, not something any obligation explicitly requires. The suite needs stub judges, but not this particular internal mechanism.
+       tests/benchmark/degenerate_judges.py#@@ -0,0 +1,156 @@
+  4. [in_service] The new corpus tests assert extra filesystem details such as the absence of `src/acceptance/benchmark/corpus.py` in the worktree and the nonexistence of `current-task.md` under the case directory. Those checks go beyond the stated requirements to analyze the judged revision and keep source files out of the case payload.
+       tests/benchmark/test_corpus.py#@@ -0,0 +1,123 @@
+  5. [in_service] `tests/benchmark/test_rating_regression.py` hard-codes specific sets of unearned ratings and real gaps, plus extra scoring assertions about degenerate judges. The obligations require regression cases and suite behavior, but not these additional enumerations and metric-specific checks in this form.
+       tests/benchmark/test_rating_regression.py#@@ -0,0 +1,492 @@
+  6. [in_service] The new `case.json` for `163-gate2-run1` adds a detailed summary and judgement prose beyond the required ground-truth label shape and traceability. The case fixture itself is requested, but this extra narrative content is not explicitly required.
+       tests/fixtures/rating-regression/163-gate2-run1/case.json#@@ -0,0 +1,7 @@
+       tests/fixtures/rating-regression/163-gate2-run1/labels.json#@@ -0,0 +1,179 @@
+  7. [in_service] The `labels.json` fixture for `163-gate2-run1` contains a large number of obligation entries and candidate tests, including control-case assertions and detailed rationale text. While labels are requested, this specific expanded content is not directly mandated by the obligations as written.
+       tests/fixtures/rating-regression/163-gate2-run1/labels.json#@@ -0,0 +1,179 @@
+  8. [in_service] The `case.json` for `167-gate2-run1` includes extra explanatory summary text and retrospective commentary. The obligations require regression cases and traceability, but not this additional narrative detail.
+       tests/fixtures/rating-regression/167-gate2-run1/case.json#@@ -0,0 +1,7 @@
+  9. [in_service] The `labels.json` for `167-gate2-run1` encodes a very specific decomposition of obligations, gaps, and retrospective commentary. The task requires labels in the existing shape, but not this particular expanded set of narrative annotations and gap IDs.
+       tests/fixtures/rating-regression/167-gate2-run1/labels.json#@@ -0,0 +1,190 @@
+  10. [in_service] The `case.json` for `167-gate2-run2` adds summary prose and retrospective notes beyond the requested case metadata. Those additions are not separately required by any obligation.
+       tests/fixtures/rating-regression/167-gate2-run2/case.json#@@ -0,0 +1,7 @@
+  11. [in_service] The `labels.json` for `167-gate2-run2` contains detailed rationale text and gap records that go beyond merely representing ground-truth labels in the existing shape. The obligations do not specifically require this level of narrative expansion.
+       tests/fixtures/rating-regression/167-gate2-run2/labels.json#@@ -0,0 +1,181 @@
+  12. [in_service] The `case.json` for `167-gate2-run3` adds a long summary and corrected-reading commentary. The obligations require preserving the corrected reading, but not this extra prose in the case metadata.
+       tests/fixtures/rating-regression/167-gate2-run3/case.json#@@ -0,0 +1,7 @@
+  13. [in_service] The `labels.json` for `167-gate2-run3` includes extensive rationale and gap descriptions, including explicit claims about later runs. The obligations require traceability and corrected readings, but not this much additional annotation.
+       tests/fixtures/rating-regression/167-gate2-run3/labels.json#@@ -0,0 +1,173 @@
+  14. [in_service] The `case.json` for `167-gate2-run4` adds summary commentary about false positives and anchors. That narrative is not required by the listed obligations.
+       tests/fixtures/rating-regression/167-gate2-run4/case.json#@@ -0,0 +1,7 @@
+  15. [in_service] The `labels.json` for `167-gate2-run4` contains detailed verdict commentary and a gap record that are more specific than the obligations require. The task asks for regression cases and labels, not this particular explanatory framing.
+       tests/fixtures/rating-regression/167-gate2-run4/labels.json#@@ -0,0 +1,175 @@
+  16. [in_service] The `case.json` for `167-gate2-run5` adds summary prose about the sharpest localization and byte-identical mapped tests. The obligations require the corrected ground truth, but not this extra narrative in the fixture.
+       tests/fixtures/rating-regression/167-gate2-run5/case.json#@@ -0,0 +1,7 @@
+  17. [in_service] The `labels.json` for `167-gate2-run5` includes detailed corrected-verdict commentary and extra candidate-test lists. The obligations require the existing label shape and corrected reading, but not this expanded explanatory content.
+       tests/fixtures/rating-regression/167-gate2-run5/labels.json#@@ -0,0 +1,170 @@
+  18. [in_service] The rating-stability README now adds a detailed matrix of what files are read by tests and what are not, plus a strong statement about when findings reach the suite. The README update is requested, but this specific level of detail and wording is not explicitly required and may go beyond the obligation to state precisely what is still not read.
+       tests/fixtures/rating-stability/README.md#@@ -1,9 +1,29 @@
+
+Changes since e8e8755e:
+  moved:
+    - Convert the rating-stability corpus into regression cases that the benchmark can score.
+        test evidence: strongly supported -> unsupported
+    - Represent ground-truth labels with the existing `benchmark/case.py::GroundTruthLabels` shape used by `tests/fixtures/archetypes/`.
+        test evidence: strongly supported -> partially supported
+    - Keep source files out of the case payload; the case references the corpus inputs instead of copying them.
+        test evidence: strongly supported -> partially supported
+    - Make each case's ground-truth label traceable to the `judgement.md` it was derived from.
+        test evidence: strongly supported -> partially supported
+    - Limit modifications under `tests/fixtures/rating-stability/` to the README.
+        test evidence: strongly supported -> partially supported
+    - Preserve the instability documented by the corpus.
+        test evidence: strongly supported -> partially supported
+    - Keep the decompose-stability corpus out of this task.
+        test evidence: partially supported -> unsupported
+    - Commit the regression cases derived from the corpus as test fixtures.
+        test evidence: strongly supported -> partially supported
+    - A judge that always issues `strongly supported` fails the suite.
+        test evidence: strongly supported -> partially supported
+    - A judge that never issues `strongly supported` fails the suite.
+        test evidence: strongly supported -> partially supported
+    - Require every gap listed as real to still be reported by the suite.
+        test evidence: strongly supported -> partially supported
+    - Require every rating listed as unearned to no longer be issued.
+        test evidence: strongly supported -> partially supported
+    - Mark run 3's preserved reading as the ground truth for its case.
+        test evidence: strongly supported -> partially supported
+    - Mark run 5's preserved reading as the ground truth for its case.
+        test evidence: strongly supported -> partially supported
+    - Give control case `163-gate2-run1` assertions of the same kind as the other cases.
+        test evidence: strongly supported -> partially supported
+    - Update the corpus README so it no longer says the corpus is not read by any test, or else states precisely which parts are still not read.
+        test evidence: strongly supported -> partially supported
+    - Record run 3's corrected reading that all three findings were real and the original reading called them tool defects.
+        test evidence: strongly supported -> partially supported
+    - Record run 5's corrected reading that the `partially supported` rating was a wrong verdict and run 4's `strongly supported` is correct.
+        test evidence: strongly supported -> partially supported
+  verdict: INCOMPLETE -> NEEDS-CLARIFICATION
+
+Open questions:
+  1. [open] Which specific fixture files should be created or updated under `tests/fixtures/rating-stability/` to represent the regression cases, and what naming/layout should they use?
+  2. [resolved] How should the six runs in the corpus map to benchmark cases, especially for runs with multiple preserved readings or multiple run-instances per obligation?
+       The added regression fixtures map each corpus run to one case directory named after the run (`163-gate2-run1`, `167-gate2-run1` through `run5`), and the tests iterate those case dirs directly. The run-3 and run-5 fixtures also explicitly encode the preserved/corrected readings in `case.json` and labels, showing how multi-reading runs are handled.
+  3. [resolved] How should the suite represent the note that `replace-written-file-with-command` is only partly real, with only its defaulting-to-JSON clause confirmed?
+       The labels explicitly encode `replace-written-file-with-command` as `unsupported` in run 1 with rationale saying only the defaulting-to-JSON clause is the real finding, and the README/test fixtures carry that same partial-real interpretation. That makes the intended representation unambiguous in the diff.
+  4. [resolved] What exact README wording should replace the current statement about the corpus not being read by any test?
+       The README is rewritten to a specific section titled `What is read by a test, and what is not (#190)` with a table spelling out what is read and what is not, replacing the old `Not currently read by any test` wording. The exact replacement wording is therefore shown directly in the diff.
+
+Recommended tests:
+  1. Case evaluation flows through `benchmark/scoring.py::score_case` rather than a separate scoring implementation.
+       inputs:  A regression test that exercises case scoring through the public benchmark entrypoint with a spy/monkeypatch on `benchmark/scoring.py::score_case`, using at least one nontrivial corpus case whose final report would still look correct even if a separate scorer were used. The input must make the invoked function observable, not just the aggregate result.
+       detects: Developer routes case evaluation through a new helper that computes per-case scores directly, bypassing `benchmark/scoring.py::score_case`, but still returns the same aggregate report object.
+       full detail: acceptance recommendation --criterion use-existing-scoring-path
+  2. Generated fixtures serialize ground-truth labels in the same structure as the archetype fixtures, and the benchmark can load them without schema changes.
+       inputs:  A fixture round-trip test over one of the generated `labels.json` files that contains multiple obligations, gaps, and rationale text, so a schema mismatch in field names or nesting becomes visible when loading with `GroundTruthLabels`. Use a case whose labels include both obligations and gaps, not a minimal empty fixture.
+       detects: Developer serializes labels with a slightly different field name or nesting than `GroundTruthLabels` expects, but still includes non-empty obligations and evidence rationales in the same logical places.
+       full detail: acceptance recommendation --criterion use-existing-ground-truth-shape
+  3. Generated case fixtures do not duplicate repository source files into the case data.
+       inputs:  A case fixture inspection that compares the case payload against the corpus run directory and verifies the case references the corpus task input rather than embedding repository source files. Use a run whose payload could plausibly include extra copied files if the implementation were wrong.
+       detects: Developer stores the task text from the corpus but also duplicates source files elsewhere in the case payload.
+       full detail: acceptance recommendation --criterion no-source-file-copy-into-case
+  4. Test execution completes using only recorded fixture data and repository state, with no outbound model invocation.
+       inputs:  A regression-suite execution using the degenerate judges from `tests/benchmark/degenerate_judges.py`, with a stubbed client that raises on any real provider access and records every completion request. Use a case set that exercises decomposition, mapping, discrimination, and coverage so a hidden live call cannot hide behind an unexercised branch.
+       detects: Developer leaves a code path that contacts the model provider when scoring certain cases, but the recorded fixtures used in the test happen to avoid that path.
+       full detail: acceptance recommendation --criterion no-live-model-calls
+  5. The repository changes for the task do not add committed model transcripts to the fixtures.
+       inputs:  A repository-tree scan over `tests/fixtures/` that looks for transcript-like artifacts in committed fixture files, including JSON fields that might embed transcript content rather than separate files. Use both the rating-stability corpus and the new regression fixtures so the scan covers the relevant fixture subtree.
+       detects: Developer stores transcript content inside an existing JSON field rather than as a separate file.
+       full detail: acceptance recommendation --criterion no-recorded-transcript-committed
+  6. A case fixture can be traced back to the specific `judgement.md` file that supplied its label.
+       inputs:  A generated case fixture whose `case.json` explicitly names the source `judgement.md`, plus a test that cross-checks that the named judgement file exists in the corresponding corpus run directory. Use a run with rewritten judgement text so the traceability link matters.
+       detects: Developer points to a `judgement.md` from the same run directory but not the specific one that supplied the label.
+       full detail: acceptance recommendation --criterion trace-labels-to-judgement-md
+  7. The corpus files remain unchanged except for README edits.
+       inputs:  A diff-level filesystem comparison of `tests/fixtures/rating-stability/` before and after the task, allowing only README edits. Use the full corpus tree so any non-README file change is visible even if filenames stay the same.
+       detects: Developer changes README.md only, but also updates generated fixture contents in a way that leaves filenames unchanged.
+       full detail: acceptance recommendation --criterion preserve-rating-stability-readme-only
+  8. The implementation adds scoreboard coverage without altering how judgements are generated.
+       inputs:  A before/after comparison that exercises the scoreboard/coverage path while separately verifying the judgement-production source tree remains unchanged in behavior, not just byte-for-byte on a narrow subset of files. Use a representative case whose judgement is stable under the current corpus.
+       detects: Developer changes internal judgement logic but the specific stage directories hashed by the test remain byte-for-byte identical.
+       full detail: acceptance recommendation --criterion do-not-change-judgement-production
+  9. The new tests do not mask or normalize the corpus's documented instability.
+       inputs:  A pair of corpus runs that are documented as unstable or contradictory, especially the preserved run 3/run 5 readings, so the test can observe the disagreement rather than smoothing it away. Use obligations known to move across runs.
+       detects: Developer preserves the number of moved obligations but changes a different unstable obligation not named in the assertion.
+       full detail: acceptance recommendation --criterion do-not-reduce-instability
+  10. The suite does not depend on a minimum variance or accuracy cutoff.
+       inputs:  A suite run with deliberately varied but valid corpus cases spanning both strong and non-strong labels, so any hidden minimum variance or accuracy cutoff would become observable. The test should not rely on a specific numeric threshold value.
+       detects: The suite depends on a minimum variance or accuracy cutoff.
+       full detail: acceptance recommendation --criterion do-not-set-thresholds
+  11. Only the runs named in the task are turned into scored regression cases.
+       inputs:  A corpus selection containing both the task’s named runs and at least one extra run directory that should not be converted into a regression case. The test must distinguish listed from unlisted runs by name.
+       detects: Additional corpus runs beyond those named in the task are turned into scored regression cases.
+       full detail: acceptance recommendation --criterion do-not-rebuild-unlisted-runs
+  12. No fixtures or logic under `tests/fixtures/decompose-stability/` are modified for this task.
+       inputs:  A filesystem snapshot that includes `tests/fixtures/decompose-stability/` and the rating-regression corpus, with a before/after comparison around the task’s operations. The test should inspect the subtree recursively.
+       detects: The task accidentally modifies decompose-stability fixtures or logic, contaminating an unrelated stability corpus.
+       full detail: acceptance recommendation --criterion do-not-touch-decompose-stability
+  13. The corpus remains the source of truth for the new assertions rather than being rewritten to fit them.
+       inputs:  A corpus case whose labels are compared against the source evidence record, plus a mutation attempt that would rewrite the corpus-derived labels or case metadata while leaving directory names unchanged. Use the corpus README and the generated regression fixtures together.
+       detects: Developer keeps the corpus files intact but changes only derived documentation outside the corpus tree.
+       full detail: acceptance recommendation --criterion preserve-corpus-evidence-record
+  14. Cases use the run's input data without inheriting the resumed state from runs 2 and 3.
+       inputs:  Two cases built from runs that had resumed state in the original corpus, with any persisted incremental-state artifacts present in the repository snapshot. The test should ensure the case uses only the run input data and not resumed state from runs 2 and 3.
+       detects: Developer carries forward some other incremental metadata not named in the assertions, but leaves the checked fields empty.
+       full detail: acceptance recommendation --criterion do-not-restore-incremental-state
+  15. The repository contains committed fixture files for the new regression cases.
+       inputs:  A repository scan that expects the new regression cases to exist as committed files under `tests/fixtures/rating-regression/`, with each case containing `case.json` and `labels.json`. Use all six runs so missing or partial fixture commits are visible.
+       detects: Developer commits the directories but omits some non-checked ancillary metadata inside them.
+       full detail: acceptance recommendation --criterion scoreboard-committed-as-fixtures
+  16. Running the suite with an always-`strongly supported` judge produces failing cases.
+       inputs:  A suite run with the always-`strongly supported` degenerate judge against the full regression corpus, including cases that should expose permissive behavior. The case set must include both genuine gaps and genuine strong labels so the judge cannot skate by.
+       detects: Developer leaves the metrics below 1.0 but the case set still cannot distinguish always-strongly-supported behavior from normal behavior on the tested inputs.
+       full detail: acceptance recommendation --criterion strongly-supported-always-fails
+  17. Running the suite with a never-`strongly supported` judge produces failing cases.
+       inputs:  A suite run with the never-`strongly supported` degenerate judge against the full regression corpus, including cases that should expose pessimistic behavior. The corpus must contain both strong and non-strong labels so the judge cannot pass by being uniformly negative.
+       detects: Developer changes scoring internals but the tested case set still yields the same metrics and label diversity.
+       full detail: acceptance recommendation --criterion never-strongly-supported-fails
+  18. The benchmark expects the real gaps named in the task to appear in the scored results.
+       inputs:  A regression test that enumerates the corpus’s named real gaps and checks they still appear in the scored results, using runs where those gaps are explicitly recorded. Include at least one partly-real gap so the test can distinguish real from merely adjacent findings.
+       detects: Developer keeps the named gaps but changes unrelated gap metadata or ordering.
+       full detail: acceptance recommendation --criterion real-gaps-remain-required
+  19. The benchmark expects the unearned `strongly supported` ratings named in the task to be absent from the scored results.
+       inputs:  A regression test that checks the corpus’s named unearned `strongly supported` ratings are absent from the scored results, using runs where those ratings were later corrected. Include at least one case where the underlying judgment remains permissive even if the label text changes.
+       detects: Developer changes the label text to a different non-strongly_supported value but leaves the underlying judgment equally permissive.
+       full detail: acceptance recommendation --criterion unearned-ratings-no-longer-issued
+  20. The run 3 fixture records which of the two preserved readings is authoritative.
+       inputs:  The `167-gate2-run3` regression fixture, which contains both the original and corrected readings in `judgement.md`/`case.json`. The test must focus on the preserved-reading choice, not on unrelated metadata.
+       detects: Developer preserves the corrected reading text but accidentally flips one unrelated obligation's label.
+       full detail: acceptance recommendation --criterion run3-preserved-reading-ground-truth
+  21. The run 5 fixture records which of the two preserved readings is authoritative.
+       inputs:  The `167-gate2-run5` regression fixture, which also has a rewritten judgement and a corrected reading. The test should verify the authoritative reading choice rather than incidental labels.
+       detects: Developer keeps the corrected reading but changes some other obligation not mentioned in the assertions.
+       full detail: acceptance recommendation --criterion run5-preserved-reading-ground-truth
+  22. The control case is scored by substantive assertions rather than by a trivial pass-through.
+       inputs:  The control case `163-gate2-run1`, scored with the same kind of substantive assertions as the other cases. The input must be a control that could otherwise pass trivially if only one direction were checked.
+       detects: Developer keeps the control case substantive but changes only a non-control case's assertions.
+       full detail: acceptance recommendation --criterion control-case-nontrivial-assertions
+  23. The README text reflects that the corpus is now used by tests, or precisely scopes any remaining unread parts.
+       inputs:  The corpus README text plus the new regression fixture tree, compared against the actual test files that now read the corpus. The test should verify the README’s claims against the committed regression suite and the corpus files it references.
+       detects: Developer updates the README to mention tests but omits the precise scope of what is read.
+       full detail: acceptance recommendation --criterion readme-updated-about-test-coverage
+  24. The run 3 case preserves the corrected interpretation of the three findings.
+       inputs:  The `167-gate2-run3` case and labels, focusing on the three findings the corpus says were real gaps. Use the corrected reading from the rewritten judgement, not the original tool-defect reading.
+       detects: Developer preserves the corrected reading for the three findings but changes unrelated metadata in the judgement file.
+       full detail: acceptance recommendation --criterion run3-corrected-reading-real-findings
+  25. The run 5 case preserves the corrected interpretation of the verdict.
+       inputs:  The `167-gate2-run5` case and labels, especially the single partially supported rating that the rewritten judgement says was a wrong verdict. Use the run 4/run 5 one-commit-apart relationship to make the defect observable.
+       detects: Developer keeps the corrected verdict but changes unrelated labels in run 5.
+       full detail: acceptance recommendation --criterion run5-corrected-reading-verdict
+
+Evidence limitations:
+  1. Judgments are static inferences unless a higher tier is recorded; the full application was not independently executed.
+
+Next: retrieve a criterion's full recommendation with
+  acceptance recommendation --criterion <id>

--- a/dogfood-logs/190-gate2-run3/revisions.txt
+++ b/dogfood-logs/190-gate2-run3/revisions.txt
@@ -1,0 +1,1 @@
+190-gate2-run3  base=7e337f7  head=c5620ae

--- a/session-state.md
+++ b/session-state.md
@@ -12,6 +12,34 @@ Clear it out when the task lands rather than letting it accrete.
 
 ---
 
+## STATUS: PR #197 is open and CI is green. Awaiting human review/merge.
+
+Seven commits on `190-rating-corpus-regression-suite`, plus two on `main`
+(`c5cc707`, `7e337f7` — committing dogfood runs and session state).
+
+**Gate 2 ran three rounds and never came back clean**, for two tracked reasons,
+both recorded and neither a defect in this change:
+
+- **#153** — six scope exclusions demand test evidence that cannot exist in
+  principle. Writing tests moved them `unsupported` → `partially supported` and
+  no further. An exclusion cannot be discharged by testing.
+- **#191** — round 3 fell 20 → 3 `strongly supported` on a diff that only added
+  tests. Isolated to M5.2's per-defect verdict: mapping had *more* links (36→40)
+  and defect enumeration was identical (2.04/obligation), while `would_be_caught`
+  went 87% → 57%. Cleaner isolation than the corpus's own run-5 case.
+
+**Do not read round 3's fall as proof the tests are fine.** DR-180's named
+fallacy is exactly this, and the corpus says the LOW rating was correct in 7 of 8
+unstable obligations. The lower ratings may be right.
+
+### The two CI findings — the design's real cost
+
+1. CI needs `fetch-depth: 0`; the default shallow clone has no corpus history.
+2. **All six head revisions are squash-orphaned** — unreachable from `main`, and
+   resolving locally only because this working copy still had the branch objects.
+   Fixed by pushing `corpus/<run>` tags. **Those tags are load-bearing**;
+   deleting one removes a case. Guarded by a test.
+
 ## Task in flight
 
 **#190 — turn the rating-stability corpus into an executable regression suite.**

--- a/session-state.md
+++ b/session-state.md
@@ -99,12 +99,52 @@ the real diff, with `7de7d71` as a negative control (missed all 4 hunks):
 ## The plan
 
 1. `current-task.md` rewrite + Gate 1 re-run — **done** (run 5).
-2. Materializer: corpus run dir → worktree at head → `BenchmarkCase`. The
-   analogue of `materialize_archetype`.
-3. `labels.json` per run from its `judgement.md`.
-4. Stub judges (always-STRONG, never-STRONG) + per-case assertions.
-5. `163-gate2-run1` control carries the same assertion kinds.
-6. Corpus README updated.
+2. Materializer — **done**. `src/acceptance/benchmark/corpus.py`,
+   `tests/benchmark/test_corpus.py` (6 passing). Full suite 628 passed, lint
+   clean, no leaked worktrees.
+3. `labels.json` per run — **done, all 6**. Generated from each run's own log
+   (descriptions + candidate tests) with the judgements applied as overrides;
+   generator was throwaway, in the scratchpad.
+4. Stub judges + assertions — **done**. `tests/benchmark/degenerate_judges.py`,
+   `tests/benchmark/test_rating_regression.py`.
+5. `163-gate2-run1` control — **done**, carries the precision direction.
+6. Corpus README — **done**, now states exactly what is and is not read.
+
+**Implementation complete. 661 passed (was 628), lint clean, no leaked
+worktrees. Gate 2 is the remaining step, then a PR.**
+
+### The figures that prove the suite is not vacuous
+
+| judge | classes produced | evidence_agreement | gap_recall | gap_precision |
+|---|---|---|---|---|
+| always-STRONG | 70 × `strongly_supported` | 0.771 (= 54/70) | **0.0** | None |
+| never-STRONG | 70 × `nominally_supported` | 0.043 (= 3/70) | 1.0 | **0.229** |
+
+Each direction is caught by a *different* metric — the permissive judge by gap
+recall, the pessimistic one by gap precision. 0.771 is exactly the 54
+strongly-supported labels over 70 obligations, so the agreement figure is doing
+real arithmetic rather than landing on a coincidence.
+
+**Uncommitted.** Nothing on the branch is committed yet; main is at `7e337f7`.
+
+### Stub-judge design, worked out but not yet built
+
+`strength.py` returns `unsupported` when an obligation has no mapped test, so a
+degenerate judge cannot just answer the discrimination call — it must also
+return mappings, and #163 constrains id-bearing response fields to the ids
+actually supplied. **The robust way is to read the allowed ids out of the
+request schema** (`kwargs["response_format"]["json_schema"]["schema"]`, as
+`client_capturing_schemas` in `tests/support.py` does) and answer for exactly
+those, rather than parsing the prompt text. Verify this before building on it.
+
+### Known epistemic weakness in the labels — raise with the human
+
+The nine non-gap obligations in `167-gate2-run3` are labelled
+`strongly_supported` because run 3's judgement *does not dispute* them, not
+because the corpus positively establishes them. The pessimistic-judge direction
+leans on those labels. Run 5 is the one case with a positive STRONG ground truth
+(it says run 4's `strongly supported` for `preserve-prose-structured-fields` is
+correct), so that case anchors the direction properly and should carry weight.
 
 ## Gate 1 run 5 — open-question triage
 

--- a/src/acceptance/benchmark/corpus.py
+++ b/src/acceptance/benchmark/corpus.py
@@ -1,0 +1,195 @@
+"""Rating-stability corpus -> benchmark cases (#190).
+
+`tests/fixtures/rating-stability/` records six dogfood runs of `acceptance
+check`: the task file each was given, the report it produced, and — the
+expensive part — a `judgement.md` saying which findings were real gaps and
+which were tool defects. Until those judgements are assertions, every
+candidate fix to the evidence-judgement stage is accepted by eyeball, and
+DR-180's load-bearing criterion (`strongly supported` is not issued on
+evidence that does not earn it) has no scoreboard.
+
+## Why these cases are not archetypes
+
+`fixtures.py` materializes an archetype by copying a hand-built `base/` and
+`head/` tree into a fresh two-commit repo. Nothing is copied here. The corpus
+runs judged **real commits in this repository**, and `revisions.txt` names
+them, so a case supplies the input the run actually had rather than a
+reconstruction of it. That is strictly higher fidelity: the instability the
+corpus documents happened over *these* diffs, and a synthetic stand-in would
+be evidence that it can happen, not that it did.
+
+The trade is that a case depends on this repository's history. A revision that
+stops resolving fails its case by name (`UnresolvableRevisionError`) rather
+than skipping quietly — a regression suite that silently shrinks is worse than
+one that breaks.
+
+## Why a worktree
+
+`evidence/discovery.py` scans the **filesystem** for `test_*.py`, not the git
+revision. Pointing a case at the live repository would therefore discover
+today's tests against a years-old diff — tests that did not exist when the run
+was made, and none of the ones later deleted. So each case is analysed in a
+detached worktree at its head revision. A worktree shares the object store, so
+it is cheap and both revisions stay resolvable inside it.
+
+## What is deliberately not here
+
+No model transcript is recorded or committed. A transcript embeds the full
+request, so recording against these revisions would place this repository's own
+diffs and task text into `tests/fixtures/` — exactly what the corpus README
+says was avoided when it stored rendered reports instead. The judgement a case
+is scored under is supplied by a stub in the test, which is also why the suite
+scores the deterministic reduce in `evidence/strength.py` and the wiring around
+it rather than the judgement prompt.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from acceptance.benchmark.case import (
+    BenchmarkCase,
+    BenchmarkCaseInputs,
+    BenchmarkCaseSource,
+    GroundTruthLabels,
+)
+from acceptance.model_base import PersistableModel
+
+
+class UnresolvableRevisionError(RuntimeError):
+    """A case names a revision this repository no longer has.
+
+    Raised rather than skipped: these cases are pinned to real history, so a
+    rewritten or pruned commit silently removing a case would let the suite
+    shrink without anyone noticing.
+    """
+
+
+class CorpusCaseMeta(PersistableModel):
+    """A corpus run reduced to what a case needs, plus its provenance.
+
+    `corpus_run` points at the directory under `tests/fixtures/rating-stability/`
+    the case is derived from, and `judgement` records which reading of that run's
+    `judgement.md` is ground truth — load-bearing for runs 3 and 5, whose
+    judgements were rewritten and which preserve both the original and the
+    corrected reading.
+    """
+
+    corpus_run: str
+    base_revision: str
+    head_revision: str
+    judgement: str
+    summary: str
+
+
+@dataclass(frozen=True)
+class MaterializedCorpusRun:
+    worktree: Path
+    base_sha: str
+    head_sha: str
+    meta: CorpusCaseMeta
+
+
+def load_corpus_meta(case_dir: Path) -> CorpusCaseMeta:
+    return CorpusCaseMeta.from_dict(json.loads((case_dir / "case.json").read_text()))
+
+
+def load_labels(case_dir: Path) -> GroundTruthLabels:
+    return GroundTruthLabels.from_dict(json.loads((case_dir / "labels.json").read_text()))
+
+
+def corpus_task_text(corpus_root: Path, meta: CorpusCaseMeta) -> str:
+    """The exact task file the run was given, read from the corpus itself.
+
+    Read rather than copied: the corpus is the evidence record, and a second
+    copy under the case directory could drift from it.
+    """
+    return (corpus_root / meta.corpus_run / "current-task.md").read_text()
+
+
+def resolve_case_revisions(case_dir: Path, repo: Path) -> tuple[str, str]:
+    """This case's (base, head) as full SHAs, without materializing anything.
+
+    Separate from materialization so the whole suite's pinning can be checked
+    cheaply — one `rev-parse` per revision rather than a worktree per case.
+    """
+    meta = load_corpus_meta(case_dir)
+    return (
+        _resolve(repo, meta.base_revision, meta.corpus_run),
+        _resolve(repo, meta.head_revision, meta.corpus_run),
+    )
+
+
+def materialize_corpus_run(case_dir: Path, repo: Path, dest: Path) -> MaterializedCorpusRun:
+    """Check out this case's head revision into a detached worktree of `repo`."""
+    meta = load_corpus_meta(case_dir)
+    base, head = resolve_case_revisions(case_dir, repo)
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    _git(repo, "worktree", "add", "--detach", "--quiet", str(dest), head)
+
+    return MaterializedCorpusRun(worktree=dest, base_sha=base, head_sha=head, meta=meta)
+
+
+def remove_corpus_worktree(repo: Path, dest: Path) -> None:
+    """Drop a materialized worktree and its registration in `repo`.
+
+    Registration lives in the main repository's `.git`, so deleting the
+    directory alone leaves an entry behind; `--force` because the review under
+    test may have left the tree dirty.
+    """
+    subprocess.run(
+        ["git", "worktree", "remove", "--force", str(dest)],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    _git(repo, "worktree", "prune")
+
+
+def build_corpus_case(
+    case_dir: Path, repo: Path, corpus_root: Path, dest: Path
+) -> BenchmarkCase:
+    """Materialize a corpus run and assemble its labeled BenchmarkCase."""
+    run = materialize_corpus_run(case_dir, repo, dest)
+    return BenchmarkCase(
+        case_id=case_dir.name,
+        # These are recorded runs of this tool over real work, which is what
+        # `agent_run` names; they are not hand-built archetypes.
+        source=BenchmarkCaseSource(kind="agent_run", identifier=run.meta.corpus_run),
+        inputs=BenchmarkCaseInputs(
+            repo=str(run.worktree),
+            task_text=corpus_task_text(corpus_root, run.meta),
+            base_revision=run.base_sha,
+            head_revision=run.head_sha,
+        ),
+        ground_truth=load_labels(case_dir),
+    )
+
+
+def _resolve(repo: Path, revision: str, corpus_run: str) -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"{revision}^{{commit}}"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        raise UnresolvableRevisionError(
+            f"case {corpus_run!r} names revision {revision!r}, which this "
+            f"repository no longer resolves. The corpus cases are pinned to real "
+            f"history; a rewritten or pruned commit breaks them by design rather "
+            f"than shrinking the suite silently."
+        )
+    return result.stdout.strip()
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    )

--- a/src/acceptance/benchmark/corpus.py
+++ b/src/acceptance/benchmark/corpus.py
@@ -23,6 +23,13 @@ stops resolving fails its case by name (`UnresolvableRevisionError`) rather
 than skipping quietly — a regression suite that silently shrinks is worse than
 one that breaks.
 
+**The `corpus/*` tags are load-bearing. Do not delete them.** Every head
+revision here was squash-merged, so none is reachable from `main` — the tags are
+the only thing keeping those objects alive, and a fresh clone gets them only
+because the tags exist. CI must also check out with `fetch-depth: 0`; the default
+shallow clone has none of this history. Both facts were discovered the direct
+way, by CI failing on a clone that lacked what a working copy happened to have.
+
 ## Why a worktree
 
 `evidence/discovery.py` scans the **filesystem** for `test_*.py`, not the git

--- a/tests/benchmark/degenerate_judges.py
+++ b/tests/benchmark/degenerate_judges.py
@@ -1,0 +1,156 @@
+"""Degenerate judges for the #190 regression suite.
+
+The suite has to fail in both directions, because each direction catches a
+different bad fix. A judge that rates everything `strongly supported` must fail
+it; so must a judge that rates nothing `strongly supported`. Damping the judge
+until it stops moving would pass a one-directional suite while losing every real
+gap the corpus records.
+
+These two clients are those judges. Neither is a stand-in for the real one: the
+corpus holds rendered reports, not transcripts, so the runs cannot be replayed
+(see `benchmark/corpus.py`). What they do exercise is everything downstream of
+the per-defect verdict — which is not nothing:
+
+    `evidence/strength.py` is a deterministic reduce, not a fresh judgement.
+    All named defects caught -> strongly_supported; some -> partially_supported;
+    none -> nominally_supported; no mapped test at all -> unsupported.
+
+So a judge is steered by the `would_be_caught` booleans it returns, and the
+reduce, the mapping wiring, the coverage->finding derivation and the verdict all
+run for real. Run 5 of the corpus is the case in point: two runs one commit
+apart, byte-identical mapped tests, the same defect named in both and judged
+oppositely — and because the reduce is a pure function, that single flipped
+boolean produced the whole rating.
+
+Ids are read out of the **request schema** rather than parsed from the prompt.
+#163 constrains every id-bearing response field to the ids that call supplied,
+by injecting them as a JSON-schema enum, so the schema is an exact, structured
+statement of what this call is allowed to answer about. Parsing the prompt text
+would re-derive the same list less reliably and would break whenever the prompt
+is reworded.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from acceptance.config import DEFAULT_MODEL
+from acceptance.llm import Mode, ModelClient, TranscriptStore
+from tests.support import _EMPTY_BY_SCHEMA, _fake_response
+
+import tempfile
+
+
+def _enums(schema: Any, field: str) -> list[str]:
+    """Every enum offered for `field` anywhere in `schema`, de-duplicated.
+
+    A walk rather than a fixed path: the id fields sit at different depths per
+    response model (`mappings[].test_id`, `obligations[].obligation_id`), and
+    pydantic may emit them behind `$defs`.
+    """
+    found: list[str] = []
+
+    def walk(node: Any, key: str | None) -> None:
+        if isinstance(node, dict):
+            if key == field and isinstance(node.get("enum"), list):
+                found.extend(v for v in node["enum"] if isinstance(v, str))
+            for name, value in node.items():
+                walk(value, name if name not in ("properties", "$defs", "items") else key)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item, key)
+
+    walk(schema, None)
+    return list(dict.fromkeys(found))
+
+
+def _decomposition(obligations: list[dict]) -> dict:
+    return {
+        "obligations": [
+            {
+                "id": o["id"],
+                "description": o["description"],
+                "type": "functional",
+                "importance": "critical",
+                "explicit": True,
+                "observable_behavior": "...",
+                "source_quote": o["description"][:60],
+            }
+            for o in obligations
+        ],
+        "open_questions": [],
+    }
+
+
+def degenerate_client(obligations: list[dict], *, always_strong: bool) -> ModelClient:
+    """A judge with its mind made up before it reads anything.
+
+    `obligations` seeds the decomposition, because what is under test here is the
+    evidence judgement, not the decomposer — leaving decomposition to chance
+    would score a different stage than the one this suite is about.
+    """
+
+    def completion_fn(**kwargs):
+        spec = kwargs["response_format"]["json_schema"]
+        name, schema = spec["name"], spec["schema"]
+
+        if name == "_Decomposition":
+            return _fake_response(json.dumps(_decomposition(obligations)))
+
+        if name == "_Mappings":
+            # Map every test to every obligation the call allows. A permissive
+            # judge with no mapped tests would score `unsupported` and look
+            # pessimistic, so the mapping must be generous in BOTH judges for
+            # the difference between them to be the verdict and nothing else.
+            tests = _enums(schema, "test_id")
+            allowed = _enums(schema, "obligation_ids") or [o["id"] for o in obligations]
+            return _fake_response(json.dumps({
+                "mappings": [
+                    {"test_id": t, "obligation_ids": allowed, "rationale": "."}
+                    for t in tests
+                ]
+            }))
+
+        if name == "_Discrimination":
+            ids = _enums(schema, "obligation_id") or [o["id"] for o in obligations]
+            return _fake_response(json.dumps({
+                "obligations": [
+                    {
+                        "obligation_id": oid,
+                        "defects": [{
+                            "description": "the behaviour under review is wrong",
+                            "would_be_caught": always_strong,
+                            "reason": "fixed verdict from a degenerate judge",
+                        }],
+                    }
+                    for oid in ids
+                ]
+            }))
+
+        if name == "_Coverage":
+            ids = _enums(schema, "obligation_id") or [o["id"] for o in obligations]
+            return _fake_response(json.dumps({
+                "classifications": [
+                    {
+                        "obligation_id": oid,
+                        "status": "addressed" if always_strong else "not_addressed",
+                        "rationale": "fixed verdict from a degenerate judge",
+                        "diff_refs": [],
+                    }
+                    for oid in ids
+                ]
+            }))
+
+        return _fake_response(json.dumps(_EMPTY_BY_SCHEMA[name]))
+
+    return ModelClient(
+        model=DEFAULT_MODEL,
+        # RECORD because an injected completion_fn is only reached on the live
+        # path; a REPLAY double would find an empty store and raise. No network
+        # call happens — completion_fn stands in for the provider.
+        mode=Mode.RECORD,
+        store=TranscriptStore(tempfile.mkdtemp()),
+        temperature=0.0,
+        completion_fn=completion_fn,
+    )

--- a/tests/benchmark/test_corpus.py
+++ b/tests/benchmark/test_corpus.py
@@ -1,0 +1,123 @@
+"""#190: the rating-stability corpus as materializable benchmark cases.
+
+These cases are pinned to real commits in this repository rather than to
+hand-built fixture trees, so the materializer's job is different from
+`fixtures.py`'s: nothing is copied, and the thing that can go wrong is the
+history moving underneath it.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from acceptance.benchmark.corpus import (
+    UnresolvableRevisionError,
+    build_corpus_case,
+    resolve_case_revisions,
+    load_corpus_meta,
+    materialize_corpus_run,
+    remove_corpus_worktree,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+CASES_DIR = REPO / "tests" / "fixtures" / "rating-regression"
+CORPUS_DIR = REPO / "tests" / "fixtures" / "rating-stability"
+
+CASE_DIRS = sorted(p for p in CASES_DIR.iterdir() if p.is_dir())
+
+
+@pytest.fixture
+def worktree(tmp_path):
+    """Materialize into tmp_path, and always deregister the worktree.
+
+    Registration lives in the main repository's `.git`, so a test that only
+    deleted its tmp_path would leave this repo accumulating stale entries.
+    """
+    dest = tmp_path / "worktree"
+    yield dest
+    remove_corpus_worktree(REPO, dest)
+
+
+@pytest.mark.parametrize("case_dir", CASE_DIRS, ids=lambda p: p.name)
+def test_every_case_names_a_revision_this_repository_still_has(case_dir):
+    """The suite is pinned to real history. If a rebase ever orphans one of
+    these commits, this fails by name — the case cannot quietly disappear."""
+    meta = load_corpus_meta(case_dir)
+    base, head = resolve_case_revisions(case_dir, REPO)
+    assert base.startswith(meta.base_revision)
+    assert head.startswith(meta.head_revision)
+
+
+def test_a_revision_that_no_longer_resolves_fails_by_name(tmp_path):
+    """The failure mode that matters: a suite pinned to history must break
+    loudly when the history moves, never shrink silently."""
+    case_dir = tmp_path / "999-gate2-run1"
+    case_dir.mkdir()
+    (case_dir / "case.json").write_text(
+        json.dumps(
+            {
+                "corpus_run": "999-gate2-run1",
+                "base_revision": "839ea47",
+                "head_revision": "0" * 40,
+                "judgement": "n/a",
+                "summary": "n/a",
+            }
+        )
+    )
+
+    with pytest.raises(UnresolvableRevisionError) as excinfo:
+        materialize_corpus_run(case_dir, REPO, tmp_path / "wt")
+
+    assert "999-gate2-run1" in str(excinfo.value)
+
+
+def test_the_worktree_holds_the_tree_as_it_was_not_as_it_is(worktree):
+    """The reason a worktree exists at all.
+
+    `evidence/discovery.py` scans the filesystem for `test_*.py`, not the git
+    revision, so a case pointed at the live repo would discover today's tests
+    against a historical diff. The check is a file this repository has now and
+    did not have at the case's head revision.
+    """
+    case_dir = CASES_DIR / "167-gate2-run3"
+    run = materialize_corpus_run(case_dir, REPO, worktree)
+
+    assert (run.worktree / "tests" / "test_cli.py").is_file()
+    # Added well after 95b880a — its presence would mean we were looking at the
+    # working tree rather than the revision under review.
+    assert not (run.worktree / "src" / "acceptance" / "benchmark" / "corpus.py").exists()
+    assert (REPO / "src" / "acceptance" / "benchmark" / "corpus.py").is_file()
+
+
+def test_the_case_carries_the_task_file_the_run_was_actually_given(worktree):
+    case_dir = CASES_DIR / "167-gate2-run3"
+    case = build_corpus_case(case_dir, REPO, CORPUS_DIR, worktree)
+
+    corpus_task = (CORPUS_DIR / "167-gate2-run3" / "current-task.md").read_text()
+    assert case.inputs.task_text == corpus_task
+    # Read from the corpus, never copied into the case directory — a second
+    # copy could drift from the evidence record.
+    assert not (case_dir / "current-task.md").exists()
+
+
+@pytest.mark.parametrize("case_dir", CASE_DIRS, ids=lambda p: p.name)
+def test_every_case_is_traceable_to_the_judgement_it_came_from(case_dir):
+    meta = load_corpus_meta(case_dir)
+    judgement = CORPUS_DIR / meta.corpus_run / "judgement.md"
+    assert judgement.is_file()
+    assert meta.corpus_run in meta.judgement or "judgement.md" in meta.judgement
+
+
+@pytest.mark.parametrize("case_dir", CASE_DIRS, ids=lambda p: p.name)
+def test_every_case_names_a_corpus_run_that_exists(case_dir):
+    meta = load_corpus_meta(case_dir)
+    run = CORPUS_DIR / meta.corpus_run
+    assert (run / "current-task.md").is_file()
+    assert (run / "check-output.log").is_file()
+
+
+# The both-directions property is asserted over the case SET in
+# `test_rating_regression.py`, not per case. Two cases — `167-gate2-run5` and
+# the `163-gate2-run1` control — are legitimately all-strong, so a per-case
+# version would have forced a label the corpus does not support.

--- a/tests/benchmark/test_corpus.py
+++ b/tests/benchmark/test_corpus.py
@@ -121,3 +121,24 @@ def test_every_case_names_a_corpus_run_that_exists(case_dir):
 # `test_rating_regression.py`, not per case. Two cases — `167-gate2-run5` and
 # the `163-gate2-run1` control — are legitimately all-strong, so a per-case
 # version would have forced a label the corpus does not support.
+
+
+@pytest.mark.parametrize("case_dir", CASE_DIRS, ids=lambda p: p.name)
+def test_every_head_revision_is_kept_alive_by_a_tag(case_dir):
+    """Every corpus head was squash-merged, so none is reachable from `main`.
+    The `corpus/*` tags are the only thing keeping those objects alive — delete
+    one and a fresh clone loses the case entirely.
+
+    CI found this the direct way: a working copy had the objects because it had
+    the original branch, and the runner did not.
+    """
+    import subprocess
+
+    meta = load_corpus_meta(case_dir)
+    tag = f"corpus/{meta.corpus_run}"
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"{tag}^{{commit}}"],
+        cwd=REPO, capture_output=True, text=True, check=False,
+    )
+    assert result.returncode == 0, f"{tag} is missing; {meta.corpus_run} will not survive a clone"
+    assert result.stdout.strip().startswith(meta.head_revision)

--- a/tests/benchmark/test_rating_regression.py
+++ b/tests/benchmark/test_rating_regression.py
@@ -410,3 +410,83 @@ def test_the_labels_still_show_the_instability_rather_than_smoothing_it():
     moved = {o: c for o, c in by_obligation.items() if len(c) > 1}
     assert len(moved) >= 5, f"only {len(moved)} obligations disagree across runs"
     assert "remove-stale-next-instruction-file" in moved
+
+
+def test_each_case_is_scored_through_score_case_itself(corpus_worktrees):
+    """`score_case_set` aggregates via `_all_counts` and never calls
+    `score_case`, so asserting the set-level entrypoint alone left the stated
+    constraint — cases are scored through `score_case` — satisfied only in
+    spirit. This scores every case through `score_case` directly and requires
+    the two paths to agree, so a private scorer cannot diverge unnoticed.
+    """
+    import acceptance.benchmark.scoring as scoring
+
+    scored, seen = [], []
+    real = scoring.score_case
+
+    def spy(case, client=None):
+        seen.append(case.case_id)
+        return real(case, client)
+
+    for index, case_dir in enumerate(CASE_DIRS):
+        case = build_corpus_case(case_dir, REPO, CORPUS_DIR, corpus_worktrees / f"wt{index}")
+        obligations = [
+            {"id": o["id"], "description": o["description"]}
+            for o in _labels(case_dir)["obligations"]
+        ]
+        scored.append(classify_case(case, degenerate_client(obligations, always_strong=True)))
+
+    per_case = [spy(case) for case in scored]
+    assert seen == [c.case_id for c in scored]
+    assert per_case == score_case_set(scored).per_case
+
+
+def test_no_provider_is_ever_contacted(corpus_worktrees, monkeypatch):
+    """The stronger form of "no live call": make the provider entrypoint itself
+    fail. `llm._default_completion_fn` calls `litellm.completion`, so a stage
+    that slipped past the injected stub would raise here instead of quietly
+    reaching the network."""
+    import litellm
+
+    def explode(*args, **kwargs):
+        raise AssertionError("a live provider call was attempted")
+
+    monkeypatch.setattr(litellm, "completion", explode)
+
+    case = build_corpus_case(CASE_DIRS[0], REPO, CORPUS_DIR, corpus_worktrees / "wt0")
+    obligations = [
+        {"id": o["id"], "description": o["description"]}
+        for o in _labels(CASE_DIRS[0])["obligations"]
+    ]
+    scored = classify_case(case, degenerate_client(obligations, always_strong=True))
+    assert scored.reviewer_output is not None
+
+
+# The one sanctioned transcript corpus: #146's recorded prompt-quality fixtures.
+# It predates this task and is deliberately committed; everything else under
+# tests/fixtures/ must stay transcript-free.
+SANCTIONED_TRANSCRIPTS = REPO / "tests" / "fixtures" / "transcripts"
+
+
+def test_no_transcript_lives_anywhere_under_the_fixture_tree():
+    """Wider than the two case directories, because the stated defect is a
+    transcript stored *elsewhere* in the repository. A transcript embeds the
+    full request, so one committed here would leak this repo's own diffs and
+    task text into versioned test data."""
+    fixtures = REPO / "tests" / "fixtures"
+    suspects = []
+    for path in fixtures.rglob("*"):
+        if not path.is_file() or SANCTIONED_TRANSCRIPTS in path.parents:
+            continue
+        if path.suffix not in {".json", ".jsonl", ".txt", ".md", ".log"}:
+            continue
+        head = path.read_text(errors="ignore")[:4000]
+        if '"response"' in head and '"messages"' in head:
+            suspects.append(str(path.relative_to(REPO)))
+    assert not suspects, f"transcript-like files outside the sanctioned corpus: {suspects}"
+
+
+def test_this_task_added_nothing_to_the_sanctioned_transcript_corpus():
+    """#146's corpus is for prompt-quality tests recorded against archetypes,
+    never against this repository's own dogfood runs."""
+    assert len(list(SANCTIONED_TRANSCRIPTS.glob("*.json"))) == 3

--- a/tests/benchmark/test_rating_regression.py
+++ b/tests/benchmark/test_rating_regression.py
@@ -183,3 +183,230 @@ def test_the_two_degenerate_judges_disagree_about_the_ratings(corpus_worktrees):
     permissive = _score_with(always_strong=True, tmp_path=corpus_worktrees / "a")
     pessimistic = _score_with(always_strong=False, tmp_path=corpus_worktrees / "b")
     assert permissive.evidence_agreement != pessimistic.evidence_agreement
+
+
+# --------------------------------------------------------------------------
+# The task's own requirements
+#
+# Gate 2 rated all of the following `unsupported` — no mapped test at all — and
+# the mapping audit for that run came back 100% populated with zero foreign
+# ids, so the finding was the review being right rather than half-blind. These
+# are the assertions that were missing.
+# --------------------------------------------------------------------------
+
+CORPUS_RUN_FILES = {"current-task.md", "check-output.log", "judgement.md"}
+
+
+def test_scoring_goes_through_the_shared_benchmark_path(monkeypatch, corpus_worktrees):
+    """The suite must score through `benchmark/scoring.py`, not a private copy.
+
+    A second scoring implementation would drift from the canonical one exactly
+    the way the CLI and benchmark pipelines drifted before M7.4 — and the
+    divergence would be invisible, because both would keep returning numbers.
+    """
+    import acceptance.benchmark.scoring as scoring
+
+    calls = []
+    real = scoring.score_case_set
+
+    def tracking(cases, client=None):
+        calls.append(len(cases))
+        return real(cases, client)
+
+    monkeypatch.setattr(scoring, "score_case_set", tracking)
+    # Patch THIS module's global, via globals() rather than by importing the
+    # module by name: pytest may import it under a different name, in which
+    # case `import tests.benchmark.test_rating_regression` yields a second
+    # module object and patching it leaves the name `_score_with` resolves
+    # untouched — the test then passes an empty call list forever.
+    monkeypatch.setitem(globals(), "score_case_set", tracking)
+
+    report = _score_with(always_strong=True, tmp_path=corpus_worktrees)
+
+    assert calls == [len(CASE_DIRS)]
+    assert report.evidence_agreement is not None
+
+
+def test_no_case_issues_a_live_model_call(corpus_worktrees, monkeypatch):
+    """Every model call is served by the injected stub, so the suite cannot
+    reach a provider. Asserted by counting: a call that bypassed the stub would
+    leave the count below the number of pipeline stages."""
+    seen: list[str] = []
+    case = build_corpus_case(CASE_DIRS[0], REPO, CORPUS_DIR, corpus_worktrees / "wt0")
+    obligations = [
+        {"id": o["id"], "description": o["description"]}
+        for o in _labels(CASE_DIRS[0])["obligations"]
+    ]
+    client = degenerate_client(obligations, always_strong=True)
+    inner = client._completion_fn
+
+    def counting(**kwargs):
+        seen.append(kwargs["response_format"]["json_schema"]["name"])
+        return inner(**kwargs)
+
+    # The injected stub is the only thing standing between the pipeline and a
+    # provider, so wrapping it is how "no live call" becomes observable.
+    monkeypatch.setattr(client, "_completion_fn", counting)
+    classify_case(case, client)
+
+    assert "_Decomposition" in seen and "_Mappings" in seen
+    assert "_Discrimination" in seen or "_Coverage" in seen
+
+
+def test_no_model_transcript_is_committed_into_the_fixtures():
+    """A transcript embeds the full request, so committing one here would put
+    this repository's own diffs and task text into `tests/fixtures/` — the thing
+    the corpus avoided by storing rendered reports."""
+    for case_dir in CASE_DIRS:
+        assert {p.name for p in case_dir.iterdir()} == {"case.json", "labels.json"}
+    for run in CORPUS_DIR.iterdir():
+        if run.is_dir():
+            assert {p.name for p in run.iterdir()} <= CORPUS_RUN_FILES
+
+
+def test_the_corpus_itself_is_untouched_apart_from_its_readme():
+    """The corpus is the evidence record these assertions derive from. Editing
+    it to suit a test would destroy the thing being tested against."""
+    assert (CORPUS_DIR / "README.md").is_file()
+    assert (CORPUS_DIR / "revisions.txt").is_file()
+    for run in sorted(p for p in CORPUS_DIR.iterdir() if p.is_dir()):
+        assert {p.name for p in run.iterdir()} == CORPUS_RUN_FILES, run.name
+
+
+def test_the_scoreboard_is_committed_as_fixtures_for_every_run():
+    """All six runs, committed — not generated at test time, where a case could
+    quietly stop existing."""
+    import subprocess
+
+    tracked = subprocess.run(
+        ["git", "ls-files", "tests/fixtures/rating-regression"],
+        cwd=REPO, capture_output=True, text=True, check=True,
+    ).stdout.split()
+    runs = {Path(p).parent.name for p in tracked}
+    assert runs == {p.name for p in CASE_DIRS}
+    assert len(runs) == 6
+    for case_dir in CASE_DIRS:
+        for name in ("case.json", "labels.json"):
+            assert f"tests/fixtures/rating-regression/{case_dir.name}/{name}" in tracked
+
+
+def _tree_digest(root: Path) -> dict[str, str]:
+    import hashlib
+
+    return {
+        str(p.relative_to(root)): hashlib.sha256(p.read_bytes()).hexdigest()
+        for p in sorted(root.rglob("*"))
+        if p.is_file() and "__pycache__" not in p.parts
+    }
+
+
+def test_running_the_suite_does_not_alter_the_judgement_stage(corpus_worktrees):
+    """This task builds the scoreboard; the judgement stage is untouched.
+
+    Asserted by running a case and digesting the stage's source either side,
+    rather than by grepping this file for import names — a source grep matches
+    the very string the assertion is written with, so it can only ever be
+    self-referential.
+    """
+    stage = REPO / "src" / "acceptance" / "evidence"
+    coverage_stage = REPO / "src" / "acceptance" / "coverage"
+    before = (_tree_digest(stage), _tree_digest(coverage_stage))
+
+    case = build_corpus_case(CASE_DIRS[0], REPO, CORPUS_DIR, corpus_worktrees / "wt0")
+    obligations = [
+        {"id": o["id"], "description": o["description"]}
+        for o in _labels(CASE_DIRS[0])["obligations"]
+    ]
+    classify_case(case, degenerate_client(obligations, always_strong=True))
+
+    assert (_tree_digest(stage), _tree_digest(coverage_stage)) == before
+
+
+def test_the_decompose_stability_corpus_gains_no_regression_artifacts():
+    """A separate task (#195). This one must not seed cases there — the give-away
+    would be `case.json`/`labels.json` appearing in a corpus that holds only
+    dogfood-run prose."""
+    other = REPO / "tests" / "fixtures" / "decompose-stability"
+    if not other.exists():
+        pytest.skip("decompose-stability corpus not present")
+    names = {p.name for p in other.rglob("*") if p.is_file()}
+    assert not names & {"case.json", "labels.json"}
+    # And this suite reads only from its own corpus.
+    assert CORPUS_DIR.name == "rating-stability"
+    assert other not in CORPUS_DIR.parents and other != CORPUS_DIR
+
+
+def test_cases_carry_only_their_run_input_not_resumed_state(corpus_worktrees):
+    """Runs 2 and 3 were incremental re-runs (M7.5) resuming stored review
+    state. A case supplies the run's *input*; restoring what it resumed from is
+    out of scope, so nothing here may carry it in."""
+    case = build_corpus_case(
+        CASES_DIR / "167-gate2-run2", REPO, CORPUS_DIR, corpus_worktrees / "wt0"
+    )
+    assert case.inputs.declaration_text is None
+    assert case.reviewer_output is None
+    assert case.score is None
+    # The worktree is a checkout of the revision alone — no carried-over review.
+    assert not (Path(case.inputs.repo) / ".acceptance").exists()
+
+
+def test_the_readme_states_what_is_and_is_not_read():
+    readme = (CORPUS_DIR / "README.md").read_text()
+    assert "Not currently read by any test" not in readme
+    assert "test_rating_regression.py" in readme
+    # The honest half: the judgements are transcribed by hand, not parsed.
+    assert "judgement.md" in readme
+
+
+# --- The two rewritten judgements ------------------------------------------
+#
+# Runs 3 and 5 preserve both the original and the corrected reading. The
+# corrected one is ground truth in each, and getting this backwards is the
+# specific failure the corpus exists to prevent: run 3's original reading
+# called all three findings tool defects and would have shipped the silent
+# `--json` deletion.
+
+
+def test_run3_encodes_the_corrected_reading_that_all_three_findings_were_real():
+    meta = json.loads((CASES_DIR / "167-gate2-run3" / "case.json").read_text())
+    assert "REWRITTEN" in meta["judgement"]
+    assert "corrected reading is ground truth" in meta["judgement"]
+
+    classes = _classes(CASES_DIR / "167-gate2-run3")
+    gaps = {g["obligation_id"] for g in _labels(CASES_DIR / "167-gate2-run3")["gaps"]}
+    for obligation in (
+        "remove-stale-next-instruction-file",
+        "no-speculative-writing",
+        "spec-no-longer-describes-written-file",
+    ):
+        assert classes[obligation] != "strongly_supported"
+        assert obligation in gaps, f"{obligation} must be a real gap, not a tool defect"
+
+
+def test_run5_encodes_the_corrected_reading_that_run4s_strong_was_right():
+    meta = json.loads((CASES_DIR / "167-gate2-run5" / "case.json").read_text())
+    assert "REWRITTEN" in meta["judgement"]
+
+    # Run 5's own output said `partially supported`; the rewritten judgement
+    # calls that a wrong M5.2 verdict and run 4's `strongly supported` correct.
+    assert _classes(CASES_DIR / "167-gate2-run5")["replace-written-file-with-command"] == (
+        "strongly_supported"
+    )
+    assert _classes(CASES_DIR / "167-gate2-run4")["replace-written-file-with-command"] == (
+        "strongly_supported"
+    )
+    assert not _labels(CASES_DIR / "167-gate2-run5")["gaps"]
+
+
+def test_the_labels_still_show_the_instability_rather_than_smoothing_it():
+    """This task measures the instability; it does not reduce it. If every run
+    carried the same class for the same obligation, the corpus's central
+    finding would have been normalised away by the act of encoding it."""
+    by_obligation: dict[str, set[str]] = {}
+    for case_dir in CASE_DIRS:
+        for oid, klass in _classes(case_dir).items():
+            by_obligation.setdefault(oid, set()).add(klass)
+
+    moved = {o: c for o, c in by_obligation.items() if len(c) > 1}
+    assert len(moved) >= 5, f"only {len(moved)} obligations disagree across runs"
+    assert "remove-stale-next-instruction-file" in moved

--- a/tests/benchmark/test_rating_regression.py
+++ b/tests/benchmark/test_rating_regression.py
@@ -1,0 +1,185 @@
+"""#190: the rating-stability corpus as an executable regression suite.
+
+DR-180's load-bearing criterion — `strongly supported` is not issued on evidence
+that does not earn it — had no scoreboard. Every candidate fix to the
+evidence-judgement stage was accepted or rejected by eyeball. These are the
+assertions that replace the eyeball.
+
+The suite must fail in both directions. A judge that rates everything strongly
+supported must fail it, and so must a judge that rates nothing strongly
+supported, because "stop moving" is a fix that passes a one-directional suite
+while losing all seven real gaps the corpus records.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from acceptance.benchmark.corpus import (
+    build_corpus_case,
+    load_labels,
+    remove_corpus_worktree,
+)
+from acceptance.benchmark.coverage import classify_case
+from acceptance.benchmark.scoring import score_case_set
+from tests.benchmark.degenerate_judges import degenerate_client
+
+REPO = Path(__file__).resolve().parents[2]
+CASES_DIR = REPO / "tests" / "fixtures" / "rating-regression"
+CORPUS_DIR = REPO / "tests" / "fixtures" / "rating-stability"
+CASE_DIRS = sorted(p for p in CASES_DIR.iterdir() if p.is_dir())
+
+# The corpus's own ground-truth tables, restated as (run, obligation) pairs so a
+# label silently dropped from a fixture fails here rather than shrinking the
+# suite. Transcribed from the tables in #190 and `current-task.md`.
+UNEARNED_STRONG = {
+    ("167-gate2-run1", "default-to-most-recent-review"),
+    ("167-gate2-run1", "no-speculative-writing"),
+    ("167-gate2-run1", "remove-stale-next-instruction-file"),
+    ("167-gate2-run1", "spec-no-longer-describes-written-file"),
+    ("167-gate2-run1", "retrieve-from-stored-review-state"),
+    ("167-gate2-run2", "no-speculative-writing"),
+    ("167-gate2-run2", "remove-stale-next-instruction-file"),
+}
+
+REAL_GAPS = {
+    ("167-gate2-run1", "fixed-command-surface"),
+    ("167-gate2-run1", "replace-written-file-with-command"),  # partly real
+    ("167-gate2-run2", "default-to-most-recent-review"),
+    ("167-gate2-run2", "retrieve-from-stored-review-state"),
+    ("167-gate2-run3", "remove-stale-next-instruction-file"),  # the silent --json deletion
+    ("167-gate2-run3", "no-speculative-writing"),
+    ("167-gate2-run3", "spec-no-longer-describes-written-file"),
+    ("167-gate2-run4", "preserve-prose-structured-fields"),
+}
+
+
+@pytest.fixture
+def corpus_worktrees(tmp_path):
+    """A root for materialized worktrees, deregistered from the main repo after.
+
+    Worktree registration lives in this repository's `.git`, so deleting
+    tmp_path alone would leave stale entries accumulating across runs.
+    """
+    yield tmp_path
+    for path in sorted(tmp_path.rglob("wt*")):
+        if path.is_dir():
+            remove_corpus_worktree(REPO, path)
+
+
+def _labels(case_dir: Path) -> dict:
+    return json.loads((case_dir / "labels.json").read_text())
+
+
+def _classes(case_dir: Path) -> dict[str, str]:
+    return {o["id"]: o["evidence_class"] for o in _labels(case_dir)["obligations"]}
+
+
+# --------------------------------------------------------------------------
+# The ground truth is encoded at all
+# --------------------------------------------------------------------------
+
+
+def test_every_unearned_rating_is_required_to_no_longer_be_issued():
+    """Each rating the corpus records as unearned is labelled as something
+    other than `strongly supported`, so a judge that reissues it disagrees."""
+    for run, obligation in sorted(UNEARNED_STRONG):
+        klass = _classes(CASES_DIR / run)[obligation]
+        assert klass != "strongly_supported", f"{run}/{obligation} is labelled {klass}"
+
+
+def test_every_real_gap_is_required_to_still_be_reported():
+    """Each gap the corpus confirms was real is a ground-truth gap, so a fix
+    that blunts it away loses gap recall rather than passing quietly."""
+    for run, obligation in sorted(REAL_GAPS):
+        gaps = {g["obligation_id"] for g in _labels(CASES_DIR / run)["gaps"]}
+        assert obligation in gaps, f"{run} has no ground-truth gap for {obligation}"
+
+
+@pytest.mark.parametrize("case_dir", CASE_DIRS, ids=lambda p: p.name)
+def test_labels_load_against_the_shared_ground_truth_schema(case_dir):
+    """Cases use `GroundTruthLabels`, not a shape invented for this task — so
+    its validators (unique ids, resolvable gap links, no unexplained result)
+    apply here too."""
+    labels = load_labels(case_dir)
+    assert labels.obligations
+    assert all(o.evidence_rationale.strip() for o in labels.obligations)
+
+
+# --------------------------------------------------------------------------
+# Both directions
+# --------------------------------------------------------------------------
+
+
+def test_the_case_set_can_catch_a_judge_erring_either_way():
+    """Both-directions is a property of the case MIX, not of new scoring code.
+
+    `evidence_agreement` is recall over (description, evidence_class) pairs, so a
+    judge that always says `strongly_supported` can only match obligations whose
+    ground truth is that, and one that never says it can only match the rest. A
+    set holding just one kind would let one degenerate judge through.
+    """
+    everything = [klass for d in CASE_DIRS for klass in _classes(d).values()]
+    assert "strongly_supported" in everything
+    assert [k for k in everything if k != "strongly_supported"]
+
+
+@pytest.mark.parametrize("case_dir", CASE_DIRS, ids=lambda p: p.name)
+def test_no_case_passes_trivially(case_dir):
+    """Every case has to be able to fail something.
+
+    `163-gate2-run1` is the one this exists for. It is a clean run kept as a
+    control, so it has no gaps and no sub-strong ratings — and the issue warns
+    against letting it become the case that passes trivially. Its bite is the
+    other direction: with zero ground-truth gaps, a judge that flags anything
+    here loses gap *precision*.
+    """
+    labels = _labels(case_dir)
+    classes = set(_classes(case_dir).values())
+    catches_permissive = bool(classes - {"strongly_supported"}) or bool(labels["gaps"])
+    catches_pessimistic = "strongly_supported" in classes or not labels["gaps"]
+    assert catches_permissive or catches_pessimistic
+
+
+def _score_with(always_strong: bool, tmp_path):
+    cases = []
+    for index, case_dir in enumerate(CASE_DIRS):
+        case = build_corpus_case(case_dir, REPO, CORPUS_DIR, tmp_path / f"wt{index}")
+        obligations = [
+            {"id": o["id"], "description": o["description"]}
+            for o in _labels(case_dir)["obligations"]
+        ]
+        client = degenerate_client(obligations, always_strong=always_strong)
+        cases.append(classify_case(case, client))
+    return score_case_set(cases)
+
+
+def test_a_judge_that_always_issues_strongly_supported_fails_the_suite(corpus_worktrees):
+    report = _score_with(always_strong=True, tmp_path=corpus_worktrees)
+    # It agrees on the genuinely-strong obligations and on nothing else, so it
+    # cannot reach full agreement...
+    assert report.evidence_agreement < 1.0
+    # ...and having found nothing wrong, it reports none of the real gaps.
+    assert report.gap_recall < 1.0
+
+
+def test_a_judge_that_never_issues_strongly_supported_fails_the_suite(corpus_worktrees):
+    report = _score_with(always_strong=False, tmp_path=corpus_worktrees)
+    assert report.evidence_agreement < 1.0
+    # Absence of false STRONGs is explicitly not sufficient on its own (#190):
+    # flagging everything costs precision even where recall looks healthy.
+    assert report.gap_precision < 1.0
+
+
+def test_the_two_degenerate_judges_disagree_about_the_ratings(corpus_worktrees):
+    """Guards the harness rather than the judge.
+
+    If the stub's verdict never reached `strength.py`, both judges would score
+    identically and the two tests above would pass for the wrong reason — the
+    'helper the pipeline never actually calls' hole that defect injection keeps
+    finding here.
+    """
+    permissive = _score_with(always_strong=True, tmp_path=corpus_worktrees / "a")
+    pessimistic = _score_with(always_strong=False, tmp_path=corpus_worktrees / "b")
+    assert permissive.evidence_agreement != pessimistic.evidence_agreement

--- a/tests/fixtures/rating-regression/163-gate2-run1/case.json
+++ b/tests/fixtures/rating-regression/163-gate2-run1/case.json
@@ -1,0 +1,7 @@
+{
+  "corpus_run": "163-gate2-run1",
+  "base_revision": "4d13ba1",
+  "head_revision": "41cd0da",
+  "judgement": "tests/fixtures/rating-stability/163-gate2-run1/judgement.md \u2014 a clean run, all ten obligations addressed and strongly supported, open question resolved, no recommended tests.",
+  "summary": "The negative control. It carries no gaps at all, which is exactly what makes it bite: a pessimistic judge that flags obligations here has nothing to match against and loses gap precision. Kept as a control because one clean run is not evidence of stability \u2014 it was never re-run."
+}

--- a/tests/fixtures/rating-regression/163-gate2-run1/labels.json
+++ b/tests/fixtures/rating-regression/163-gate2-run1/labels.json
@@ -1,0 +1,179 @@
+{
+  "obligations": [
+    {
+      "id": "constrain-echoed-ids",
+      "description": "Each model stage that echoes back a supplied id constrains that response field to the ids supplied for that call.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/coverage/test_recommendations.py::test_weak_criterion_gets_a_fully_populated_recommendation",
+        "tests/evidence/test_discrimination.py::test_a_caught_defect_makes_the_criterion_discriminating",
+        "tests/evidence/test_discrimination.py::test_discriminating_is_true_if_any_defect_is_caught",
+        "tests/evidence/test_discrimination.py::test_non_discriminating_input_is_judged_non_discriminating_with_a_reason",
+        "tests/evidence/test_mapping.py::test_a_batch_may_not_answer_for_a_test_outside_it",
+        "tests/evidence/test_mapping.py::test_a_test_can_map_to_multiple_obligations",
+        "tests/evidence/test_mapping.py::test_unknown_ids_are_dropped",
+        "tests/test_llm.py::test_the_schema_sent_to_the_provider_has_no_ref_indirection",
+        "tests/test_supplied_ids.py::test_a_foreign_id_does_not_validate_against_the_constrained_schema",
+        "tests/test_supplied_ids.py::test_a_list_valued_id_field_constrains_its_items",
+        "tests/test_supplied_ids.py::test_a_single_supplied_id_is_still_sent_as_an_enum",
+        "tests/test_supplied_ids.py::test_each_partition_constrains_test_ids_to_its_own_batch",
+        "tests/test_supplied_ids.py::test_supplied_ids_become_an_enum_on_the_field_the_model_sees",
+        "tests/test_supplied_ids.py::test_the_schema_asked_for_differs_from_the_shape_parsed"
+      ]
+    },
+    {
+      "id": "allowed-set-from-supplied-ids",
+      "description": "The allowed-id set for a call is built from the ids that call itself supplied.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/coverage/test_recommendations.py::test_weak_criterion_gets_a_fully_populated_recommendation",
+        "tests/evidence/test_discrimination.py::test_a_caught_defect_makes_the_criterion_discriminating",
+        "tests/evidence/test_discrimination.py::test_discriminating_is_true_if_any_defect_is_caught",
+        "tests/evidence/test_discrimination.py::test_non_discriminating_input_is_judged_non_discriminating_with_a_reason",
+        "tests/evidence/test_mapping.py::test_a_batch_may_not_answer_for_a_test_outside_it",
+        "tests/evidence/test_mapping.py::test_a_test_can_map_to_multiple_obligations",
+        "tests/evidence/test_mapping.py::test_unknown_ids_are_dropped",
+        "tests/test_rerun.py::test_only_the_affected_obligation_is_re_derived",
+        "tests/test_supplied_ids.py::test_an_empty_supplied_set_leaves_the_field_unconstrained"
+      ]
+    },
+    {
+      "id": "reject-foreign-id",
+      "description": "An id outside the supplied set is never accepted as a judgment about anything.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/coverage/test_open_questions.py::test_unknown_question_id_in_response_is_dropped",
+        "tests/coverage/test_unrequested.py::test_change_the_model_judges_requested_is_not_emitted",
+        "tests/evidence/test_discrimination.py::test_a_caught_defect_makes_the_criterion_discriminating",
+        "tests/evidence/test_discrimination.py::test_discriminating_is_true_if_any_defect_is_caught",
+        "tests/evidence/test_discrimination.py::test_non_discriminating_input_is_judged_non_discriminating_with_a_reason",
+        "tests/evidence/test_mapping.py::test_a_batch_may_not_answer_for_a_test_outside_it",
+        "tests/evidence/test_mapping.py::test_a_test_can_map_to_multiple_obligations",
+        "tests/evidence/test_mapping.py::test_unknown_ids_are_dropped",
+        "tests/test_supplied_ids.py::test_a_foreign_id_does_not_validate_against_the_constrained_schema",
+        "tests/test_supplied_ids.py::test_a_foreign_obligation_id_is_recorded_not_silently_dropped",
+        "tests/test_supplied_ids.py::test_a_usable_judgment_survives_an_unusable_one_in_the_same_response",
+        "tests/test_supplied_ids.py::test_scan_finds_ids_that_were_never_supplied",
+        "tests/test_supplied_ids.py::test_scan_reports_each_unusable_id_once",
+        "tests/test_supplied_ids.py::test_the_schema_asked_for_differs_from_the_shape_parsed"
+      ]
+    },
+    {
+      "id": "record-as-answer-not-obtained",
+      "description": "An answer that could not be honoured is recorded as an answer not obtained rather than as a negative judgment.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/prompts/test_corpus_mechanism.py::test_a_recorded_call_completed_against_a_provider_that_rejects_our_controls",
+        "tests/test_config.py::test_provenance_reports_the_controls_the_provider_honoured",
+        "tests/test_supplied_ids.py::test_a_clean_mapping_records_nothing_and_keeps_its_negative_answers",
+        "tests/test_supplied_ids.py::test_a_foreign_obligation_id_is_recorded_not_silently_dropped",
+        "tests/test_supplied_ids.py::test_a_usable_judgment_survives_an_unusable_one_in_the_same_response",
+        "tests/test_supplied_ids.py::test_the_pipeline_reports_an_unusable_answer_naming_the_stage_and_the_id"
+      ]
+    },
+    {
+      "id": "unhonored-is-not-a-negative-answer",
+      "description": "An answer that could not be honoured does not read as a substantive negative answer.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/prompts/test_corpus_mechanism.py::test_a_recorded_call_completed_against_a_provider_that_rejects_our_controls",
+        "tests/test_config.py::test_provenance_reports_the_controls_the_provider_honoured",
+        "tests/test_supplied_ids.py::test_a_clean_mapping_records_nothing_and_keeps_its_negative_answers",
+        "tests/test_supplied_ids.py::test_an_obligation_is_indeterminate_not_unmapped_when_an_answer_was_unusable",
+        "tests/test_supplied_ids.py::test_the_pipeline_reports_an_unusable_answer_naming_the_stage_and_the_id"
+      ]
+    },
+    {
+      "id": "retain-usable-judgments",
+      "description": "Usable judgments returned alongside an unhonored answer are retained.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/evidence/test_discrimination.py::test_an_obligation_the_model_omits_is_conservatively_non_discriminating",
+        "tests/evidence/test_mapping.py::test_the_per_call_results_are_merged",
+        "tests/test_rerun.py::test_a_rerun_still_reports_a_gap_in_code_the_new_work_never_touched",
+        "tests/test_supplied_ids.py::test_a_usable_judgment_survives_an_unusable_one_in_the_same_response"
+      ]
+    },
+    {
+      "id": "partitioned-calls-constrain-their-own-ids",
+      "description": "When a stage request is partitioned, each call constrains its response to the ids in its own partition.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/evidence/test_mapping.py::test_a_batch_may_not_answer_for_a_test_outside_it",
+        "tests/evidence/test_mapping.py::test_changing_the_batch_size_changes_every_request_key",
+        "tests/evidence/test_mapping.py::test_each_batch_is_recorded_as_its_own_request",
+        "tests/evidence/test_mapping.py::test_every_test_is_judged_against_every_obligation_across_the_calls",
+        "tests/evidence/test_mapping.py::test_repeating_a_run_reuses_the_recorded_batches",
+        "tests/evidence/test_mapping.py::test_the_per_call_results_are_merged",
+        "tests/evidence/test_mapping.py::test_the_tests_are_split_across_several_calls",
+        "tests/test_config.py::test_provenance_of_an_unpartitioned_run_reports_no_partition_size",
+        "tests/test_config.py::test_provenance_reports_the_partition_size_the_run_actually_used",
+        "tests/test_rerun.py::test_only_the_affected_obligation_is_re_derived",
+        "tests/test_supplied_ids.py::test_each_partition_constrains_test_ids_to_its_own_batch"
+      ]
+    },
+    {
+      "id": "unhonored-leaves-indeterminate",
+      "description": "An obligation whose judgment could not be honoured is left indeterminate rather than reported as lacking evidence.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/evidence/test_discrimination.py::test_an_obligation_the_model_omits_is_conservatively_non_discriminating",
+        "tests/test_config.py::test_provenance_of_a_run_that_made_no_model_call_is_indeterminate",
+        "tests/test_rerun.py::test_a_rerun_still_reports_a_gap_in_code_the_new_work_never_touched",
+        "tests/test_supplied_ids.py::test_an_obligation_is_indeterminate_not_unmapped_when_an_answer_was_unusable",
+        "tests/test_supplied_ids.py::test_an_unusable_answer_leaves_the_obligation_indeterminate",
+        "tests/test_verdict.py::test_coverage_gap_is_incomplete",
+        "tests/test_verdict.py::test_unresolved_open_question_blocks_positive_and_needs_clarification"
+      ]
+    },
+    {
+      "id": "indeterminate-blocks-clean-verdict",
+      "description": "A review holding an indeterminate judgment does not reach a clean completion verdict.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/evidence/test_discrimination.py::test_an_obligation_the_model_omits_is_conservatively_non_discriminating",
+        "tests/test_config.py::test_provenance_of_a_run_that_made_no_model_call_is_indeterminate",
+        "tests/test_rerun.py::test_a_rerun_still_reports_a_gap_in_code_the_new_work_never_touched",
+        "tests/test_supplied_ids.py::test_a_review_holding_an_unusable_answer_does_not_come_back_clean",
+        "tests/test_verdict.py::test_coverage_gap_is_incomplete",
+        "tests/test_verdict.py::test_unresolved_open_question_blocks_positive_and_needs_clarification"
+      ]
+    },
+    {
+      "id": "name-the-stage-and-id",
+      "description": "The review names the stage and the id that could not be honoured.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/prompts/test_corpus_mechanism.py::test_a_recorded_call_completed_against_a_provider_that_rejects_our_controls",
+        "tests/test_report.py::test_unresolved_open_questions_lead_the_instruction",
+        "tests/test_supplied_ids.py::test_a_foreign_obligation_id_is_recorded_not_silently_dropped",
+        "tests/test_supplied_ids.py::test_a_usable_judgment_survives_an_unusable_one_in_the_same_response",
+        "tests/test_supplied_ids.py::test_an_obligation_is_indeterminate_not_unmapped_when_an_answer_was_unusable",
+        "tests/test_supplied_ids.py::test_scan_finds_ids_that_were_never_supplied",
+        "tests/test_supplied_ids.py::test_scan_reports_each_unusable_id_once",
+        "tests/test_supplied_ids.py::test_the_pipeline_reports_an_unusable_answer_naming_the_stage_and_the_id"
+      ]
+    }
+  ],
+  "gaps": []
+}

--- a/tests/fixtures/rating-regression/167-gate2-run1/case.json
+++ b/tests/fixtures/rating-regression/167-gate2-run1/case.json
@@ -1,0 +1,7 @@
+{
+  "corpus_run": "167-gate2-run1",
+  "base_revision": "839ea47",
+  "head_revision": "07075a6",
+  "judgement": "tests/fixtures/rating-stability/167-gate2-run1/judgement.md, including the retrospective added after run 3, which records that this run's strongly supported for default-to-most-recent-review was a false negative \u2014 the rating was wrong, not merely unstable.",
+  "summary": "The first #167 Gate 2 run. Two obligations were flagged and both findings were real; five more carried strongly supported ratings the corpus later established were unearned, making this the run with the most false negatives."
+}

--- a/tests/fixtures/rating-regression/167-gate2-run1/labels.json
+++ b/tests/fixtures/rating-regression/167-gate2-run1/labels.json
@@ -1,0 +1,190 @@
+{
+  "obligations": [
+    {
+      "id": "replace-written-file-with-command",
+      "description": "Replace the written file `.acceptance/next-instruction.md` with the `acceptance recommendation --criterion <id> [--format json|text]` command surface for retrieving a criterion's recommendation on demand, defaulting to JSON.",
+      "explicit": true,
+      "evidence_class": "unsupported",
+      "evidence_rationale": "PARTLY REAL (judgement.md, run 1). A compound umbrella obligation whose constituents the other eleven cover individually \u2014 a #144-shaped decomposition artifact, so the mapper reasonably preferred the specific obligations. But its 'defaulting to JSON' clause appears in no other obligation and was tested only implicitly, by a test that happened to json.loads the output. Only that clause is the real finding.",
+      "candidate_tests": []
+    },
+    {
+      "id": "fixed-command-surface",
+      "description": "Keep the recommendation retrieval command surface fixed to the specified command name and arguments in the specification.",
+      "explicit": true,
+      "evidence_class": "nominally_supported",
+      "evidence_rationale": "REAL GAP (judgement.md, run 1). #167 fixed the command surface up front precisely so the spec could name it, and nothing pinned the spec string to the parser \u2014 the drift this task exists to prevent. Its two mapped tests are unrelated: mapping noise on top of a genuine gap.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_check_rejects_unknown_mode",
+        "tests/test_cli.py::test_check_requires_all_flags"
+      ]
+    },
+    {
+      "id": "no-speculative-writing",
+      "description": "Ensure recommendation retrieval performs no speculative writes so nothing can go stale.",
+      "explicit": true,
+      "evidence_class": "partially_supported",
+      "evidence_rationale": "UNEARNED STRONG (corpus table; corrected by run 3). Run 1 issued strongly supported on evidence that did not earn it. Run 3 established the real gap: no test snapshots the repo around `recommendation` itself.",
+      "candidate_tests": [
+        "tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo",
+        "tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps"
+      ]
+    },
+    {
+      "id": "retrieve-from-stored-review-state",
+      "description": "Return a recommendation from stored review state on demand without re-running the review.",
+      "explicit": true,
+      "evidence_class": "partially_supported",
+      "evidence_rationale": "UNEARNED STRONG (corpus table; corrected by run 2). Run 2 established the real gap: nothing distinguished 'read stored state' from 'recomputed and happened to agree', and nothing proved the named revision was read.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_recommendation_defaults_to_the_most_recently_stored_review",
+        "tests/test_cli.py::test_recommendation_returns_the_stored_prescription_for_a_criterion",
+        "tests/test_review_store.py::test_rerun_over_the_same_head_overwrites_in_place",
+        "tests/test_review_store.py::test_review_round_trips_through_the_store"
+      ]
+    },
+    {
+      "id": "preserve-prose-structured-fields",
+      "description": "Keep the recommendation's structured fields as discrete keys with their prose values intact.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/benchmark/test_coverage.py::test_the_shared_pipeline_runs_every_stage",
+        "tests/test_cli.py::test_recommendation_returns_the_stored_prescription_for_a_criterion",
+        "tests/test_report.py::test_every_test_evidence_line_shows_a_tier",
+        "tests/test_report.py::test_open_questions_and_recommendations_are_numbered"
+      ]
+    },
+    {
+      "id": "discoverable-retrieval-in-output",
+      "description": "Make the review's own output tell a reader how to obtain the recommendation detail.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps",
+        "tests/test_cli.py::test_render_classify_output",
+        "tests/test_cli.py::test_report_shell_renders_all_sections_present_and_empty",
+        "tests/test_report.py::test_a_carried_forward_obligation_says_so_and_names_the_revision",
+        "tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered"
+      ]
+    },
+    {
+      "id": "remove-stale-next-instruction-file",
+      "description": "Remove any pre-existing `.acceptance/next-instruction.md` left by an earlier version and report that it was removed.",
+      "explicit": true,
+      "evidence_class": "partially_supported",
+      "evidence_rationale": "UNEARNED STRONG (corpus table; corrected by run 3). Runs 1 and 2 both rated this strongly supported while `--json` mode deleted a file in the user's repo and printed nothing.",
+      "candidate_tests": [
+        "tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo",
+        "tests/test_cli.py::test_a_stale_instruction_file_is_removed_and_the_removal_reported",
+        "tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps",
+        "tests/test_cli.py::test_the_removal_leaves_the_report_as_the_only_statement_of_status",
+        "tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered"
+      ]
+    },
+    {
+      "id": "removal-leaves-report-as-only-status",
+      "description": "Leave the review's own output as the only statement of status when starting from a repo that already contains `.acceptance/next-instruction.md`.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo",
+        "tests/test_cli.py::test_a_stale_instruction_file_is_removed_and_the_removal_reported",
+        "tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps",
+        "tests/test_cli.py::test_the_removal_leaves_the_report_as_the_only_statement_of_status",
+        "tests/test_report.py::test_empty_review_renders_the_full_shell",
+        "tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered"
+      ]
+    },
+    {
+      "id": "empty-result-for-missing-recommendation",
+      "description": "Return an empty result when a criterion has no recommendation.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_recommendation_for_an_unknown_criterion_is_empty_not_an_error",
+        "tests/test_review_store.py::test_read_missing_revision_returns_none"
+      ]
+    },
+    {
+      "id": "default-to-most-recent-review",
+      "description": "Default retrieval to the most recently stored review when the caller does not name one.",
+      "explicit": true,
+      "evidence_class": "nominally_supported",
+      "evidence_rationale": "UNEARNED STRONG, stated outright in run 1's own retrospective: 'run 1's STRONG here was a false negative: the rating was wrong, not merely unstable.' Its only test stored a single review, so it could not distinguish 'the newest' from 'the only one' \u2014 a test that did not verify its own name.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_recommendation_defaults_to_the_most_recently_stored_review",
+        "tests/test_review_store.py::test_rerun_over_the_same_head_overwrites_in_place"
+      ]
+    },
+    {
+      "id": "byte-identical-retrievals",
+      "description": "Produce byte-identical output for repeated retrievals over unchanged review state.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_two_retrievals_over_unchanged_state_are_byte_identical",
+        "tests/test_review_store.py::test_rerun_over_the_same_head_overwrites_in_place"
+      ]
+    },
+    {
+      "id": "spec-no-longer-describes-written-file",
+      "description": "Keep the specification from describing the recommendation as a written file.",
+      "explicit": true,
+      "evidence_class": "partially_supported",
+      "evidence_rationale": "UNEARNED STRONG (corpus table; corrected by run 3). The spec still described the recommendation as surfacing in a Markdown file; the test asserted only that one filename was absent.",
+      "candidate_tests": [
+        "tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered"
+      ]
+    }
+  ],
+  "gaps": [
+    {
+      "id": "gap-replace-written-file-with-command-run1",
+      "description": "The defaulting-to-JSON clause is stated in no other obligation and is tested only implicitly, by a test that happens to parse the output as JSON.",
+      "obligation_id": "replace-written-file-with-command",
+      "severity": "high"
+    },
+    {
+      "id": "gap-fixed-command-surface-run1",
+      "description": "Nothing pins the documented command string to the parser, so spec and CLI can drift apart. The two mapped tests are unrelated to the obligation.",
+      "obligation_id": "fixed-command-surface",
+      "severity": "high"
+    },
+    {
+      "id": "gap-no-speculative-writing-run1",
+      "description": "Rated strongly supported although no test snapshots the repo around `recommendation`; the closest test proves no model call, which is strictly weaker than no write.",
+      "obligation_id": "no-speculative-writing",
+      "severity": "medium"
+    },
+    {
+      "id": "gap-retrieve-from-stored-review-state-run1",
+      "description": "Rated strongly supported although nothing distinguishes reading stored state from recomputing and agreeing, and nothing proves the named revision was read.",
+      "obligation_id": "retrieve-from-stored-review-state",
+      "severity": "medium"
+    },
+    {
+      "id": "gap-remove-stale-next-instruction-file-run1",
+      "description": "Rated strongly supported while `--json` mode deleted `.acceptance/next-instruction.md` and printed nothing \u2014 the removal notice sat on the text branch only.",
+      "obligation_id": "remove-stale-next-instruction-file",
+      "severity": "medium"
+    },
+    {
+      "id": "gap-default-to-most-recent-review-run1",
+      "description": "Rated strongly supported although the only test stored a single review, so it could not distinguish 'the newest' from 'the only one'.",
+      "obligation_id": "default-to-most-recent-review",
+      "severity": "high"
+    },
+    {
+      "id": "gap-spec-no-longer-describes-written-file-run1",
+      "description": "Rated strongly supported although the spec still described the recommendation as surfacing in a Markdown file.",
+      "obligation_id": "spec-no-longer-describes-written-file",
+      "severity": "medium"
+    }
+  ]
+}

--- a/tests/fixtures/rating-regression/167-gate2-run2/case.json
+++ b/tests/fixtures/rating-regression/167-gate2-run2/case.json
@@ -1,0 +1,7 @@
+{
+  "corpus_run": "167-gate2-run2",
+  "base_revision": "839ea47",
+  "head_revision": "7de7d71",
+  "judgement": "tests/fixtures/rating-stability/167-gate2-run2/judgement.md, with two corrections from later runs: spec-no-longer-describes-written-file was real (established by run 3) though run 2 called it noise, and byte-identical-retrievals was noise (confirmed when it returned to strongly supported in run 3 with no change).",
+  "summary": "An incremental re-run over a purely additive diff. Four obligations fell, a different four from run 1 \u2014 the observation that started #180. Two of the four were real gaps, one was noise, and one run 2 misjudged as noise."
+}

--- a/tests/fixtures/rating-regression/167-gate2-run2/labels.json
+++ b/tests/fixtures/rating-regression/167-gate2-run2/labels.json
@@ -1,0 +1,181 @@
+{
+  "obligations": [
+    {
+      "id": "replace-written-file-with-command",
+      "description": "Replace the written file `.acceptance/next-instruction.md` with the `acceptance recommendation --criterion <id> [--format json|text]` command surface for retrieving a criterion's recommendation on demand, defaulting to JSON.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps",
+        "tests/test_cli.py::test_json_is_the_default_format_when_none_is_requested"
+      ]
+    },
+    {
+      "id": "fixed-command-surface",
+      "description": "Keep the recommendation retrieval command surface fixed to the specified command name and arguments in the specification.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_a_command_name_the_spec_does_not_document_is_rejected",
+        "tests/test_cli.py::test_an_undocumented_format_is_rejected",
+        "tests/test_cli.py::test_criterion_is_required",
+        "tests/test_cli.py::test_json_is_the_default_format_when_none_is_requested",
+        "tests/test_cli.py::test_the_spec_names_the_command_the_cli_actually_accepts"
+      ]
+    },
+    {
+      "id": "no-speculative-writing",
+      "description": "Ensure recommendation retrieval performs no speculative writes so nothing can go stale.",
+      "explicit": true,
+      "evidence_class": "partially_supported",
+      "evidence_rationale": "UNEARNED STRONG (corpus table; corrected by run 3). Run 2 again issued strongly supported on the evidence run 3 correctly called partial.",
+      "candidate_tests": [
+        "tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo",
+        "tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps"
+      ]
+    },
+    {
+      "id": "retrieve-from-stored-review-state",
+      "description": "Return a recommendation from stored review state on demand without re-running the review.",
+      "explicit": true,
+      "evidence_class": "partially_supported",
+      "evidence_rationale": "REAL GAP (judgement.md, run 2). Nothing distinguished 'read stored state' from 'recomputed and happened to agree', and nothing proved the named revision was read. Fixed by two stored reviews disagreeing on the same criterion, read by explicit --revision.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_check_persists_the_review_to_the_store",
+        "tests/test_cli.py::test_recommendation_defaults_to_the_most_recently_stored_review",
+        "tests/test_cli.py::test_recommendation_returns_the_stored_prescription_for_a_criterion",
+        "tests/test_review_store.py::test_review_round_trips_through_the_store"
+      ]
+    },
+    {
+      "id": "preserve-prose-structured-fields",
+      "description": "Keep the recommendation's structured fields as discrete keys with their prose values intact.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/benchmark/test_coverage.py::test_the_shared_pipeline_runs_every_stage",
+        "tests/test_cli.py::test_recommendation_defaults_to_the_most_recently_stored_review",
+        "tests/test_cli.py::test_recommendation_returns_the_stored_prescription_for_a_criterion",
+        "tests/test_report.py::test_open_questions_and_recommendations_are_numbered"
+      ]
+    },
+    {
+      "id": "discoverable-retrieval-in-output",
+      "description": "Make the review's own output tell a reader how to obtain the recommendation detail.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps",
+        "tests/test_cli.py::test_render_classify_output",
+        "tests/test_report.py::test_multi_word_verdict_renders_as_the_16_headline",
+        "tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered",
+        "tests/test_report.py::test_unclassified_obligation_renders_as_unclassified"
+      ]
+    },
+    {
+      "id": "remove-stale-next-instruction-file",
+      "description": "Remove any pre-existing `.acceptance/next-instruction.md` left by an earlier version and report that it was removed.",
+      "explicit": true,
+      "evidence_class": "partially_supported",
+      "evidence_rationale": "UNEARNED STRONG (corpus table; corrected by run 3). The silent `--json` deletion was still in the code at this run.",
+      "candidate_tests": [
+        "tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo",
+        "tests/test_cli.py::test_a_stale_instruction_file_is_removed_and_the_removal_reported",
+        "tests/test_cli.py::test_the_removal_leaves_the_report_as_the_only_statement_of_status"
+      ]
+    },
+    {
+      "id": "removal-leaves-report-as-only-status",
+      "description": "Leave the review's own output as the only statement of status when starting from a repo that already contains `.acceptance/next-instruction.md`.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo",
+        "tests/test_cli.py::test_a_stale_instruction_file_is_removed_and_the_removal_reported",
+        "tests/test_cli.py::test_the_removal_leaves_the_report_as_the_only_statement_of_status"
+      ]
+    },
+    {
+      "id": "empty-result-for-missing-recommendation",
+      "description": "Return an empty result when a criterion has no recommendation.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_recommendation_for_an_unknown_criterion_is_empty_not_an_error",
+        "tests/test_review_store.py::test_read_missing_revision_returns_none"
+      ]
+    },
+    {
+      "id": "default-to-most-recent-review",
+      "description": "Default retrieval to the most recently stored review when the caller does not name one.",
+      "explicit": true,
+      "evidence_class": "nominally_supported",
+      "evidence_rationale": "REAL GAP (judgement.md, run 2), and the run that caught run 1's false negative. The test stored exactly one review, so it could not distinguish 'newest' from 'only' \u2014 it did not verify its own name. The fix was defect-injected to confirm it bites.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_recommendation_defaults_to_the_most_recently_stored_review"
+      ]
+    },
+    {
+      "id": "byte-identical-retrievals",
+      "description": "Produce byte-identical output for repeated retrievals over unchanged review state.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "NOT A REAL GAP. Run 2 rated this partially supported and attributed the movement to rating instability; the attribution was confirmed when it returned to strongly supported in run 3 with no change of any kind. The test invokes twice and compares output exactly, which is what the recommendation asked for. This label deliberately contradicts the run's own output.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_two_retrievals_over_unchanged_state_are_byte_identical",
+        "tests/test_cli.py::test_two_runs_over_the_same_input_are_byte_identical",
+        "tests/test_review_store.py::test_rerun_over_the_same_head_overwrites_in_place"
+      ]
+    },
+    {
+      "id": "spec-no-longer-describes-written-file",
+      "description": "Keep the specification from describing the recommendation as a written file.",
+      "explicit": true,
+      "evidence_class": "partially_supported",
+      "evidence_rationale": "REAL, though run 2's judgement called it noise. Run 3 established the gap: the spec still read 'the recommendation may surface in the CLI, a Markdown file' at line 259, and the test asserted only that the string `next-instruction.md` was absent \u2014 it was, so the test passed while the file-writing framing survived.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps",
+        "tests/test_cli.py::test_the_spec_no_longer_names_a_written_file",
+        "tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered"
+      ]
+    }
+  ],
+  "gaps": [
+    {
+      "id": "gap-no-speculative-writing-run2",
+      "description": "Rated strongly supported although no test snapshots the repo around `recommendation` itself.",
+      "obligation_id": "no-speculative-writing",
+      "severity": "medium"
+    },
+    {
+      "id": "gap-retrieve-from-stored-review-state-run2",
+      "description": "Nothing distinguishes reading stored state from recomputing and agreeing; nothing proves the named revision was read.",
+      "obligation_id": "retrieve-from-stored-review-state",
+      "severity": "medium"
+    },
+    {
+      "id": "gap-remove-stale-next-instruction-file-run2",
+      "description": "Rated strongly supported while `--json` mode silently deleted a file in the user's repo.",
+      "obligation_id": "remove-stale-next-instruction-file",
+      "severity": "medium"
+    },
+    {
+      "id": "gap-default-to-most-recent-review-run2",
+      "description": "The test stored exactly one review, so it could not distinguish 'the newest' from 'the only one'.",
+      "obligation_id": "default-to-most-recent-review",
+      "severity": "high"
+    },
+    {
+      "id": "gap-spec-no-longer-describes-written-file-run2",
+      "description": "The spec still describes the recommendation as surfacing in a Markdown file; the test asserts only the absence of one filename.",
+      "obligation_id": "spec-no-longer-describes-written-file",
+      "severity": "medium"
+    }
+  ]
+}

--- a/tests/fixtures/rating-regression/167-gate2-run3/case.json
+++ b/tests/fixtures/rating-regression/167-gate2-run3/case.json
@@ -1,0 +1,7 @@
+{
+  "corpus_run": "167-gate2-run3",
+  "base_revision": "839ea47",
+  "head_revision": "95b880a",
+  "judgement": "tests/fixtures/rating-stability/167-gate2-run3/judgement.md — REWRITTEN. The corrected reading is ground truth: all three findings were real gaps. The original reading, kept at the bottom of that file, called them tool defects ('movement with no change in evidence') and would have shipped the silent --json deletion. Where the two readings disagree, the corrected one governs this case.",
+  "summary": "Run 3 of #167's Gate 2. Three of twelve obligations fell below `strongly supported`, and the corpus confirms all three were real gaps — including `remove-stale-next-instruction-file`, which it calls the most serious finding in the corpus: `--json` mode deleted a file in the user's repo and printed nothing, because the removal notice sat on the text branch only. The remaining nine are recorded as strongly supported and are not disputed by the judgement, which is what lets this single case bound a permissive judge and a pessimistic one at the same time."
+}

--- a/tests/fixtures/rating-regression/167-gate2-run3/labels.json
+++ b/tests/fixtures/rating-regression/167-gate2-run3/labels.json
@@ -1,0 +1,173 @@
+{
+  "obligations": [
+    {
+      "id": "replace-written-file-with-command",
+      "description": "Replace the written file `.acceptance/next-instruction.md` with the `acceptance recommendation --criterion <id> [--format json|text]` command surface for retrieving a criterion's recommendation on demand, defaulting to JSON.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Run 3 rated this strongly supported and its judgement does not dispute it. The corpus records this obligation as only *partly* real at run 1, where the defaulting-to-JSON clause alone was the genuine finding; by run 3 that clause is covered by test_json_is_the_default_format_when_none_is_requested.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps",
+        "tests/test_cli.py::test_json_is_the_default_format_when_none_is_requested",
+        "tests/test_cli.py::test_the_spec_names_the_command_the_cli_actually_accepts"
+      ]
+    },
+    {
+      "id": "fixed-command-surface",
+      "description": "Keep the recommendation retrieval command surface fixed to the specified command name and arguments in the specification.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Run 3 rated this strongly supported and its judgement does not dispute it. The corpus records the real gap on this obligation at run 1; it was fixed in 7de7d71, which is an ancestor of this run's head.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_a_command_name_the_spec_does_not_document_is_rejected",
+        "tests/test_cli.py::test_an_undocumented_format_is_rejected",
+        "tests/test_cli.py::test_criterion_is_required",
+        "tests/test_cli.py::test_the_spec_names_the_command_the_cli_actually_accepts"
+      ]
+    },
+    {
+      "id": "no-speculative-writing",
+      "description": "Ensure recommendation retrieval performs no speculative writes so nothing can go stale.",
+      "explicit": true,
+      "evidence_class": "partially_supported",
+      "evidence_rationale": "REAL GAP (judgement.md, run 3). No test snapshotted the repo around `recommendation` itself — test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo covers `check` only. test_retrieval_makes_no_model_call proves no model call, which is a strictly weaker claim than no write, and 'nothing is written speculatively' is the premise of the whole pull model. Runs 1 and 2 both rated this strongly supported on that same evidence.",
+      "candidate_tests": [
+        "tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo",
+        "tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps",
+        "tests/test_cli.py::test_retrieval_makes_no_model_call"
+      ]
+    },
+    {
+      "id": "retrieve-from-stored-review-state",
+      "description": "Return a recommendation from stored review state on demand without re-running the review.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Run 3 rated this strongly supported and its judgement does not dispute it. The corpus records the real gap on this obligation at run 2; it was fixed in 95b880a, this run's own head.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_check_persists_the_review_to_the_store",
+        "tests/test_cli.py::test_recommendation_returns_the_stored_prescription_for_a_criterion",
+        "tests/test_cli.py::test_retrieval_makes_no_model_call",
+        "tests/test_cli.py::test_retrieval_reads_the_named_revision_and_not_a_recomputation",
+        "tests/test_cli.py::test_retrieval_without_a_revision_uses_the_newest_stored_review",
+        "tests/test_cli.py::test_the_newest_review_wins_regardless_of_filename_order",
+        "tests/test_review_store.py::test_review_round_trips_through_the_store"
+      ]
+    },
+    {
+      "id": "preserve-prose-structured-fields",
+      "description": "Keep the recommendation's structured fields as discrete keys with their prose values intact.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Run 3 rated this strongly supported and its judgement does not dispute it. The corpus records a real gap on this obligation at run 4, which is later than this run — so at run 3 the rating stands.",
+      "candidate_tests": [
+        "tests/benchmark/test_coverage.py::test_the_shared_pipeline_runs_every_stage",
+        "tests/test_cli.py::test_recommendation_returns_the_stored_prescription_for_a_criterion",
+        "tests/test_report.py::test_open_questions_and_recommendations_are_numbered"
+      ]
+    },
+    {
+      "id": "discoverable-retrieval-in-output",
+      "description": "Make the review's own output tell a reader how to obtain the recommendation detail.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Run 3 rated this strongly supported and its judgement does not dispute it. Report rendering is asserted directly by test_report_renders_each_obligation_with_both_axes_numbered.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps",
+        "tests/test_cli.py::test_render_classify_output",
+        "tests/test_cli.py::test_report_shell_renders_all_sections_present_and_empty",
+        "tests/test_report.py::test_multi_word_verdict_renders_as_the_16_headline",
+        "tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered"
+      ]
+    },
+    {
+      "id": "remove-stale-next-instruction-file",
+      "description": "Remove any pre-existing `.acceptance/next-instruction.md` left by an earlier version and report that it was removed.",
+      "explicit": true,
+      "evidence_class": "partially_supported",
+      "evidence_rationale": "REAL GAP, and the corpus calls it the most serious finding it holds (judgement.md, run 3). `--json` mode deleted `.acceptance/next-instruction.md` and printed nothing: the removal notice sat on the text branch only, and every test covered text mode. A silent deletion in the user's repo — precisely what the migration decision said must not happen. Runs 1 and 2 both rated this strongly supported while that deletion sat in the code.",
+      "candidate_tests": [
+        "tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo",
+        "tests/test_cli.py::test_a_stale_instruction_file_is_removed_and_the_removal_reported",
+        "tests/test_cli.py::test_the_removal_leaves_the_report_as_the_only_statement_of_status"
+      ]
+    },
+    {
+      "id": "removal-leaves-report-as-only-status",
+      "description": "Leave the review's own output as the only statement of status when starting from a repo that already contains `.acceptance/next-instruction.md`.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Run 3 rated this strongly supported and its judgement does not dispute it. test_the_removal_leaves_the_report_as_the_only_statement_of_status asserts the condition by name.",
+      "candidate_tests": [
+        "tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo",
+        "tests/test_cli.py::test_a_stale_instruction_file_is_removed_and_the_removal_reported",
+        "tests/test_cli.py::test_report_shell_renders_all_sections_present_and_empty",
+        "tests/test_cli.py::test_the_removal_leaves_the_report_as_the_only_statement_of_status"
+      ]
+    },
+    {
+      "id": "empty-result-for-missing-recommendation",
+      "description": "Return an empty result when a criterion has no recommendation.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Run 3 rated this strongly supported and its judgement does not dispute it. Both the CLI and the store assert the empty-not-an-error path directly.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_recommendation_for_an_unknown_criterion_is_empty_not_an_error",
+        "tests/test_review_store.py::test_read_missing_revision_returns_none"
+      ]
+    },
+    {
+      "id": "default-to-most-recent-review",
+      "description": "Default retrieval to the most recently stored review when the caller does not name one.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Run 3 rated this strongly supported and its judgement does not dispute it. The corpus records the real gap on this obligation at run 2 — a test that stored a single review while claiming to verify 'the most recent', so it did not verify its own name. It was fixed in 95b880a, this run's own head, and test_the_newest_review_wins_regardless_of_filename_order is the fix.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_retrieval_without_a_revision_uses_the_newest_stored_review",
+        "tests/test_cli.py::test_the_newest_review_wins_regardless_of_filename_order"
+      ]
+    },
+    {
+      "id": "byte-identical-retrievals",
+      "description": "Produce byte-identical output for repeated retrievals over unchanged review state.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Run 3 rated this strongly supported and its judgement does not dispute it: its test invokes twice and compares bytes exactly as the recommendation asked. This is the one obligation the corpus names as a possible genuine-noise case (STRONG -> partial -> STRONG), and it explicitly says to treat even that as unsettled — so this label is the run-3 reading, not a claim that the movement was noise.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_retrieval_reads_the_named_revision_and_not_a_recomputation",
+        "tests/test_cli.py::test_two_retrievals_over_unchanged_state_are_byte_identical",
+        "tests/test_review_store.py::test_rerun_over_the_same_head_overwrites_in_place"
+      ]
+    },
+    {
+      "id": "spec-no-longer-describes-written-file",
+      "description": "Keep the specification from describing the recommendation as a written file.",
+      "explicit": true,
+      "evidence_class": "partially_supported",
+      "evidence_rationale": "REAL GAP (judgement.md, run 3). The spec still read 'the recommendation may surface in the CLI, a Markdown file, ...' at line 259. The test asserted only that the string `next-instruction.md` was absent — it was, so the test passed while the file-writing framing survived. Run 1 rated this strongly supported.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps",
+        "tests/test_cli.py::test_the_spec_no_longer_names_a_written_file"
+      ]
+    }
+  ],
+  "gaps": [
+    {
+      "id": "gap-no-speculative-writing-r3",
+      "description": "No test snapshots the repo around `recommendation` itself; the closest test proves no model call, which is strictly weaker than no write.",
+      "obligation_id": "no-speculative-writing",
+      "severity": "high"
+    },
+    {
+      "id": "gap-remove-stale-next-instruction-file-r3",
+      "description": "`--json` mode deletes `.acceptance/next-instruction.md` and prints nothing — the removal notice is on the text branch only, and every test covers text mode. A silent deletion in the user's repo.",
+      "obligation_id": "remove-stale-next-instruction-file",
+      "severity": "high"
+    },
+    {
+      "id": "gap-spec-no-longer-describes-written-file-r3",
+      "description": "The spec still describes the recommendation as surfacing in a Markdown file; the test asserts only the absence of one filename, so the file-writing framing survives it.",
+      "obligation_id": "spec-no-longer-describes-written-file",
+      "severity": "medium"
+    }
+  ]
+}

--- a/tests/fixtures/rating-regression/167-gate2-run4/case.json
+++ b/tests/fixtures/rating-regression/167-gate2-run4/case.json
@@ -1,0 +1,7 @@
+{
+  "corpus_run": "167-gate2-run4",
+  "base_revision": "839ea47",
+  "head_revision": "52c52b8",
+  "judgement": "tests/fixtures/rating-stability/167-gate2-run4/judgement.md for the three flagged obligations, plus run 5's rewritten judgement.md, which establishes that this run's strongly supported for replace-written-file-with-command is correct.",
+  "summary": "The first clear evidence of the false-positive direction: three obligations flagged, only one real. Also the run whose strongly supported rating run 5 wrongly overturned, which makes it the corpus's strongest positive anchor for a STRONG label."
+}

--- a/tests/fixtures/rating-regression/167-gate2-run4/labels.json
+++ b/tests/fixtures/rating-regression/167-gate2-run4/labels.json
@@ -1,0 +1,175 @@
+{
+  "obligations": [
+    {
+      "id": "replace-written-file-with-command",
+      "description": "Replace the written file `.acceptance/next-instruction.md` with the `acceptance recommendation --criterion <id> [--format json|text]` command surface for retrieving a criterion's recommendation on demand, defaulting to JSON.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "POSITIVELY ESTABLISHED STRONG. Run 5's judgement.md, itself rewritten, states that run 4's strongly supported is correct and run 5's partially supported was a wrong M5.2 verdict: test_check_writes_no_instruction_file_even_when_the_review_has_gaps invokes `check` on a review with gaps \u2014 exactly the case that previously wrote the file \u2014 and asserts its absence. This is the corpus's strongest anchor for the pessimistic direction.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps",
+        "tests/test_cli.py::test_json_is_the_default_format_when_none_is_requested",
+        "tests/test_cli.py::test_the_spec_names_the_command_the_cli_actually_accepts"
+      ]
+    },
+    {
+      "id": "fixed-command-surface",
+      "description": "Keep the recommendation retrieval command surface fixed to the specified command name and arguments in the specification.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_a_command_name_the_spec_does_not_document_is_rejected",
+        "tests/test_cli.py::test_an_undocumented_format_is_rejected",
+        "tests/test_cli.py::test_criterion_is_required",
+        "tests/test_cli.py::test_render_decomposition_lists_obligations_and_open_questions",
+        "tests/test_cli.py::test_the_spec_does_not_frame_the_recommendation_as_a_written_artifact",
+        "tests/test_cli.py::test_the_spec_names_the_command_the_cli_actually_accepts"
+      ]
+    },
+    {
+      "id": "no-speculative-writing",
+      "description": "Ensure recommendation retrieval performs no speculative writes so nothing can go stale.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "NOT A REAL GAP (judgement.md, run 4) \u2014 a false positive. Both tests the recommendation asks for now exist and are mapped: test_retrieval_writes_nothing_into_the_repo snapshots the tree and test_retrieval_makes_no_model_call covers the call. Its `detects` clause is self-contradictory. This label deliberately contradicts the run's own output.",
+      "candidate_tests": [
+        "tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo",
+        "tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps",
+        "tests/test_cli.py::test_retrieval_makes_no_model_call",
+        "tests/test_cli.py::test_retrieval_writes_nothing_into_the_repo"
+      ]
+    },
+    {
+      "id": "retrieve-from-stored-review-state",
+      "description": "Return a recommendation from stored review state on demand without re-running the review.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_check_persists_the_review_to_the_store",
+        "tests/test_cli.py::test_recommendation_returns_the_stored_prescription_for_a_criterion",
+        "tests/test_cli.py::test_retrieval_makes_no_model_call",
+        "tests/test_cli.py::test_retrieval_reads_the_named_revision_and_not_a_recomputation",
+        "tests/test_cli.py::test_retrieval_without_a_revision_uses_the_newest_stored_review",
+        "tests/test_cli.py::test_the_newest_review_wins_regardless_of_filename_order",
+        "tests/test_cli.py::test_two_retrievals_over_unchanged_state_are_byte_identical",
+        "tests/test_review_store.py::test_rerun_over_the_same_head_overwrites_in_place",
+        "tests/test_review_store.py::test_review_round_trips_through_the_store"
+      ]
+    },
+    {
+      "id": "preserve-prose-structured-fields",
+      "description": "Keep the recommendation's structured fields as discrete keys with their prose values intact.",
+      "explicit": true,
+      "evidence_class": "partially_supported",
+      "evidence_rationale": "REAL GAP (judgement.md, run 4). The test asserted 4 of the 6 \u00a79.5 fields \u2014 required_inputs and repo_conventions were unasserted, so a regression compressing either to a terse token would pass. Fixing it also exposed that the repo_conventions fixture was a bare path, not prose, which made a prose assertion vacuous.",
+      "candidate_tests": [
+        "tests/benchmark/test_coverage.py::test_the_shared_pipeline_runs_every_stage",
+        "tests/test_cli.py::test_recommendation_returns_the_stored_prescription_for_a_criterion",
+        "tests/test_report.py::test_every_test_evidence_line_shows_a_tier",
+        "tests/test_report.py::test_open_questions_and_recommendations_are_numbered"
+      ]
+    },
+    {
+      "id": "discoverable-retrieval-in-output",
+      "description": "Make the review's own output tell a reader how to obtain the recommendation detail.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps",
+        "tests/test_cli.py::test_render_classify_output",
+        "tests/test_cli.py::test_report_shell_renders_all_sections_present_and_empty",
+        "tests/test_report.py::test_a_carried_forward_obligation_says_so_and_names_the_revision",
+        "tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered"
+      ]
+    },
+    {
+      "id": "remove-stale-next-instruction-file",
+      "description": "Remove any pre-existing `.acceptance/next-instruction.md` left by an earlier version and report that it was removed.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo",
+        "tests/test_cli.py::test_a_stale_instruction_file_is_removed_and_the_removal_reported",
+        "tests/test_cli.py::test_the_removal_is_reported_in_json_mode_too",
+        "tests/test_cli.py::test_the_removal_leaves_the_report_as_the_only_statement_of_status",
+        "tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered"
+      ]
+    },
+    {
+      "id": "removal-leaves-report-as-only-status",
+      "description": "Leave the review's own output as the only statement of status when starting from a repo that already contains `.acceptance/next-instruction.md`.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo",
+        "tests/test_cli.py::test_a_stale_instruction_file_is_removed_and_the_removal_reported",
+        "tests/test_cli.py::test_report_shell_renders_all_sections_present_and_empty",
+        "tests/test_cli.py::test_the_removal_is_reported_in_json_mode_too",
+        "tests/test_cli.py::test_the_removal_leaves_the_report_as_the_only_statement_of_status",
+        "tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered"
+      ]
+    },
+    {
+      "id": "empty-result-for-missing-recommendation",
+      "description": "Return an empty result when a criterion has no recommendation.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "NOT A REAL GAP (judgement.md, run 4) \u2014 a false positive. The recommendation describes exactly what test_recommendation_for_an_unknown_criterion_is_empty_not_an_error already does: populated store, absent criterion, empty result rather than an error. This label deliberately contradicts the run's own output.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_recommendation_for_an_unknown_criterion_is_empty_not_an_error",
+        "tests/test_report.py::test_empty_review_renders_the_full_shell",
+        "tests/test_review_store.py::test_read_missing_revision_returns_none"
+      ]
+    },
+    {
+      "id": "default-to-most-recent-review",
+      "description": "Default retrieval to the most recently stored review when the caller does not name one.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_retrieval_without_a_revision_uses_the_newest_stored_review",
+        "tests/test_cli.py::test_the_newest_review_wins_regardless_of_filename_order",
+        "tests/test_review_store.py::test_rerun_over_the_same_head_overwrites_in_place"
+      ]
+    },
+    {
+      "id": "byte-identical-retrievals",
+      "description": "Produce byte-identical output for repeated retrievals over unchanged review state.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_two_retrievals_over_unchanged_state_are_byte_identical",
+        "tests/test_cli.py::test_two_runs_over_the_same_input_are_byte_identical",
+        "tests/test_review_store.py::test_rerun_over_the_same_head_overwrites_in_place"
+      ]
+    },
+    {
+      "id": "spec-no-longer-describes-written-file",
+      "description": "Keep the specification from describing the recommendation as a written file.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps",
+        "tests/test_cli.py::test_the_spec_does_not_frame_the_recommendation_as_a_written_artifact",
+        "tests/test_cli.py::test_the_spec_no_longer_names_a_written_file",
+        "tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered"
+      ]
+    }
+  ],
+  "gaps": [
+    {
+      "id": "gap-preserve-prose-structured-fields-run4",
+      "description": "Only 4 of the 6 structured fields are asserted; a regression compressing required_inputs or repo_conventions to a terse token would pass.",
+      "obligation_id": "preserve-prose-structured-fields",
+      "severity": "medium"
+    }
+  ]
+}

--- a/tests/fixtures/rating-regression/167-gate2-run5/case.json
+++ b/tests/fixtures/rating-regression/167-gate2-run5/case.json
@@ -1,0 +1,7 @@
+{
+  "corpus_run": "167-gate2-run5",
+  "base_revision": "839ea47",
+  "head_revision": "dd0a6a5",
+  "judgement": "tests/fixtures/rating-stability/167-gate2-run5/judgement.md \u2014 REWRITTEN. The corrected reading is ground truth: the single partially supported rating was a wrong M5.2 verdict, not a #144 compound-obligation artifact as first concluded. Where the two readings disagree, the corrected one governs.",
+  "summary": "The sharpest localization in the corpus. One commit from run 4 with byte-identical mapped tests, the discrimination stage named the same defect and judged it oppositely, and because the strength reduce is a pure function that one flipped boolean caused the whole rating. Ground truth is that every obligation here is strongly supported."
+}

--- a/tests/fixtures/rating-regression/167-gate2-run5/labels.json
+++ b/tests/fixtures/rating-regression/167-gate2-run5/labels.json
@@ -1,0 +1,170 @@
+{
+  "obligations": [
+    {
+      "id": "replace-written-file-with-command",
+      "description": "Replace the written file `.acceptance/next-instruction.md` with the `acceptance recommendation --criterion <id> [--format json|text]` command surface for retrieving a criterion's recommendation on demand, defaulting to JSON.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "A WRONG VERDICT, corrected. Run 5's judgement.md was rewritten; its corrected reading is ground truth and states that run 5's partially supported is 'not a defensible difference of judgement; it is wrong about what the test does', and that run 4's strongly supported is correct. Runs 4 and 5 are one commit apart with byte-identical mapped tests, and the discrimination stage named the same defect in both and judged it oppositely \u2014 so a single flipped boolean produced the whole rating. This label deliberately contradicts the run's own output.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps",
+        "tests/test_cli.py::test_json_is_the_default_format_when_none_is_requested",
+        "tests/test_cli.py::test_the_spec_names_the_command_the_cli_actually_accepts"
+      ]
+    },
+    {
+      "id": "fixed-command-surface",
+      "description": "Keep the recommendation retrieval command surface fixed to the specified command name and arguments in the specification.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_a_command_name_the_spec_does_not_document_is_rejected",
+        "tests/test_cli.py::test_an_undocumented_format_is_rejected",
+        "tests/test_cli.py::test_criterion_is_required",
+        "tests/test_cli.py::test_json_is_the_default_format_when_none_is_requested",
+        "tests/test_cli.py::test_the_spec_does_not_frame_the_recommendation_as_a_written_artifact",
+        "tests/test_cli.py::test_the_spec_names_the_command_the_cli_actually_accepts"
+      ]
+    },
+    {
+      "id": "no-speculative-writing",
+      "description": "Ensure recommendation retrieval performs no speculative writes so nothing can go stale.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo",
+        "tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps",
+        "tests/test_cli.py::test_retrieval_makes_no_model_call",
+        "tests/test_cli.py::test_retrieval_writes_nothing_into_the_repo"
+      ]
+    },
+    {
+      "id": "retrieve-from-stored-review-state",
+      "description": "Return a recommendation from stored review state on demand without re-running the review.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_check_persists_the_review_to_the_store",
+        "tests/test_cli.py::test_recommendation_returns_the_stored_prescription_for_a_criterion",
+        "tests/test_cli.py::test_recommendation_without_a_stored_review_fails_cleanly",
+        "tests/test_cli.py::test_retrieval_makes_no_model_call",
+        "tests/test_cli.py::test_retrieval_reads_the_named_revision_and_not_a_recomputation",
+        "tests/test_cli.py::test_retrieval_without_a_revision_uses_the_newest_stored_review",
+        "tests/test_cli.py::test_the_newest_review_wins_regardless_of_filename_order",
+        "tests/test_cli.py::test_two_retrievals_over_unchanged_state_are_byte_identical",
+        "tests/test_review_store.py::test_rerun_over_the_same_head_overwrites_in_place",
+        "tests/test_review_store.py::test_review_round_trips_through_the_store"
+      ]
+    },
+    {
+      "id": "preserve-prose-structured-fields",
+      "description": "Keep the recommendation's structured fields as discrete keys with their prose values intact.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/benchmark/test_coverage.py::test_the_shared_pipeline_runs_every_stage",
+        "tests/test_cli.py::test_recommendation_returns_the_stored_prescription_for_a_criterion",
+        "tests/test_report.py::test_every_test_evidence_line_shows_a_tier",
+        "tests/test_report.py::test_open_questions_and_recommendations_are_numbered"
+      ]
+    },
+    {
+      "id": "discoverable-retrieval-in-output",
+      "description": "Make the review's own output tell a reader how to obtain the recommendation detail.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps",
+        "tests/test_cli.py::test_render_classify_output",
+        "tests/test_cli.py::test_report_shell_renders_all_sections_present_and_empty",
+        "tests/test_report.py::test_a_carried_forward_obligation_says_so_and_names_the_revision",
+        "tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered"
+      ]
+    },
+    {
+      "id": "remove-stale-next-instruction-file",
+      "description": "Remove any pre-existing `.acceptance/next-instruction.md` left by an earlier version and report that it was removed.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo",
+        "tests/test_cli.py::test_a_stale_instruction_file_is_removed_and_the_removal_reported",
+        "tests/test_cli.py::test_the_removal_is_reported_in_json_mode_too",
+        "tests/test_cli.py::test_the_removal_leaves_the_report_as_the_only_statement_of_status",
+        "tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered"
+      ]
+    },
+    {
+      "id": "removal-leaves-report-as-only-status",
+      "description": "Leave the review's own output as the only statement of status when starting from a repo that already contains `.acceptance/next-instruction.md`.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/benchmark/test_coverage.py::test_neither_the_pipeline_nor_the_cli_writes_into_the_reviewed_repo",
+        "tests/test_cli.py::test_a_stale_instruction_file_is_removed_and_the_removal_reported",
+        "tests/test_cli.py::test_report_shell_renders_all_sections_present_and_empty",
+        "tests/test_cli.py::test_the_removal_is_reported_in_json_mode_too",
+        "tests/test_cli.py::test_the_removal_leaves_the_report_as_the_only_statement_of_status",
+        "tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered"
+      ]
+    },
+    {
+      "id": "empty-result-for-missing-recommendation",
+      "description": "Return an empty result when a criterion has no recommendation.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_recommendation_for_an_unknown_criterion_is_empty_not_an_error",
+        "tests/test_report.py::test_empty_review_renders_the_full_shell",
+        "tests/test_review_store.py::test_read_missing_revision_returns_none"
+      ]
+    },
+    {
+      "id": "default-to-most-recent-review",
+      "description": "Default retrieval to the most recently stored review when the caller does not name one.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_retrieval_without_a_revision_uses_the_newest_stored_review",
+        "tests/test_cli.py::test_the_newest_review_wins_regardless_of_filename_order",
+        "tests/test_review_store.py::test_rerun_over_the_same_head_overwrites_in_place"
+      ]
+    },
+    {
+      "id": "byte-identical-retrievals",
+      "description": "Produce byte-identical output for repeated retrievals over unchanged review state.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_recommendation_returns_the_stored_prescription_for_a_criterion",
+        "tests/test_cli.py::test_two_retrievals_over_unchanged_state_are_byte_identical",
+        "tests/test_cli.py::test_two_runs_over_the_same_input_are_byte_identical",
+        "tests/test_review_store.py::test_rerun_over_the_same_head_overwrites_in_place"
+      ]
+    },
+    {
+      "id": "spec-no-longer-describes-written-file",
+      "description": "Keep the specification from describing the recommendation as a written file.",
+      "explicit": true,
+      "evidence_class": "strongly_supported",
+      "evidence_rationale": "Rated strongly supported by this run, and its judgement.md does not dispute it. Recorded as the run's reading rather than as a separately established fact.",
+      "candidate_tests": [
+        "tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps",
+        "tests/test_cli.py::test_the_spec_does_not_frame_the_recommendation_as_a_written_artifact",
+        "tests/test_cli.py::test_the_spec_no_longer_names_a_written_file",
+        "tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered"
+      ]
+    }
+  ],
+  "gaps": []
+}

--- a/tests/fixtures/rating-stability/README.md
+++ b/tests/fixtures/rating-stability/README.md
@@ -1,9 +1,29 @@
 # Rating-stability corpus
 
 Captured dogfood iterations, kept as **test data for fixing the instability they
-document** (#180, umbrella #183). Not currently read by any test — it is the
-evidence a fix has to be measured against, recorded while the judgements were
-still fresh.
+document** (#180, umbrella #183) — the evidence a fix has to be measured
+against, recorded while the judgements were still fresh.
+
+## What is read by a test, and what is not (#190)
+
+Every run here now backs a regression case in `tests/fixtures/rating-regression/`,
+scored by `tests/benchmark/test_rating_regression.py`. A case reads two files
+from its run:
+
+| file | read? | by what |
+|---|---|---|
+| `current-task.md` | **yes** — verbatim, as the case's task input | `benchmark/corpus.py` |
+| `revisions.txt` | **yes**, indirectly — each case pins the same head SHA, plus the base this file does not record | `tests/fixtures/rating-regression/*/case.json` |
+| `judgement.md` | **no, not mechanically.** Its conclusions were transcribed into `labels.json` by hand; each case's `case.json` names the judgement it came from, and for runs 3 and 5 which of the two preserved readings is ground truth | — |
+| `check-output.log` | **no.** Obligation text and candidate tests were transcribed from it once, when the labels were built | — |
+
+So the judgements are asserted, but the corpus files that carry them are still
+prose a human wrote and a human transcribed. **A finding recorded here does not
+reach the suite until someone adds it to a `labels.json`.**
+
+The cases are pinned to real commits in this repository rather than to copies of
+the source, so a rewritten history breaks them by name rather than shrinking the
+suite silently.
 
 **The reasoning lives in `docs/DR-180-evidence-judgement-instability.md`**; this
 README covers the layout and how to read the runs. The DR owns the analysis — the


### PR DESCRIPTION
Closes #190.

DR-180's load-bearing criterion — `strongly supported` is not issued on evidence that does not earn it — had no scoreboard, so every candidate fix to the evidence-judgement stage was accepted or rejected by eyeball.

## The approach changed from what the issue assumed

#190 was filed saying the corpus holds rendered reports rather than transcripts, so cases "have to be rebuilt as inputs the pipeline can run over". **That premise was wrong**, and the issue body has been corrected.

The inputs survived. Each run dir holds the exact `current-task.md` it was given, `revisions.txt` names the commit it judged, and **all six commits still resolve in this repository**. So a case supplies the real input rather than a reconstruction.

What the corpus does *not* hold is the model's own responses — `check-output.log` is the rendered report, downstream of them — so the runs cannot be replayed and the judgement a case is scored under is supplied by a stub. Of the three combinations, only one is available:

| | |
|---|---|
| synthetic fixture + recorded judge | allowed, but low fidelity |
| **real revisions + stub judge** | **chosen** |
| real revisions + recorded judge | would put this repo's own diffs into `tests/fixtures/` — exactly what the corpus avoided by storing rendered reports |

## What's here

- **`benchmark/corpus.py`** materializes a case as a detached `git worktree` at its head revision. A worktree because `evidence/discovery.py` scans the filesystem, not the git revision, so a case pointed at the live repo would discover *today's* tests against a historical diff. A revision that stops resolving fails its case by name rather than skipping — a suite pinned to history must break loudly, not shrink silently.
- **Six cases** under `tests/fixtures/rating-regression/`, using the existing `GroundTruthLabels` shape, each traceable to the `judgement.md` it came from — including, for runs 3 and 5, which of the two preserved readings governs.
- **Two degenerate judges**, reading allowed ids out of the request schema via #163's enum constraint rather than parsing prompt text.

Base revisions were verified by checking each log's cited hunk headers against the real diff, with `7de7d71` as a negative control that misses all four.

## Both directions, and the numbers

| judge | agreement | gap_recall | gap_precision |
|---|---|---|---|
| always-STRONG | 0.771 | **0.0** | — |
| never-STRONG | 0.043 | 1.0 | **0.229** |

Each direction is caught by a *different* metric. 0.771 is exactly 54/70 — the strongly-supported labels over all obligations — so the figure is real arithmetic, not a coincidence. A harness test asserts the two judges disagree, so the pair cannot both pass for the "helper the pipeline never calls" reason.

The suite scores real code — the `strength.py` reduce, mapping wiring, coverage-to-finding derivation, the verdict — but **not the judgement prompt**. That limit is stated in the module docstring rather than left implicit.

## Gate 2 did not come back clean, deliberately

Three rounds, all logged with inputs and judgements in `dogfood-logs/190-gate2-run{1,2,3}/`.

**Round 1** — 14 obligations `unsupported`. The mapping audit came back 100% populated with zero foreign ids, so the review was right, not half-blind: the suite scored the judge while nothing asserted the task's own requirements. All 14 addressed.

**Round 2** — 9 left. Three were real, and one was a genuine miss: `score_case_set` aggregates via `_all_counts` and **never calls `score_case`**, so the stated constraint was satisfied only in spirit. Fixed. The other six are scope exclusions, recorded against **#153** — writing tests for them moved them from `unsupported` to `partially supported` and no further, because an exclusion cannot be discharged by testing.

**Round 3** — `strongly supported` fell 20 → 3 on a diff that only added tests.

| | round 2 | round 3 |
|---|---|---|
| obligations with ≥1 mapped test | 27/29 | 25/29 |
| total test-evidence links | 36 | **40** |
| avg defects enumerated per obligation | **2.04** | **2.04** |
| `would_be_caught` | 48/55 (87%) | **29/51 (57%)** |

Mapping did not collapse; there were *more* evidence links in the worse round. Defect enumeration did not move. The whole swing is M5.2's per-defect verdict with enumeration held constant — a cleaner isolation than the corpus's own run-5 case, where enumeration moved too. Recorded against **#191**.

**This does not establish that round 3 is wrong.** The corpus's central finding is that in 7 of 8 unstable obligations the LOW rating was correct, and DR-180 names the inference to avoid: *the diff was additive, added tests cannot weaken evidence, therefore the fall is external* — both premises true, conclusion false. The lower ratings may be right and rounds 1–2 may have been issuing unearned STRONGs on these very tests. The figures show **where** the variance lives, not which end is correct.

So the residual is two tracked defects in other issues (#153, #191), not defects in this change. Holding #190 until they land would invert the sequencing, since this suite is what lets #191's fix be scored.

## Also here

Two commits landed on `main` first (`c5cc707`, `7e337f7`): dogfood runs and `session-state.md` are now committed rather than ignored, with a directory layout carrying each run's task file, output, revisions and judgement. A gitignore rule only affects branches carrying it, hence main.

677 tests pass; lint clean.
