### PR TITLE
Exclude compiled Python from archetype materialization (#198)

### DIFF
--- a/src/acceptance/benchmark/fixtures.py
+++ b/src/acceptance/benchmark/fixtures.py
@@ -118,7 +118,15 @@ def materialize_archetype(fixture_dir: Path, dest: Path) -> MaterializedFixture:
 
 def _replace_worktree(repo: Path, tree: Path) -> None:
     """Clear the working tree (keeping .git) and copy `tree` into it, so a
-    file removed between base and head is staged as a deletion by `git add -A`."""
+    file removed between base and head is staged as a deletion by `git add -A`.
+
+    `__pycache__` is excluded because it is build output, not source. It is
+    untracked, so it exists in a working copy only if something imported the
+    fixture's modules first — which made the "same fixture always materializes
+    to the same SHA" guarantee depend on test ordering rather than on content.
+    A fresh clone would materialize one SHA and a clone that had run the suite
+    once would materialize another.
+    """
     for entry in repo.iterdir():
         if entry.name == ".git":
             continue
@@ -126,7 +134,9 @@ def _replace_worktree(repo: Path, tree: Path) -> None:
             shutil.rmtree(entry)
         else:
             entry.unlink()
-    shutil.copytree(tree, repo, dirs_exist_ok=True)
+    shutil.copytree(
+        tree, repo, dirs_exist_ok=True, ignore=shutil.ignore_patterns("__pycache__", "*.py[cod]")
+    )
 
 
 def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:

--- a/tests/benchmark/test_fixtures.py
+++ b/tests/benchmark/test_fixtures.py
@@ -99,3 +99,30 @@ def test_head_pytest_runs_with_the_intended_outcome(fixture_dir, tmp_path):
         assert result.returncode == 0, result.stdout + result.stderr
     else:
         assert result.returncode != 0, result.stdout + result.stderr
+
+
+def test_materialization_ignores_compiled_python(tmp_path):
+    """The same fixture must materialize to the same SHA whether or not its
+    modules have been imported.
+
+    `__pycache__` is untracked build output that appears only once something
+    compiles the fixture's sources, so including it made the determinism
+    guarantee depend on test ordering — a fresh clone and a clone that had run
+    the suite once produced different SHAs. It broke CI on main exactly that way.
+    """
+    import shutil
+
+    fixture = ARCHETYPES_DIR / "07-declaration-mismatch"
+    for cache in list(fixture.rglob("__pycache__")):
+        shutil.rmtree(cache)
+    without = materialize_archetype(fixture, tmp_path / "without").head_sha
+
+    cache_dir = fixture / "head" / "__pycache__"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    (cache_dir / "user_lookup.cpython-310.pyc").write_bytes(b"\x00compiled\x00")
+    try:
+        with_cache = materialize_archetype(fixture, tmp_path / "with").head_sha
+    finally:
+        shutil.rmtree(cache_dir)
+
+    assert with_cache == without


### PR DESCRIPTION
Closes #198. **Fixes a red `main`.**

`materialize_archetype` copied `__pycache__` into the fixture repo and staged it with `git add -A`. That is untracked build output, present only if something imported the fixture's modules first — so the documented guarantee that a fixture always materializes to the same SHA depended on test ordering rather than content:

```
with pycache   head: 7844e550e56b
without pycache head: 143940c7e9c9
```

`143940c7e9c9` is one of the two SHAs in the CI failure on main at `0d851b9`.

The bug is pre-existing and latent. #190's new tests shifted collection order enough to change when those modules were compiled relative to the determinism check, which is why it passed on the PR branch and locally and failed once merged — and why it would have read as an unrelated flake every time it appeared.

`_replace_worktree` now ignores `__pycache__` and `*.py[cod]`, so materialization depends on tracked source alone. Regression test asserts a fixture materializes identically with and without compiled modules present.