### PR TITLE
M1.2.r2: a self-contradictory requirement disposition is unrepresentable (#217)

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,88 +1,70 @@
 # Task
-`decompose` returns a flat list of obligations plus a flat list of open
-questions. A response covering 20 of a task file's 29 requirements is exactly as
-well-formed as one covering all 29, so nothing downstream can notice that nine
-requirements produced nothing. Gate 1 for #195 lost 4 of 15 Completion
-expectations and 5 of 8 Scope exclusions this way, and the review reported no
-gap.
+DR-202 decision 3 gives a requirement exactly one of three dispositions, each
+carrying something: yielded obligations, deliberately yields none with a reason,
+or raised an open question instead. The implementation added a fourth,
+`UNDISPOSED`, carrying none of them, and reached it two ways: a response that
+never mentioned a requirement, and a response that labelled a requirement
+`yielded` while naming no obligations.
 
-Make decomposition return a mapping from requirement to obligation, so that a
-requirement producing nothing is a recorded fact rather than an absence.
+Both are malformed responses, and both are currently absorbed as soft findings.
+`_requirement_map` discards the reason the response supplied, substitutes a
+diagnostic string of its own, and lets the run continue to a verdict on an
+answer that did not account for the mandate.
 
-Separately, and independent of that defect: a reader auditing a breakdown cannot
-see which requirement each obligation came from. `Obligation.source_spans` points
-at a character offset, so the trace runs one way and only to text, never to an
-identified requirement.
-
-This change is mostly representational, and one part of it is not. Passing the
-parse to the model instead of the raw task text is only safe if the parse is
-complete, and it is not: only the first paragraph of the `Task` section survives
-it. Correcting that changes which obligations a task file decomposes into,
-because requirements that were invisible to the model become visible.
+The registry of requirements is derived deterministically from the parse, and
+the code iterates over that registry. Dropping a requirement is therefore not a
+possible outcome — the only possible bad outcome is a response of poor quality.
+Make that true in the types: every requirement carries one of exactly three
+dispositions, each structurally required to carry its own payload, and a
+response that fails to account for every requirement does not parse. Remove the
+fourth disposition entirely.
 
 ## Constraints
-- A requirement registry is derived from `requirement/task_file.py::parse_task_file`.
-- Requirement ids are assigned by the code, never by the model.
-- A requirement id is its section and its ordinal within that section, in parse
-  order.
-- Each registry entry carries the `TextSpan` of the requirement it identifies.
-- The requirement-to-obligation relation is many-to-many.
-- An obligation serving two requirements is linked to both.
-- An obligation is never duplicated so that each requirement can hold its own
-  copy.
-- Every requirement carries exactly one disposition.
-- The dispositions are: yielded obligations; deliberately yields none, with a
-  reason; raised an open question instead.
-- The mapping is persisted in the structured review state that
-  `review_state.py` and `review_store.py` already define.
-- The mapping is rendered in the §16 report.
-- `requirement/obligations.py::_user_prompt` passes typed, identified fields.
-- `_user_prompt` does not pass `parsed.source`.
-- Every paragraph of the task file's `Task` section is a requirement.
-- Task-file text that the parse claims for no requirement is recorded.
-- Recorded unclaimed text is rendered by both the decompose output and the
-  report.
-- The decomposer receives no `ChangeSet`.
-- The decomposer receives no repository path.
-- The decomposer receives no head revision.
+- A requirement disposition is one of exactly three: yielded obligations,
+  no obligations needed with a reason, or an open question that prevents an
+  answer.
+- `Disposition` has no `UNDISPOSED` value.
+- `_RequirementDisposition` is a discriminated union on its disposition field.
+- A `yielded` disposition carries at least one obligation id.
+- A `no_obligation` disposition carries a reason that is not empty.
+- An `open_question` disposition carries at least one open-question id.
+- A response labelling a requirement `yielded` while naming no obligation id
+  fails to parse.
+- A response labelling a requirement `no_obligation` with an empty reason fails
+  to parse.
+- A response that omits any requirement in the registry is rejected.
+- A response that names a requirement id absent from the registry is rejected.
+- A rejected response produces no `RequirementMap`.
+- The JSON schema sent to the model cannot express a `yielded` disposition with
+  zero obligation ids.
+- The reason a response supplies for declining a requirement is preserved rather
+  than replaced by a diagnostic string.
 - Typed schemas are pydantic models, as the rest of the repository defines them.
 - Tests issue no live model calls.
 
 ## Scope exclusions
-- Changing how obligations are derived from the requirements the model is shown.
-  The derivation is untouched; what changes is which requirements reach it.
-- Partitioning obligation derivation by requirement batch, which is #204.
-- Assigning obligation types in a separate pass, which is #205.
-- Requiring an open question to cite where the task file fails to answer it,
-  which is #206.
-- Reading the base revision during open-question resolution, which is #207.
-- Deciding whether the decomposer receives base-revision code context, which is
-  #208.
-- De-duplicating semantically duplicate obligations, which is #144.
+- The decomposer declining to yield obligations for scope exclusions, against
+  the instruction already in the decompose prompt. That is a prompt defect
+  tracked separately and costs a transcript re-record.
+- Changing the decompose prompt text.
+- Retrying or repairing a rejected response.
+- Nested-bullet and multi-paragraph parse coverage, which is #216.
+- Whether mandate coverage bounds the completion verdict, which is #214.
 - Aligning requirement ids across two versions of a task file, which is #209.
-- Rebuilding #195's regression suite to bind its labels to the mapping.
-- Measuring whether decomposition recall improves as a result of this change.
 
 ## Completion expectations
 - Implementation
-- A task file whose every requirement yields an obligation produces a mapping in
-  which no requirement is undisposed.
-- A requirement that yields no obligation appears in the mapping carrying its
-  reason.
-- A requirement that yields no obligation is visible in the rendered report.
-- A requirement stated twice in different sections yields one obligation linked
-  to both requirements.
-- That same case yields one obligation rather than two.
-- Requirement ids are identical across two runs over byte-identical task text.
-- A `Task` section of several paragraphs yields one requirement per paragraph.
-- Text under a heading the format does not recognise is reported as unread.
-- A task file whose every block is claimed reports zero unread blocks.
-- A test pins that the decomposer cannot reach a diff.
-- A test pins that the decomposer cannot reach a head revision.
-- A test pins that the pipeline persists the mapping rather than discarding it.
-- The regression suite #195 delivered runs unchanged against the new output.
-- No case in that suite flips its result.
-- `docs/DR-202-decomposition-requirement-mapping.md` records the resolved
-  requirement-id decision in place of listing it as open.
-- The decomposition-accuracy figure is marked non-comparable across this change
-  where a reader meets it.
+- Every requirement in a parsed `RequirementMap` carries one of the three
+  dispositions.
+- A response with a `yielded` disposition and no obligation ids is rejected.
+- A response with a `no_obligation` disposition and an empty reason is rejected.
+- A response omitting a requirement present in the registry is rejected.
+- No `RequirementMap` is produced from a rejected response.
+- The `UNDISPOSED` value and every code path that assigns it are removed.
+- A test asserts that the schema sent to the model rejects a `yielded`
+  disposition carrying zero obligation ids.
+- The tests, CLI rendering and report sections that referred to the removed
+  disposition are updated rather than left asserting it.
+- `docs/DR-202-decomposition-requirement-mapping.md` records that the
+  disposition set is the three of decision 3, and that completeness is enforced
+  at parse.

--- a/current-task.md
+++ b/current-task.md
@@ -24,7 +24,11 @@ fourth disposition entirely.
   no obligations needed with a reason, or an open question that prevents an
   answer.
 - `Disposition` has no `UNDISPOSED` value.
-- `_RequirementDisposition` is a discriminated union on its disposition field.
+- `_RequirementDisposition` is a union of one shape per disposition, each
+  carrying only the payload its own disposition defines.
+- The union is unambiguous at parse: each shape names its disposition as a
+  literal value.
+- The schema sent to the model uses only keywords OpenAI strict mode accepts.
 - A `yielded` disposition carries at least one obligation id.
 - A `no_obligation` disposition carries a reason that is not empty.
 - An `open_question` disposition carries at least one open-question id.
@@ -39,6 +43,9 @@ fourth disposition entirely.
   zero obligation ids.
 - The reason a response supplies for declining a requirement is preserved rather
   than replaced by a diagnostic string.
+- The helper that restricts an id field to the ids a call supplied keeps working
+  when the response model's item type is a union, so the requirement-id
+  constraint survives the new shape.
 - Typed schemas are pydantic models, as the rest of the repository defines them.
 - Tests issue no live model calls.
 
@@ -61,8 +68,14 @@ fourth disposition entirely.
 - A response omitting a requirement present in the registry is rejected.
 - No `RequirementMap` is produced from a rejected response.
 - The `UNDISPOSED` value and every code path that assigns it are removed.
+- A response naming a requirement id outside the registry is rejected.
+- A response disposing the same requirement twice is rejected.
+- An `open_question` disposition naming no question the response produced is
+  rejected.
 - A test asserts that the schema sent to the model rejects a `yielded`
   disposition carrying zero obligation ids.
+- A test asserts that the id constraint still reaches every member of a union
+  item type.
 - The tests, CLI rendering and report sections that referred to the removed
   disposition are updated rather than left asserting it.
 - `docs/DR-202-decomposition-requirement-mapping.md` records that the

--- a/docs/DR-202-decomposition-requirement-mapping.md
+++ b/docs/DR-202-decomposition-requirement-mapping.md
@@ -108,6 +108,39 @@ erred. Nothing here asks that. Forcing an answer per requirement makes *silence*
 unrepresentable; a wrong disposition remains wrong, but it is a claim a human can
 reject at Gate 1 and a benchmark case can score.
 
+> **Amended by M1.2.r2 (#217).** The implementation of this decision added a
+> fourth disposition, `UNDISPOSED`, assigned by the code to any requirement the
+> response failed to account for. It has been removed, and the set is again the
+> three above.
+>
+> The fourth value was reached from two conditions: a response that never
+> mentioned a requirement, and a response that labelled one `yielded` while
+> naming no obligations. Both are malformed, and recording them as a disposition
+> turned a malformed response into a soft finding that still reached a verdict.
+> #216's Gate 1 is the demonstration: eight requirements came back `yielded`
+> with an empty id list **and a substantive reason**, the reason was discarded
+> in favour of a diagnostic string, and the run continued.
+>
+> The registry is derived from the parse and reconciliation walks it, so the
+> code cannot drop a requirement — the worst reachable outcome is a poor-quality
+> response. A disposition for "the response did not say" therefore encoded a
+> state no correct run produces.
+>
+> **Completeness is now enforced at parse.** Each disposition is a distinct
+> shape carrying only its own payload, so `yielded` structurally requires an
+> obligation id and `no_obligation` structurally requires a reason; and
+> reconciliation raises on a missing requirement, a duplicate, an id outside the
+> registry, or a claim naming only outputs the response never produced. A
+> response that does not account for the mandate produces no `RequirementMap`
+> at all.
+>
+> Two implementation notes worth not rediscovering. The shapes are a plain
+> `Union`, not a pydantic tagged union: a tagged union renders `oneOf` plus
+> `discriminator`, and OpenAI strict mode accepts neither. "At least one id" is
+> a required scalar field beside a list rather than a list with `min_length`,
+> because strict mode rejects `minItems` — the guarantee has to be carried by
+> the shape to survive onto the wire.
+
 **4. Requirement ids are derived from the parse.** The work list comes from
 `markdown-it`. A model-generated list of requirements would be built by the same
 attention pass that produced 29 instead of 38.

--- a/dogfood-logs/216-gate1-run1/judgement.md
+++ b/dogfood-logs/216-gate1-run1/judgement.md
@@ -1,0 +1,34 @@
+# Judgement — #216 Gate 1 run 1
+
+At `95a3856`. **Gate 1 did not pass**; the run was abandoned and #216 deferred.
+
+`Requirements: 31   with obligations: 22   deliberately none: 1   UNACCOUNTED FOR: 8`
+
+## The finding
+
+Seven scope exclusions and `completion-10` came back `disposition: "yielded"`
+with `obligation_ids: []`. The transcript shows **no invented ids** — `_resolve`
+dropped nothing — and every one of the eight carried a substantive reason:
+
+    exclusion-05  'This is a scope exclusion pointing to a separate issue (#144)
+                   and does not add a checkable requirement for this change.'
+
+The model wrote a textbook `no_obligation` reason under a `yielded` label.
+`_requirement_map` required the label to match, fell to `else`, discarded the
+reason and substituted `"disposition 'yielded' named no usable output"`.
+
+## Triage
+
+**Tool defect, two of them, both filed.**
+
+1. Reconciliation discarding a supplied reason and recording the requirement as
+   unaccounted-for — **#217 (M1.2.r2)**, fixed in this session.
+2. The decomposer declining to yield obligations for scope exclusions at all,
+   against the instruction already at `obligations.py:150`. Still open; belongs
+   in the #204/#205/#206 prompt batch, where the re-record is paid once.
+
+**Not attributable to task-file wording.** Three of the empty exclusions and
+`completion-10` are word-for-word what #202's task file used, and in #202's
+Gate 1 run 4 all four yielded obligations — same code, model and seed.
+
+Zero open questions were raised, so Gate 1 step 3 had nothing to triage.

--- a/dogfood-logs/216-gate1-run1/output.log
+++ b/dogfood-logs/216-gate1-run1/output.log
@@ -1,0 +1,193 @@
+Requirements: 31   with obligations: 22   deliberately none: 1   UNACCOUNTED FOR: 8
+
+[task-01] `requirement/task_file.py::parse_task_file` claims a list item using the first
+    inline text found inside that item. A list item whose children are a paragraph
+    followed by a nested bullet list is therefore spanned by its first paragraph alone,
+    and the nested list is never visited. Because the item was claimed, the nested text
+    never reaches `unclaimed` either.
+    -> obligation-claim-nested-content-reachable  [functional/explicit]   (also serves task-03, exclusion-01, completion-02)
+       Make content nested inside a claimed list item reachable so it is either
+       extracted as a requirement in its own right or recorded as unread text, with
+       every nested region accounted for exactly once by one of those two readings.
+
+[task-02] Nested requirements consequently reach neither the requirement registry nor
+    `unread_source`. The guard #202 added does not merely fail to notice the loss: it
+    reports `unaccounted for: 0` and so affirmatively certifies the mandate as fully
+    read while requirements are missing. The same loss applies to the second and
+    subsequent paragraphs of a single list item, and to any block nested inside a
+    claimed list item, including nested code fences and nested tables.
+    -> obligation-nested-content-either-registry-or-unclaimed  [invariant/explicit]   (also serves constraint-01)
+       Preserve the invariant that content nested inside a claimed list item is either a
+       requirement registry entry or an unclaimed span.
+    -> obligation-unread-source-covers-nested-text  [functional/explicit]   (also serves constraint-03)
+       Count task-file text nested inside recognised sections in `unclaimed`, not only
+       text under unrecognised top-level headings.
+    -> obligation-zero-unread-when-all-blocks-claimed  [regression/explicit]   (also serves completion-08)
+       Preserve the behavior that a task file whose every block is claimed reports zero
+       unread blocks.
+
+[task-03] Make every region of a task file reachable. Content nested inside a claimed
+    list item is either extracted as a requirement in its own right or recorded as
+    unread text, and never neither. Which of those two readings a nested bullet gets is
+    decided as part of this change.
+    -> obligation-claim-nested-content-reachable  [functional/explicit]   (also serves task-01, exclusion-01, completion-02)
+       Make content nested inside a claimed list item reachable so it is either
+       extracted as a requirement in its own right or recorded as unread text, with
+       every nested region accounted for exactly once by one of those two readings.
+    -> obligation-nested-bullet-reading-recorded  [human_review/explicit]   (also serves completion-02, completion-09)
+       Record the chosen reading for a nested bullet as either a requirement of its own
+       or a continuation of its parent.
+
+[constraint-01] Content nested inside a claimed list item is either a requirement
+    registry entry or an unclaimed span.
+    -> obligation-nested-content-either-registry-or-unclaimed  [invariant/explicit]   (also serves task-02)
+       Preserve the invariant that content nested inside a claimed list item is either a
+       requirement registry entry or an unclaimed span.
+
+[constraint-02] No non-whitespace, non-heading region of a task file is absent from both
+    the requirement registry and `unclaimed`.
+    -> obligation-no-region-dropped-from-registry-or-unclaimed  [invariant/explicit]
+       Preserve coverage so no non-whitespace, non-heading region of a task file is
+       absent from both the requirement registry and `unclaimed`.
+
+[constraint-03] `unclaimed` accounts for task-file text nested inside recognised
+    sections, not only text under unrecognised top-level headings.
+    -> obligation-unread-source-covers-nested-text  [functional/explicit]   (also serves task-02)
+       Count task-file text nested inside recognised sections in `unclaimed`, not only
+       text under unrecognised top-level headings.
+
+[constraint-04] A requirement id is its section and its ordinal within that section, in
+    parse order.
+    -> obligation-requirement-id-section-and-ordinal  [functional/explicit]
+       Assign each requirement id from its section and its ordinal within that section,
+       in parse order.
+
+[constraint-05] Requirement ids are assigned by the code, never by the model.
+    -> obligation-requirement-ids-code-assigned  [invariant/explicit]
+       Keep requirement id assignment in code rather than by the model.
+
+[constraint-06] Requirement ids are identical across two runs over byte-identical task
+    text.
+    -> obligation-requirement-ids-deterministic-across-runs  [regression/explicit]
+       Keep requirement ids identical across two runs over byte-identical task text.
+
+[constraint-07] Each registry entry carries the `TextSpan` of the requirement it
+    identifies.
+    -> obligation-registry-entry-carries-textspan  [functional/explicit]
+       Ensure each registry entry carries the `TextSpan` of the requirement it
+       identifies.
+
+[constraint-08] Recorded unclaimed text is rendered by both the decompose output and the
+    §16 report.
+    -> obligation-unclaimed-rendered-in-decompose-and-report  [explanation_observability/explicit]
+       Render recorded unclaimed text in both the decompose output and the §16 report.
+
+[constraint-09] Typed schemas are pydantic models, as the rest of the repository defines
+    them.
+    -> obligation-pydantic-schemas  [compatibility/explicit]
+       Keep typed schemas implemented as pydantic models, matching the repository's
+       existing schema style.
+
+[constraint-10] Tests issue no live model calls.
+    -> obligation-no-live-model-calls-in-tests  [compatibility/explicit]
+       Keep tests free of live model calls.
+
+[exclusion-01] Changing how obligations are derived from the requirements the model is
+    shown. What changes is which regions of the task file become requirements or unread
+    text.
+    -> obligation-claim-nested-content-reachable  [functional/explicit]   (also serves task-01, task-03, completion-02)
+       Make content nested inside a claimed list item reachable so it is either
+       extracted as a requirement in its own right or recorded as unread text, with
+       every nested region accounted for exactly once by one of those two readings.
+
+[exclusion-02] Whether an obligation links to the requirement that actually states it,
+    which is #210.
+    !! UNACCOUNTED FOR — the decomposer did not address this
+       disposition 'yielded' named no usable output
+
+[exclusion-03] Whether mandate coverage bounds the completion verdict, which is #214.
+    !! UNACCOUNTED FOR — the decomposer did not address this
+       disposition 'yielded' named no usable output
+
+[exclusion-04] Aligning requirement ids across two versions of a task file, which is
+    #209.
+    !! UNACCOUNTED FOR — the decomposer did not address this
+       disposition 'yielded' named no usable output
+
+[exclusion-05] De-duplicating semantically duplicate obligations, which is #144.
+    !! UNACCOUNTED FOR — the decomposer did not address this
+       disposition 'yielded' named no usable output
+
+[exclusion-06] Rebuilding #195's regression suite to bind its labels to the mapping,
+    which is #211.
+    !! UNACCOUNTED FOR — the decomposer did not address this
+       disposition 'yielded' named no usable output
+
+[exclusion-07] Measuring whether decomposition recall improves as a result of this
+    change.
+    !! UNACCOUNTED FOR — the decomposer did not address this
+       disposition 'yielded' named no usable output
+
+[exclusion-08] Supporting task-file structures beyond the §7.1 format the parser already
+    recognises.
+    !! UNACCOUNTED FOR — the decomposer did not address this
+       disposition 'yielded' named no usable output
+
+[completion-01] Implementation
+    -- no obligation, deliberately
+       Section marker with no standalone requirement.
+
+[completion-02] The nested-bullet reproduction recorded on #216 yields either five
+    requirements, or two requirements plus three unread blocks.
+    -> obligation-claim-nested-content-reachable  [functional/explicit]   (also serves task-01, task-03, exclusion-01)
+       Make content nested inside a claimed list item reachable so it is either
+       extracted as a requirement in its own right or recorded as unread text, with
+       every nested region accounted for exactly once by one of those two readings.
+    -> obligation-nested-bullet-reading-recorded  [human_review/explicit]   (also serves task-03, completion-09)
+       Record the chosen reading for a nested bullet as either a requirement of its own
+       or a continuation of its parent.
+
+[completion-03] A list item holding two paragraphs loses neither paragraph.
+    -> obligation-list-item-paragraphs-preserved  [functional/explicit]
+       Preserve every paragraph within a list item so a list item holding two paragraphs
+       loses neither paragraph.
+
+[completion-04] A block nested inside a claimed list item that is neither a paragraph
+    nor a bullet — a code fence or a table — is reachable by the same rule.
+    -> obligation-nested-nonparagraph-blocks-reachable  [functional/explicit]
+       Make blocks nested inside a claimed list item that are not paragraphs or bullets
+       reachable under the same coverage rule.
+
+[completion-05] A test asserts that every non-whitespace, non-heading region of a task
+    file lies inside either a registry span or an unclaimed span.
+    -> obligation-coverage-assertion-all-nonheading-regions  [functional/explicit]
+       Assert that every non-whitespace, non-heading region of a task file lies inside
+       either a registry span or an unclaimed span.
+
+[completion-06] That coverage assertion runs over the repository's own committed task
+    files.
+    -> obligation-coverage-assertion-committed-task-files  [functional/explicit]
+       Run the coverage assertion over the repository's own committed task files.
+
+[completion-07] That coverage assertion runs over the `tests/fixtures/decompose-
+    stability/` corpus.
+    -> obligation-coverage-assertion-fixtures-corpus  [functional/explicit]
+       Run the coverage assertion over the `tests/fixtures/decompose-stability/` corpus.
+
+[completion-08] A task file whose every block is claimed still reports zero unread
+    blocks.
+    -> obligation-zero-unread-when-all-blocks-claimed  [regression/explicit]   (also serves task-02)
+       Preserve the behavior that a task file whose every block is claimed reports zero
+       unread blocks.
+
+[completion-09] The chosen reading of a nested bullet — a requirement of its own, or a
+    continuation of its parent — is recorded in a Decision Record or on #216.
+    -> obligation-nested-bullet-reading-recorded  [human_review/explicit]   (also serves task-03, completion-02)
+       Record the chosen reading for a nested bullet as either a requirement of its own
+       or a continuation of its parent.
+
+[completion-10] The decomposition-accuracy figure is marked non-comparable across this
+    change where a reader meets it.
+    !! UNACCOUNTED FOR — the decomposer did not address this
+       disposition 'yielded' named no usable output
+

--- a/dogfood-logs/217-gate1-run1/current-task.md
+++ b/dogfood-logs/217-gate1-run1/current-task.md
@@ -1,0 +1,70 @@
+# Task
+DR-202 decision 3 gives a requirement exactly one of three dispositions, each
+carrying something: yielded obligations, deliberately yields none with a reason,
+or raised an open question instead. The implementation added a fourth,
+`UNDISPOSED`, carrying none of them, and reached it two ways: a response that
+never mentioned a requirement, and a response that labelled a requirement
+`yielded` while naming no obligations.
+
+Both are malformed responses, and both are currently absorbed as soft findings.
+`_requirement_map` discards the reason the response supplied, substitutes a
+diagnostic string of its own, and lets the run continue to a verdict on an
+answer that did not account for the mandate.
+
+The registry of requirements is derived deterministically from the parse, and
+the code iterates over that registry. Dropping a requirement is therefore not a
+possible outcome — the only possible bad outcome is a response of poor quality.
+Make that true in the types: every requirement carries one of exactly three
+dispositions, each structurally required to carry its own payload, and a
+response that fails to account for every requirement does not parse. Remove the
+fourth disposition entirely.
+
+## Constraints
+- A requirement disposition is one of exactly three: yielded obligations,
+  no obligations needed with a reason, or an open question that prevents an
+  answer.
+- `Disposition` has no `UNDISPOSED` value.
+- `_RequirementDisposition` is a discriminated union on its disposition field.
+- A `yielded` disposition carries at least one obligation id.
+- A `no_obligation` disposition carries a reason that is not empty.
+- An `open_question` disposition carries at least one open-question id.
+- A response labelling a requirement `yielded` while naming no obligation id
+  fails to parse.
+- A response labelling a requirement `no_obligation` with an empty reason fails
+  to parse.
+- A response that omits any requirement in the registry is rejected.
+- A response that names a requirement id absent from the registry is rejected.
+- A rejected response produces no `RequirementMap`.
+- The JSON schema sent to the model cannot express a `yielded` disposition with
+  zero obligation ids.
+- The reason a response supplies for declining a requirement is preserved rather
+  than replaced by a diagnostic string.
+- Typed schemas are pydantic models, as the rest of the repository defines them.
+- Tests issue no live model calls.
+
+## Scope exclusions
+- The decomposer declining to yield obligations for scope exclusions, against
+  the instruction already in the decompose prompt. That is a prompt defect
+  tracked separately and costs a transcript re-record.
+- Changing the decompose prompt text.
+- Retrying or repairing a rejected response.
+- Nested-bullet and multi-paragraph parse coverage, which is #216.
+- Whether mandate coverage bounds the completion verdict, which is #214.
+- Aligning requirement ids across two versions of a task file, which is #209.
+
+## Completion expectations
+- Implementation
+- Every requirement in a parsed `RequirementMap` carries one of the three
+  dispositions.
+- A response with a `yielded` disposition and no obligation ids is rejected.
+- A response with a `no_obligation` disposition and an empty reason is rejected.
+- A response omitting a requirement present in the registry is rejected.
+- No `RequirementMap` is produced from a rejected response.
+- The `UNDISPOSED` value and every code path that assigns it are removed.
+- A test asserts that the schema sent to the model rejects a `yielded`
+  disposition carrying zero obligation ids.
+- The tests, CLI rendering and report sections that referred to the removed
+  disposition are updated rather than left asserting it.
+- `docs/DR-202-decomposition-requirement-mapping.md` records that the
+  disposition set is the three of decision 3, and that completeness is enforced
+  at parse.

--- a/dogfood-logs/217-gate1-run1/judgement.md
+++ b/dogfood-logs/217-gate1-run1/judgement.md
@@ -1,0 +1,18 @@
+# Judgement — #217 Gate 1 run 1
+
+At `95a3856` (pre-implementation). **Gate 1 passed.**
+
+`Requirements: 34   with obligations: 33   deliberately none: 1   unaccounted for: 0`
+
+Zero open questions, so step 3 had nothing to triage. The breakdown is accurate:
+no invented obligations, none of the real ones missing.
+
+## One finding, attributed
+
+`obl-three-dispositions-only` is linked to five scope exclusions that do not
+state it — `exclusion-04` is "nested-bullet parse coverage, which is #216", which
+has nothing to do with the disposition set. A scope exclusion carrying a
+neighbouring requirement's obligation is **#210** exactly. Attributed there, not
+addressed here.
+
+Decomposition confirmed by the human in-session before coding began.

--- a/dogfood-logs/217-gate1-run1/output.log
+++ b/dogfood-logs/217-gate1-run1/output.log
@@ -1,0 +1,212 @@
+Requirements: 34   with obligations: 33   deliberately none: 1   unaccounted for: 0
+
+[task-01] DR-202 decision 3 gives a requirement exactly one of three dispositions, each
+    carrying something: yielded obligations, deliberately yields none with a reason, or
+    raised an open question instead. The implementation added a fourth, `UNDISPOSED`,
+    carrying none of them, and reached it two ways: a response that never mentioned a
+    requirement, and a response that labelled a requirement `yielded` while naming no
+    obligations.
+    -> obl-three-dispositions-only  [invariant/explicit]   (also serves task-03, constraint-01, exclusion-01, exclusion-02, exclusion-04, exclusion-05, exclusion-06, completion-02)
+       Requirement dispositions are limited to exactly three cases: yielded obligations,
+       no obligations needed with a reason, or an open question that prevents an answer.
+    -> obl-no-undisposed  [invariant/explicit]   (also serves constraint-02)
+       The disposition set excludes any UNDISPOSED value.
+    -> obl-yielded-empty-ids-reject  [error_handling/explicit]   (also serves constraint-07, completion-03)
+       A response labelling a requirement yielded while naming no obligation id fails to
+       parse.
+
+[task-02] Both are malformed responses, and both are currently absorbed as soft
+    findings. `_requirement_map` discards the reason the response supplied, substitutes
+    a diagnostic string of its own, and lets the run continue to a verdict on an answer
+    that did not account for the mandate.
+    -> obl-preserve-decline-reason  [invariant/explicit]   (also serves constraint-13)
+       The reason supplied for declining a requirement is preserved rather than replaced
+       by a diagnostic string.
+    -> obl-rejected-produces-no-map  [error_handling/explicit]   (also serves constraint-11, exclusion-03, completion-06)
+       A rejected response produces no RequirementMap.
+
+[task-03] The registry of requirements is derived deterministically from the parse, and
+    the code iterates over that registry. Dropping a requirement is therefore not a
+    possible outcome — the only possible bad outcome is a response of poor quality. Make
+    that true in the types: every requirement carries one of exactly three dispositions,
+    each structurally required to carry its own payload, and a response that fails to
+    account for every requirement does not parse. Remove the fourth disposition
+    entirely.
+    -> obl-three-dispositions-only  [invariant/explicit]   (also serves task-01, constraint-01, exclusion-01, exclusion-02, exclusion-04, exclusion-05, exclusion-06, completion-02)
+       Requirement dispositions are limited to exactly three cases: yielded obligations,
+       no obligations needed with a reason, or an open question that prevents an answer.
+    -> obl-discriminated-union  [functional/explicit]   (also serves constraint-03)
+       _RequirementDisposition is modeled as a discriminated union keyed by its
+       disposition field.
+    -> obl-yielded-needs-obligation-id  [boundary/explicit]   (also serves constraint-04)
+       A yielded disposition carries at least one obligation id.
+    -> obl-no-obligation-needs-reason  [boundary/explicit]   (also serves constraint-05)
+       A no_obligation disposition carries a non-empty reason.
+    -> obl-open-question-needs-question-id  [boundary/explicit]   (also serves constraint-06)
+       An open_question disposition carries at least one open-question id.
+    -> obl-registry-completeness-enforced-at-parse  [error_handling/explicit]   (also serves exclusion-03)
+       A response that fails to account for every requirement does not parse.
+    -> obl-remove-undisposed-codepaths  [regression/explicit]   (also serves completion-07)
+       The UNDISPOSED value and every code path that assigns it are removed.
+
+[constraint-01] A requirement disposition is one of exactly three: yielded obligations,
+    no obligations needed with a reason, or an open question that prevents an answer.
+    -> obl-three-dispositions-only  [invariant/explicit]   (also serves task-01, task-03, exclusion-01, exclusion-02, exclusion-04, exclusion-05, exclusion-06, completion-02)
+       Requirement dispositions are limited to exactly three cases: yielded obligations,
+       no obligations needed with a reason, or an open question that prevents an answer.
+
+[constraint-02] `Disposition` has no `UNDISPOSED` value.
+    -> obl-no-undisposed  [invariant/explicit]   (also serves task-01)
+       The disposition set excludes any UNDISPOSED value.
+
+[constraint-03] `_RequirementDisposition` is a discriminated union on its disposition
+    field.
+    -> obl-discriminated-union  [functional/explicit]   (also serves task-03)
+       _RequirementDisposition is modeled as a discriminated union keyed by its
+       disposition field.
+
+[constraint-04] A `yielded` disposition carries at least one obligation id.
+    -> obl-yielded-needs-obligation-id  [boundary/explicit]   (also serves task-03)
+       A yielded disposition carries at least one obligation id.
+
+[constraint-05] A `no_obligation` disposition carries a reason that is not empty.
+    -> obl-no-obligation-needs-reason  [boundary/explicit]   (also serves task-03)
+       A no_obligation disposition carries a non-empty reason.
+
+[constraint-06] An `open_question` disposition carries at least one open-question id.
+    -> obl-open-question-needs-question-id  [boundary/explicit]   (also serves task-03)
+       An open_question disposition carries at least one open-question id.
+
+[constraint-07] A response labelling a requirement `yielded` while naming no obligation
+    id fails to parse.
+    -> obl-yielded-empty-ids-reject  [error_handling/explicit]   (also serves task-01, completion-03)
+       A response labelling a requirement yielded while naming no obligation id fails to
+       parse.
+
+[constraint-08] A response labelling a requirement `no_obligation` with an empty reason
+    fails to parse.
+    -> obl-no-obligation-empty-reason-reject  [error_handling/explicit]   (also serves completion-04)
+       A response labelling a requirement no_obligation with an empty reason fails to
+       parse.
+
+[constraint-09] A response that omits any requirement in the registry is rejected.
+    -> obl-missing-requirement-reject  [error_handling/explicit]   (also serves completion-05)
+       A response that omits any requirement in the registry is rejected.
+
+[constraint-10] A response that names a requirement id absent from the registry is
+    rejected.
+    -> obl-unknown-requirement-reject  [error_handling/explicit]
+       A response that names a requirement id absent from the registry is rejected.
+
+[constraint-11] A rejected response produces no `RequirementMap`.
+    -> obl-rejected-produces-no-map  [error_handling/explicit]   (also serves task-02, exclusion-03, completion-06)
+       A rejected response produces no RequirementMap.
+
+[constraint-12] The JSON schema sent to the model cannot express a `yielded` disposition
+    with zero obligation ids.
+    -> obl-schema-rejects-zero-yielded-ids  [compatibility/explicit]
+       The JSON schema sent to the model cannot express a yielded disposition with zero
+       obligation ids.
+
+[constraint-13] The reason a response supplies for declining a requirement is preserved
+    rather than replaced by a diagnostic string.
+    -> obl-preserve-decline-reason  [invariant/explicit]   (also serves task-02)
+       The reason supplied for declining a requirement is preserved rather than replaced
+       by a diagnostic string.
+
+[constraint-14] Typed schemas are pydantic models, as the rest of the repository defines
+    them.
+    -> obl-pydantic-schemas  [compatibility/explicit]
+       Typed schemas are implemented as pydantic models.
+
+[constraint-15] Tests issue no live model calls.
+    -> obl-tests-no-live-model-calls  [regression/explicit]
+       Tests issue no live model calls.
+
+[exclusion-01] The decomposer declining to yield obligations for scope exclusions,
+    against the instruction already in the decompose prompt. That is a prompt defect
+    tracked separately and costs a transcript re-record.
+    -> obl-three-dispositions-only  [invariant/explicit]   (also serves task-01, task-03, constraint-01, exclusion-02, exclusion-04, exclusion-05, exclusion-06, completion-02)
+       Requirement dispositions are limited to exactly three cases: yielded obligations,
+       no obligations needed with a reason, or an open question that prevents an answer.
+
+[exclusion-02] Changing the decompose prompt text.
+    -> obl-three-dispositions-only  [invariant/explicit]   (also serves task-01, task-03, constraint-01, exclusion-01, exclusion-04, exclusion-05, exclusion-06, completion-02)
+       Requirement dispositions are limited to exactly three cases: yielded obligations,
+       no obligations needed with a reason, or an open question that prevents an answer.
+
+[exclusion-03] Retrying or repairing a rejected response.
+    -> obl-registry-completeness-enforced-at-parse  [error_handling/explicit]   (also serves task-03)
+       A response that fails to account for every requirement does not parse.
+    -> obl-rejected-produces-no-map  [error_handling/explicit]   (also serves task-02, constraint-11, completion-06)
+       A rejected response produces no RequirementMap.
+
+[exclusion-04] Nested-bullet and multi-paragraph parse coverage, which is #216.
+    -> obl-three-dispositions-only  [invariant/explicit]   (also serves task-01, task-03, constraint-01, exclusion-01, exclusion-02, exclusion-05, exclusion-06, completion-02)
+       Requirement dispositions are limited to exactly three cases: yielded obligations,
+       no obligations needed with a reason, or an open question that prevents an answer.
+
+[exclusion-05] Whether mandate coverage bounds the completion verdict, which is #214.
+    -> obl-three-dispositions-only  [invariant/explicit]   (also serves task-01, task-03, constraint-01, exclusion-01, exclusion-02, exclusion-04, exclusion-06, completion-02)
+       Requirement dispositions are limited to exactly three cases: yielded obligations,
+       no obligations needed with a reason, or an open question that prevents an answer.
+
+[exclusion-06] Aligning requirement ids across two versions of a task file, which is
+    #209.
+    -> obl-three-dispositions-only  [invariant/explicit]   (also serves task-01, task-03, constraint-01, exclusion-01, exclusion-02, exclusion-04, exclusion-05, completion-02)
+       Requirement dispositions are limited to exactly three cases: yielded obligations,
+       no obligations needed with a reason, or an open question that prevents an answer.
+
+[completion-01] Implementation
+    -- no obligation, deliberately
+       Section marker only.
+
+[completion-02] Every requirement in a parsed `RequirementMap` carries one of the three
+    dispositions.
+    -> obl-three-dispositions-only  [invariant/explicit]   (also serves task-01, task-03, constraint-01, exclusion-01, exclusion-02, exclusion-04, exclusion-05, exclusion-06)
+       Requirement dispositions are limited to exactly three cases: yielded obligations,
+       no obligations needed with a reason, or an open question that prevents an answer.
+
+[completion-03] A response with a `yielded` disposition and no obligation ids is
+    rejected.
+    -> obl-yielded-empty-ids-reject  [error_handling/explicit]   (also serves task-01, constraint-07)
+       A response labelling a requirement yielded while naming no obligation id fails to
+       parse.
+
+[completion-04] A response with a `no_obligation` disposition and an empty reason is
+    rejected.
+    -> obl-no-obligation-empty-reason-reject  [error_handling/explicit]   (also serves constraint-08)
+       A response labelling a requirement no_obligation with an empty reason fails to
+       parse.
+
+[completion-05] A response omitting a requirement present in the registry is rejected.
+    -> obl-missing-requirement-reject  [error_handling/explicit]   (also serves constraint-09)
+       A response that omits any requirement in the registry is rejected.
+
+[completion-06] No `RequirementMap` is produced from a rejected response.
+    -> obl-rejected-produces-no-map  [error_handling/explicit]   (also serves task-02, constraint-11, exclusion-03)
+       A rejected response produces no RequirementMap.
+
+[completion-07] The `UNDISPOSED` value and every code path that assigns it are removed.
+    -> obl-remove-undisposed-codepaths  [regression/explicit]   (also serves task-03)
+       The UNDISPOSED value and every code path that assigns it are removed.
+
+[completion-08] A test asserts that the schema sent to the model rejects a `yielded`
+    disposition carrying zero obligation ids.
+    -> obl-schema-test-rejects-empty-yielded  [docs_config/explicit]
+       A test asserts that the schema sent to the model rejects a yielded disposition
+       carrying zero obligation ids.
+
+[completion-09] The tests, CLI rendering and report sections that referred to the
+    removed disposition are updated rather than left asserting it.
+    -> obl-update-references-to-removed-disposition  [regression/explicit]
+       Tests, CLI rendering, and report sections that referred to the removed
+       disposition are updated rather than left asserting it.
+
+[completion-10] `docs/DR-202-decomposition-requirement-mapping.md` records that the
+    disposition set is the three of decision 3, and that completeness is enforced at
+    parse.
+    -> obl-docs-record-three-dispositions-and-parse-enforcement  [docs_config/explicit]
+       The decomposition mapping documentation records that the disposition set is the
+       three of decision 3 and that completeness is enforced at parse.
+

--- a/dogfood-logs/217-gate2-run1/current-task.md
+++ b/dogfood-logs/217-gate2-run1/current-task.md
@@ -1,0 +1,70 @@
+# Task
+DR-202 decision 3 gives a requirement exactly one of three dispositions, each
+carrying something: yielded obligations, deliberately yields none with a reason,
+or raised an open question instead. The implementation added a fourth,
+`UNDISPOSED`, carrying none of them, and reached it two ways: a response that
+never mentioned a requirement, and a response that labelled a requirement
+`yielded` while naming no obligations.
+
+Both are malformed responses, and both are currently absorbed as soft findings.
+`_requirement_map` discards the reason the response supplied, substitutes a
+diagnostic string of its own, and lets the run continue to a verdict on an
+answer that did not account for the mandate.
+
+The registry of requirements is derived deterministically from the parse, and
+the code iterates over that registry. Dropping a requirement is therefore not a
+possible outcome — the only possible bad outcome is a response of poor quality.
+Make that true in the types: every requirement carries one of exactly three
+dispositions, each structurally required to carry its own payload, and a
+response that fails to account for every requirement does not parse. Remove the
+fourth disposition entirely.
+
+## Constraints
+- A requirement disposition is one of exactly three: yielded obligations,
+  no obligations needed with a reason, or an open question that prevents an
+  answer.
+- `Disposition` has no `UNDISPOSED` value.
+- `_RequirementDisposition` is a discriminated union on its disposition field.
+- A `yielded` disposition carries at least one obligation id.
+- A `no_obligation` disposition carries a reason that is not empty.
+- An `open_question` disposition carries at least one open-question id.
+- A response labelling a requirement `yielded` while naming no obligation id
+  fails to parse.
+- A response labelling a requirement `no_obligation` with an empty reason fails
+  to parse.
+- A response that omits any requirement in the registry is rejected.
+- A response that names a requirement id absent from the registry is rejected.
+- A rejected response produces no `RequirementMap`.
+- The JSON schema sent to the model cannot express a `yielded` disposition with
+  zero obligation ids.
+- The reason a response supplies for declining a requirement is preserved rather
+  than replaced by a diagnostic string.
+- Typed schemas are pydantic models, as the rest of the repository defines them.
+- Tests issue no live model calls.
+
+## Scope exclusions
+- The decomposer declining to yield obligations for scope exclusions, against
+  the instruction already in the decompose prompt. That is a prompt defect
+  tracked separately and costs a transcript re-record.
+- Changing the decompose prompt text.
+- Retrying or repairing a rejected response.
+- Nested-bullet and multi-paragraph parse coverage, which is #216.
+- Whether mandate coverage bounds the completion verdict, which is #214.
+- Aligning requirement ids across two versions of a task file, which is #209.
+
+## Completion expectations
+- Implementation
+- Every requirement in a parsed `RequirementMap` carries one of the three
+  dispositions.
+- A response with a `yielded` disposition and no obligation ids is rejected.
+- A response with a `no_obligation` disposition and an empty reason is rejected.
+- A response omitting a requirement present in the registry is rejected.
+- No `RequirementMap` is produced from a rejected response.
+- The `UNDISPOSED` value and every code path that assigns it are removed.
+- A test asserts that the schema sent to the model rejects a `yielded`
+  disposition carrying zero obligation ids.
+- The tests, CLI rendering and report sections that referred to the removed
+  disposition are updated rather than left asserting it.
+- `docs/DR-202-decomposition-requirement-mapping.md` records that the
+  disposition set is the three of decision 3, and that completeness is enforced
+  at parse.

--- a/dogfood-logs/217-gate2-run1/judgement.md
+++ b/dogfood-logs/217-gate2-run1/judgement.md
@@ -1,0 +1,36 @@
+# Judgement — #217 Gate 2 run 1
+
+`6ae97fd` → `76b847b`. **Not clean.** INCOMPLETE: 1 obligation not addressed,
+11 with non-discriminating test evidence.
+
+## The true positive that mattered
+
+`obligation-discriminated-union` — *"Model `_RequirementDisposition` as a
+discriminated union keyed by its disposition field"* — **code evidence: not
+addressed.** Correct. The implementation uses a plain `Union`, deliberately: a
+pydantic tagged union renders `oneOf` + `discriminator` and OpenAI strict mode
+accepts neither, and `inline_schema_refs` would leave the discriminator mapping
+pointing at `$defs` it had just inlined.
+
+Disposition: **task-file wording corrected** (the sanctioned rewrite). The
+constraint named a pydantic mechanism that turned out to be unusable; it now
+states the requirement — one shape per disposition, carrying only its own
+payload, unambiguous at parse via literal tags. The wording changed, the output
+did not.
+
+## Real test gaps, all closed in `007966f`
+
+Unknown requirement id rejected; requirement disposed twice rejected;
+open-question disposition naming no produced question rejected; the disposition
+set is exactly three with no executable reference to the removed value; DR-202
+records the amendment.
+
+## Unrequested changes
+
+One **[separable]**: the union walk added to `supplied_ids.py`. Investigated, not
+waved off — it is load-bearing (without it the `requirement_id` constraint
+silently vanishes under the new shape) but the mandate genuinely did not ask for
+it, and it had **no test at all**. Both fixed: a constraint added to the task
+file, and `test_a_union_of_item_shapes_constrains_every_member` added.
+
+The three **[in_service]** entries are accurate and accepted.

--- a/dogfood-logs/217-gate2-run1/output.log
+++ b/dogfood-logs/217-gate2-run1/output.log
@@ -1,0 +1,321 @@
+Task completion: INCOMPLETE
+
+1 obligation(s) not fully implemented (obligation-discriminated-union); 11 obligation(s) with non-discriminating test evidence (obligation-three-dispositions-only, obligation-no-undisposed, obligation-open-question-needs-id, obligation-unknown-requirement-rejected, obligation-pydantic-schemas, obligation-tests-no-live-calls, obligation-completion-three-dispositions, obligation-completion-yielded-rejected-empty, obligation-remove-undisposed-codepaths, obligation-schema-test-empty-yielded, obligation-doc-record-three-dispositions).
+
+Obligations:
+
+  1. Represent requirement dispositions as exactly three cases: yielded obligations, no obligations needed with a reason, or an open question that prevents an answer.
+       requirements: task-01, constraint-01, exclusion-01, exclusion-02, exclusion-04, exclusion-05, exclusion-06
+       code evidence: addressed
+         1.1  src/acceptance/requirement/obligations.py#@@ -173,14 +181,52 @@ class _OpenQuestion(StrictResponseModel):
+         1.2  src/acceptance/review_state.py#@@ -280,17 +280,18 @@ class Disposition(str, Enum):
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  2. Keep the disposition set limited to the three decision-3 dispositions by removing the UNDISPOSED value.
+       requirements: task-01, constraint-02
+       code evidence: addressed
+         2.1  src/acceptance/review_state.py#@@ -280,17 +280,18 @@ class Disposition(str, Enum):
+         2.2  src/acceptance/cli.py#@@ -40,7 +40,7 @@ from acceptance.report import render_report
+         2.3  src/acceptance/cli.py#@@ -286,26 +286,26 @@ def _summary(requirement_map, total: int) -> str:
+         2.4  src/acceptance/cli.py#@@ -344,12 +344,9 @@ def _requirement_block(
+         2.5  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+         2.6  src/acceptance/review_state.py#@@ -364,23 +361,17 @@ class RequirementMap(_Model):
+       test evidence: nominally supported  [tier: static]
+         2.7  tests/requirement/test_requirement_map.py::test_a_fully_accounted_response_disposes_every_requirement
+
+  3. Model `_RequirementDisposition` as a discriminated union keyed by its disposition field.
+       requirements: constraint-03
+       code evidence: not addressed
+         3.1  src/acceptance/requirement/obligations.py#@@ -173,14 +181,52 @@ class _OpenQuestion(StrictResponseModel):
+       test evidence: strongly supported  [tier: static]
+         3.2  tests/requirement/test_requirement_map.py::test_the_schema_cannot_express_a_yielded_disposition_with_no_obligations
+
+  4. Require every yielded disposition to carry at least one obligation id.
+       requirements: constraint-04
+       code evidence: addressed
+         4.1  src/acceptance/requirement/obligations.py#@@ -173,14 +181,52 @@ class _OpenQuestion(StrictResponseModel):
+       test evidence: strongly supported  [tier: static]
+         4.2  tests/requirement/test_requirement_map.py::test_a_yielded_claim_naming_no_real_obligation_is_rejected
+         4.3  tests/requirement/test_requirement_map.py::test_the_schema_cannot_express_a_yielded_disposition_with_no_obligations
+
+  5. Require every no_obligation disposition to carry a non-empty reason.
+       requirements: constraint-05
+       code evidence: addressed
+         5.1  src/acceptance/requirement/obligations.py#@@ -173,14 +181,52 @@ class _OpenQuestion(StrictResponseModel):
+         5.2  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+         5.3  src/acceptance/review_state.py#@@ -319,10 +320,6 @@ class RequirementDisposition(_Model):
+       test evidence: strongly supported  [tier: static]
+         5.4  tests/requirement/test_requirement_map.py::test_a_no_obligation_disposition_with_an_empty_reason_is_rejected
+         5.5  tests/test_cli.py::test_the_pipeline_persists_the_requirement_map
+
+  6. Require every open_question disposition to carry at least one open-question id.
+       requirements: constraint-06
+       code evidence: addressed
+         6.1  src/acceptance/requirement/obligations.py#@@ -173,14 +181,52 @@ class _OpenQuestion(StrictResponseModel):
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  7. Reject responses that label a requirement yielded while providing no obligation ids.
+       requirements: task-01, constraint-07
+       code evidence: addressed
+         7.1  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+       test evidence: strongly supported  [tier: static]
+         7.2  tests/requirement/test_requirement_map.py::test_a_yielded_claim_naming_no_real_obligation_is_rejected
+         7.3  tests/requirement/test_requirement_map.py::test_the_schema_cannot_express_a_yielded_disposition_with_no_obligations
+
+  8. Reject responses that label a requirement no_obligation while providing an empty reason.
+       requirements: constraint-08
+       code evidence: addressed
+         8.1  src/acceptance/review_state.py#@@ -319,10 +320,6 @@ class RequirementDisposition(_Model):
+         8.2  tests/requirement/test_requirement_map.py#@@ -192,16 +233,100 @@ def test_a_yielded_claim_naming_no_real_obligation_is_not_honoured():
+       test evidence: strongly supported  [tier: static]
+         8.3  tests/requirement/test_requirement_map.py::test_a_no_obligation_disposition_with_an_empty_reason_is_rejected
+
+  9. Reject responses that omit any requirement in the registry.
+       requirements: constraint-09
+       code evidence: addressed
+         9.1  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+       test evidence: strongly supported  [tier: static]
+         9.2  tests/requirement/test_obligations.py::test_archetype_1_includes_the_omitted_obligation
+         9.3  tests/requirement/test_requirement_map.py::test_a_response_that_never_mentions_a_requirement_is_rejected
+
+  10. Reject responses that name a requirement id absent from the registry.
+       requirements: constraint-10
+       code evidence: addressed
+         10.1  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  11. Produce no RequirementMap from a rejected response.
+       requirements: constraint-11
+       code evidence: addressed
+         11.1  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+       test evidence: strongly supported  [tier: static]
+         11.2  tests/requirement/test_requirement_map.py::test_a_response_that_never_mentions_a_requirement_is_rejected
+
+  12. Express in the JSON schema sent to the model that yielded cannot carry zero obligation ids.
+       requirements: constraint-12
+       code evidence: addressed
+         12.1  src/acceptance/requirement/obligations.py#@@ -173,14 +181,52 @@ class _OpenQuestion(StrictResponseModel):
+         12.2  tests/requirement/test_requirement_map.py#@@ -192,16 +233,100 @@ def test_a_yielded_claim_naming_no_real_obligation_is_not_honoured():
+       test evidence: strongly supported  [tier: static]
+         12.3  tests/requirement/test_requirement_map.py::test_the_schema_cannot_express_a_yielded_disposition_with_no_obligations
+
+  13. Preserve the reason supplied for declining a requirement instead of replacing it with a diagnostic string.
+       requirements: task-02, constraint-13
+       code evidence: addressed
+         13.1  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+         13.2  tests/requirement/test_requirement_map.py#@@ -192,16 +233,100 @@ def test_a_yielded_claim_naming_no_real_obligation_is_not_honoured():
+       test evidence: strongly supported  [tier: static]
+         13.3  tests/requirement/test_requirement_map.py::test_a_requirement_deliberately_yielding_nothing_carries_its_reason
+         13.4  tests/requirement/test_requirement_map.py::test_a_supplied_reason_is_preserved_rather_than_replaced
+         13.5  tests/test_cli.py::test_the_pipeline_persists_the_requirement_map
+
+  14. Implement the typed schemas as pydantic models.
+       requirements: constraint-14
+       code evidence: addressed
+         14.1  src/acceptance/requirement/obligations.py#@@ -173,14 +181,52 @@ class _OpenQuestion(StrictResponseModel):
+         14.2  src/acceptance/review_state.py#@@ -280,17 +280,18 @@ class Disposition(str, Enum):
+       test evidence: nominally supported  [tier: static]
+         14.3  tests/requirement/test_requirement_map.py::test_the_schema_cannot_express_a_yielded_disposition_with_no_obligations
+         14.4  tests/test_llm.py::test_the_hashed_request_carries_the_inlined_schema
+         14.5  tests/test_llm.py::test_the_schema_sent_to_the_provider_has_no_ref_indirection
+
+  15. Keep the tests free of live model calls.
+       requirements: constraint-15
+       code evidence: addressed
+         (no corresponding change)
+       test evidence: nominally supported  [tier: static]
+         15.1  tests/test_cli.py::test_a_default_cli_run_is_seeded
+         15.2  tests/test_cli.py::test_check_records_determinism_flags_in_provenance
+         15.3  tests/test_cli.py::test_classify_replay_without_transcript_fails_cleanly
+         15.4  tests/test_cli.py::test_decompose_replay_without_transcript_fails_cleanly
+         15.5  tests/test_cli.py::test_retrieval_makes_no_model_call
+         15.6  tests/test_cli.py::test_two_runs_over_the_same_input_are_byte_identical
+
+  16. Ensure every requirement in a parsed RequirementMap carries one of the three dispositions.
+       requirements: task-03, completion-02
+       code evidence: addressed
+         16.1  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+         16.2  src/acceptance/review_state.py#@@ -280,17 +280,18 @@ class Disposition(str, Enum):
+       test evidence: nominally supported  [tier: static]
+         16.3  tests/requirement/test_requirement_map.py::test_a_fully_accounted_response_disposes_every_requirement
+         16.4  tests/test_cli.py::test_check_json_emits_a_structured_review
+         16.5  tests/test_cli.py::test_the_pipeline_persists_the_requirement_map
+
+  17. Reject yielded responses that carry no obligation ids.
+       requirements: completion-03
+       code evidence: addressed
+         17.1  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  18. Reject no_obligation responses that carry an empty reason.
+       requirements: completion-04
+       code evidence: addressed
+         18.1  src/acceptance/review_state.py#@@ -319,10 +320,6 @@ class RequirementDisposition(_Model):
+       test evidence: strongly supported  [tier: static]
+         18.2  tests/requirement/test_requirement_map.py::test_a_no_obligation_disposition_with_an_empty_reason_is_rejected
+         18.3  tests/test_cli.py::test_the_pipeline_persists_the_requirement_map
+
+  19. Reject responses that omit a requirement present in the registry.
+       requirements: completion-05
+       code evidence: addressed
+         19.1  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+       test evidence: strongly supported  [tier: static]
+         19.2  tests/requirement/test_obligations.py::test_archetype_1_includes_the_omitted_obligation
+         19.3  tests/requirement/test_requirement_map.py::test_a_response_that_never_mentions_a_requirement_is_rejected
+
+  20. Produce no RequirementMap from any rejected response.
+       requirements: task-03, exclusion-03, completion-06
+       code evidence: addressed
+         20.1  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+       test evidence: strongly supported  [tier: static]
+         20.2  tests/requirement/test_requirement_map.py::test_a_response_that_never_mentions_a_requirement_is_rejected
+
+  21. Remove the UNDISPOSED value and every code path that assigns it.
+       requirements: task-03, completion-07
+       code evidence: addressed
+         21.1  src/acceptance/review_state.py#@@ -280,17 +280,18 @@ class Disposition(str, Enum):
+         21.2  src/acceptance/review_state.py#@@ -319,10 +320,6 @@ class RequirementDisposition(_Model):
+         21.3  src/acceptance/review_state.py#@@ -364,23 +361,17 @@ class RequirementMap(_Model):
+         21.4  src/acceptance/cli.py#@@ -286,26 +286,26 @@ def _summary(requirement_map, total: int) -> str:
+         21.5  src/acceptance/cli.py#@@ -344,12 +344,9 @@ def _requirement_block(
+         21.6  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+         21.7  tests/requirement/test_requirement_map.py#@@ -124,14 +148,27 @@ def test_a_fully_accounted_response_leaves_no_requirement_undisposed():
+         21.8  tests/requirement/test_requirement_map.py#@@ -146,12 +183,12 @@ def test_a_requirement_the_response_never_mentions_is_recorded_as_undisposed():
+         21.9  tests/requirement/test_requirement_map.py#@@ -334,10 +458,7 @@ def test_the_cli_lists_every_requirement_including_the_ones_yielding_nothing():
+         21.10  tests/test_cli.py#@@ -948,11 +949,14 @@ def test_the_pipeline_persists_the_requirement_map(git_repo, tmp_path, stub_mode
+         21.11  tests/test_cli.py#@@ -973,7 +977,10 @@ def test_the_pipeline_persists_the_requirement_map(git_repo, tmp_path, stub_mode
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  22. Keep a test asserting that the schema sent to the model rejects yielded dispositions with zero obligation ids.
+       requirements: completion-08
+       code evidence: addressed
+         22.1  tests/requirement/test_requirement_map.py#@@ -192,16 +233,100 @@ def test_a_yielded_claim_naming_no_real_obligation_is_not_honoured():
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  23. Update tests, CLI rendering, and report sections that referred to the removed disposition.
+       requirements: completion-09
+       code evidence: addressed
+         23.1  src/acceptance/cli.py#@@ -286,26 +286,26 @@ def _summary(requirement_map, total: int) -> str:
+         23.2  src/acceptance/cli.py#@@ -344,12 +344,9 @@ def _requirement_block(
+         23.3  src/acceptance/report.py#@@ -207,9 +207,13 @@ def _mandate_coverage_block(requirement_map: RequirementMap) -> list[str]:
+         23.4  src/acceptance/review_state.py#@@ -280,17 +280,18 @@ class Disposition(str, Enum):
+         23.5  src/acceptance/review_state.py#@@ -364,23 +361,17 @@ class RequirementMap(_Model):
+         23.6  tests/requirement/test_requirement_map.py#@@ -124,14 +148,27 @@ def test_a_fully_accounted_response_leaves_no_requirement_undisposed():
+         23.7  tests/requirement/test_requirement_map.py#@@ -146,12 +183,12 @@ def test_a_requirement_the_response_never_mentions_is_recorded_as_undisposed():
+         23.8  tests/requirement/test_requirement_map.py#@@ -334,10 +458,7 @@ def test_the_cli_lists_every_requirement_including_the_ones_yielding_nothing():
+         23.9  tests/test_cli.py#@@ -948,11 +949,14 @@ def test_the_pipeline_persists_the_requirement_map(git_repo, tmp_path, stub_mode
+         23.10  tests/test_cli.py#@@ -973,7 +977,10 @@ def test_the_pipeline_persists_the_requirement_map(git_repo, tmp_path, stub_mode
+       test evidence: strongly supported  [tier: static]
+         23.11  tests/requirement/test_requirement_map.py::test_the_cli_lists_every_requirement_including_the_ones_yielding_nothing
+         23.12  tests/requirement/test_requirement_map.py::test_the_header_counts_declines_without_claiming_a_check_it_no_longer_makes
+         23.13  tests/test_cli.py::test_a_requirement_that_yielded_nothing_is_visible_in_the_report
+         23.14  tests/test_cli.py::test_render_change_set_omits_ignored_section_when_empty
+         23.15  tests/test_cli.py::test_render_change_set_shows_ignored_paths
+         23.16  tests/test_cli.py::test_render_classify_output
+         23.17  tests/test_cli.py::test_render_classify_shows_none_for_no_open_questions
+         23.18  tests/test_cli.py::test_report_shell_renders_all_sections_present_and_empty
+         23.19  tests/test_cli.py::test_the_spec_does_not_frame_the_recommendation_as_a_written_artifact
+         23.20  tests/test_cli.py::test_the_spec_names_the_command_the_cli_actually_accepts
+         23.21  tests/test_cli.py::test_the_spec_no_longer_names_a_written_file
+
+  24. Record in the decomposition mapping documentation that decision 3 has three dispositions and that completeness is enforced at parse.
+       requirements: completion-10
+       code evidence: addressed
+         24.1  docs/DR-202-decomposition-requirement-mapping.md#@@ -108,6 +108,39 @@ erred. Nothing here asks that. Forcing an answer per requirement makes *silence*
+       test evidence: nominally supported  [tier: static]
+         24.2  tests/test_cli.py::test_render_decomposition_lists_obligations_and_open_questions
+         24.3  tests/test_decision_records.py::test_dr_202_records_the_requirement_id_decision_as_resolved
+
+Mandate coverage: 33 of 34 requirements yielded obligations
+  1. [no_obligation] completion-01: Implementation
+       reason: Section marker only; it names the implementation section but does not itself add a checkable requirement.
+
+Unrequested changes:
+  1. [in_service] The CLI summary no longer reports an explicit zero 'unaccounted for' count and the requirement block no longer distinguishes an unaccounted requirement from a deliberate decline. The obligations require removing the removed disposition and updating CLI/report references, but they do not call for changing the summary wording or collapsing the failure-vs-decline messaging beyond that.
+       src/acceptance/cli.py#@@ -286,26 +286,26 @@ def _summary(requirement_map, total: int) -> str:
+       src/acceptance/cli.py#@@ -344,12 +344,9 @@ def _requirement_block(
+       src/acceptance/report.py#@@ -207,9 +207,13 @@ def _mandate_coverage_block(requirement_map: RequirementMap) -> list[str]:
+  2. [separable] The new union-handling logic in supplied_ids.py broadens constraint propagation through unions and list items. The task requires pydantic schemas and schema-side rejection of empty yielded ids, but it does not mention changing the generic id-constraining helper or its union traversal behavior.
+       src/acceptance/supplied_ids.py#@@ -33,13 +33,17 @@ than dropped. Dropping is what made the original defect invisible.
+       src/acceptance/supplied_ids.py#@@ -63,16 +67,27 @@ def _constrained_nested(annotation: Any, allowed: Mapping[str, Sequence[str]]) -
+  3. [in_service] The benchmark doubles were changed to synthesize full declining dispositions instead of returning an empty disposition list. The obligations require tests to be updated away from the removed disposition and to keep tests free of live calls, but they do not require altering benchmark fixture behavior to auto-complete responses.
+       tests/benchmark/degenerate_decomposers.py#@@ -35,7 +35,7 @@ from typing import Any
+       tests/benchmark/degenerate_decomposers.py#@@ -80,13 +80,8 @@ def _faithful(labels: GroundTruthLabels) -> dict[str, Any]:
+       tests/benchmark/degenerate_decomposers.py#@@ -143,7 +138,19 @@ def decomposer(labels: GroundTruthLabels, *, behaviour: str) -> ModelClient:
+       tests/benchmark/degenerate_judges.py#@@ -37,7 +37,7 @@ from typing import Any
+       tests/benchmark/degenerate_judges.py#@@ -80,6 +80,7 @@ def _decomposition(obligations: list[dict]) -> dict:
+       tests/benchmark/degenerate_judges.py#@@ -97,7 +98,17 @@ def degenerate_client(obligations: list[dict], *, always_strong: bool) -> ModelC
+       tests/support.py#@@ -34,10 +34,17 @@ def _fake_response(content: str) -> SimpleNamespace:
+       tests/support.py#@@ -127,7 +134,7 @@ def client_dispatching(
+       tests/support.py#@@ -141,6 +148,57 @@ def client_dispatching(
+  4. [in_service] Several tests were rewritten to assert new rejection behavior for missing requirements and empty yielded/no_obligation payloads, and to validate the new schema shape. Those changes are largely requested, but the added helper behavior that auto-fills empty requirement_dispositions in test support changes how unrelated tests are constructed and can mask empty-response cases beyond what the obligations explicitly require.
+       tests/support.py#@@ -34,10 +34,17 @@ def _fake_response(content: str) -> SimpleNamespace:
+       tests/support.py#@@ -127,7 +134,7 @@ def client_dispatching(
+       tests/support.py#@@ -141,6 +148,57 @@ def client_dispatching(
+       tests/requirement/test_requirement_map.py#@@ -56,12 +60,32 @@ def _obligation(oid: str, description: str, quote: str) -> dict:
+       tests/requirement/test_requirement_map.py#@@ -124,14 +148,27 @@ def test_a_fully_accounted_response_leaves_no_requirement_undisposed():
+       tests/requirement/test_requirement_map.py#@@ -146,12 +183,12 @@ def test_a_requirement_the_response_never_mentions_is_recorded_as_undisposed():
+       tests/requirement/test_requirement_map.py#@@ -175,14 +212,18 @@ def test_a_requirement_deliberately_yielding_nothing_carries_its_reason():
+       tests/requirement/test_requirement_map.py#@@ -192,16 +233,100 @@ def test_a_yielded_claim_naming_no_real_obligation_is_not_honoured():
+       tests/requirement/test_requirement_map.py#@@ -364,9 +485,19 @@ def test_an_obligation_no_requirement_claims_is_still_shown():
+       tests/requirement/test_requirement_map.py#@@ -375,35 +506,23 @@ def test_an_obligation_no_requirement_claims_is_still_shown():
+       tests/test_cli.py#@@ -948,11 +949,14 @@ def test_the_pipeline_persists_the_requirement_map(git_repo, tmp_path, stub_mode
+       tests/test_cli.py#@@ -973,7 +977,10 @@ def test_the_pipeline_persists_the_requirement_map(git_repo, tmp_path, stub_mode
+
+Recommended tests:
+  1. Parsed requirement responses can only classify a requirement as yielded, no_obligation, or open_question.
+       inputs:  A parsed requirement response that exercises all three valid disposition shapes in one payload: at least one yielded entry with obligation ids, one no_obligation entry with a reason, and one open_question entry with open-question ids. The payload should be schema-valid except for any attempt to use a fourth disposition label.
+       detects: Parsed requirement responses can still classify a requirement as a fourth disposition such as UNDISPOSED, or otherwise accept a disposition outside the three allowed values.
+       full detail: acceptance recommendation --criterion obligation-three-dispositions-only
+  2. The type system and runtime no longer accept or emit an UNDISPOSED disposition.
+       inputs:  A response that would previously have produced an undisposed/unaccounted requirement: omit at least one registry requirement from requirement_dispositions, or use an edge path that would have emitted UNDISPOSED in the old runtime. The input must be complete enough that a correct implementation now rejects it rather than mapping it.
+       detects: Developer forgets to remove the UNDISPOSED enum value or runtime still accepts/emits UNDISPOSED on an edge path, so a missing requirement is still represented instead of rejected.
+       full detail: acceptance recommendation --criterion obligation-no-undisposed
+  3. An open_question response with no open-question ids is rejected by parsing/schema validation.
+       inputs:  A response containing an open_question disposition with an empty open-question id list equivalent: either omit the required open_question_id field entirely or provide an empty/invalid structure that would have been accepted by a looser schema.
+       detects: An open_question response with no open-question ids is still accepted by parsing/schema validation.
+       full detail: acceptance recommendation --criterion obligation-open-question-needs-id
+  4. A response containing an unknown requirement id does not parse.
+       inputs:  A decomposition response whose requirement_dispositions includes at least one requirement_id not present in the parsed registry, while all known registry requirements are otherwise accounted for correctly.
+       detects: A response containing an unknown requirement id still parses, or the unknown id is silently dropped during reconciliation.
+       full detail: acceptance recommendation --criterion obligation-unknown-requirement-rejected
+  5. The schema classes are defined using pydantic model types consistent with the repository.
+       inputs:  Direct inspection of the schema classes and their generated JSON schema for the decomposition response model, including the union of disposition shapes. The test should inspect both the Python class type and the emitted schema structure.
+       detects: The schema classes are plain dataclasses/custom objects, or the schema is generated through a wrapper that inlines refs and only happens to match the inspected JSON shape.
+       full detail: acceptance recommendation --criterion obligation-pydantic-schemas
+  6. Test execution does not contact a live model service.
+       inputs:  A test harness invocation that exercises the CLI or benchmark helpers under a network-blocking or call-counting stub, with the model client patched so any live service access would fail the test. The input should cover the code path most likely to make an accidental live call, not just a cached deterministic path.
+       detects: A helper or CLI test accidentally makes a live model call in a path not covered by the current tests, but cached/deterministic outputs hide it.
+       full detail: acceptance recommendation --criterion obligation-tests-no-live-calls
+  7. Parsed RequirementMap entries are fully classified as yielded, no_obligation, or open_question.
+       inputs:  A RequirementMap fixture or decomposed response where every registry requirement is explicitly classified, with a mix of yielded, no_obligation, and open_question dispositions. The input should be chosen so a misclassification between no_obligation and open_question changes the per-requirement disposition set even if counts stay similar.
+       detects: RequirementMap entries can still be undisposed/unclassified in some cases, or some requirements are misclassified as open_question instead of no_obligation while aggregate counts still look right.
+       full detail: acceptance recommendation --criterion obligation-completion-three-dispositions
+  8. A yielded response with an empty obligation-id list fails parsing.
+       inputs:  A yielded disposition object with the required yielded id field omitted or empty, while the rest of the response is otherwise valid and complete. The input should be aimed at the schema-level shape, not the reconciliation logic.
+       detects: A yielded response with an empty obligation-id list still parses, allowing a yielded claim with no actual obligations.
+       full detail: acceptance recommendation --criterion obligation-completion-yielded-rejected-empty
+  9. No runtime path can assign or emit UNDISPOSED.
+       inputs:  A code path that previously would have assigned or emitted UNDISPOSED, such as a missing requirement during reconciliation or a CLI/report rendering path that used to count unaccounted items. The test should drive that path explicitly.
+       detects: A runtime path still assigns or emits UNDISPOSED even though the main happy-path tests no longer exercise it.
+       full detail: acceptance recommendation --criterion obligation-remove-undisposed-codepaths
+  10. The test suite includes a schema-level assertion for empty yielded obligation lists.
+       inputs:  A schema-level validation test that constructs the decomposition model with a yielded disposition missing its required obligation id, using the model class directly rather than the full decompose pipeline.
+       detects: The test suite lacks a schema-level assertion for empty yielded obligation lists, so a regression in the model shape could slip through while pipeline tests still pass.
+       full detail: acceptance recommendation --criterion obligation-schema-test-empty-yielded
+  11. The referenced markdown doc states the three-disposition set and parse-time completeness enforcement.
+       inputs:  A documentation-focused test that reads docs/DR-202-decomposition-requirement-mapping.md and checks for the exact three-disposition set plus parse-time completeness enforcement language. The input is the markdown file content itself.
+       detects: The referenced markdown doc still describes four dispositions or omits parse-time completeness enforcement.
+       full detail: acceptance recommendation --criterion obligation-doc-record-three-dispositions
+
+Evidence limitations:
+  1. Judgments are static inferences unless a higher tier is recorded; the full application was not independently executed.
+
+Next: retrieve a criterion's full recommendation with
+  acceptance recommendation --criterion <id>

--- a/dogfood-logs/217-gate2-run1/revisions.txt
+++ b/dogfood-logs/217-gate2-run1/revisions.txt
@@ -1,0 +1,2 @@
+base 6ae97fd
+head 76b847b

--- a/dogfood-logs/217-gate2-run2/current-task.md
+++ b/dogfood-logs/217-gate2-run2/current-task.md
@@ -1,0 +1,83 @@
+# Task
+DR-202 decision 3 gives a requirement exactly one of three dispositions, each
+carrying something: yielded obligations, deliberately yields none with a reason,
+or raised an open question instead. The implementation added a fourth,
+`UNDISPOSED`, carrying none of them, and reached it two ways: a response that
+never mentioned a requirement, and a response that labelled a requirement
+`yielded` while naming no obligations.
+
+Both are malformed responses, and both are currently absorbed as soft findings.
+`_requirement_map` discards the reason the response supplied, substitutes a
+diagnostic string of its own, and lets the run continue to a verdict on an
+answer that did not account for the mandate.
+
+The registry of requirements is derived deterministically from the parse, and
+the code iterates over that registry. Dropping a requirement is therefore not a
+possible outcome — the only possible bad outcome is a response of poor quality.
+Make that true in the types: every requirement carries one of exactly three
+dispositions, each structurally required to carry its own payload, and a
+response that fails to account for every requirement does not parse. Remove the
+fourth disposition entirely.
+
+## Constraints
+- A requirement disposition is one of exactly three: yielded obligations,
+  no obligations needed with a reason, or an open question that prevents an
+  answer.
+- `Disposition` has no `UNDISPOSED` value.
+- `_RequirementDisposition` is a union of one shape per disposition, each
+  carrying only the payload its own disposition defines.
+- The union is unambiguous at parse: each shape names its disposition as a
+  literal value.
+- The schema sent to the model uses only keywords OpenAI strict mode accepts.
+- A `yielded` disposition carries at least one obligation id.
+- A `no_obligation` disposition carries a reason that is not empty.
+- An `open_question` disposition carries at least one open-question id.
+- A response labelling a requirement `yielded` while naming no obligation id
+  fails to parse.
+- A response labelling a requirement `no_obligation` with an empty reason fails
+  to parse.
+- A response that omits any requirement in the registry is rejected.
+- A response that names a requirement id absent from the registry is rejected.
+- A rejected response produces no `RequirementMap`.
+- The JSON schema sent to the model cannot express a `yielded` disposition with
+  zero obligation ids.
+- The reason a response supplies for declining a requirement is preserved rather
+  than replaced by a diagnostic string.
+- The helper that restricts an id field to the ids a call supplied keeps working
+  when the response model's item type is a union, so the requirement-id
+  constraint survives the new shape.
+- Typed schemas are pydantic models, as the rest of the repository defines them.
+- Tests issue no live model calls.
+
+## Scope exclusions
+- The decomposer declining to yield obligations for scope exclusions, against
+  the instruction already in the decompose prompt. That is a prompt defect
+  tracked separately and costs a transcript re-record.
+- Changing the decompose prompt text.
+- Retrying or repairing a rejected response.
+- Nested-bullet and multi-paragraph parse coverage, which is #216.
+- Whether mandate coverage bounds the completion verdict, which is #214.
+- Aligning requirement ids across two versions of a task file, which is #209.
+
+## Completion expectations
+- Implementation
+- Every requirement in a parsed `RequirementMap` carries one of the three
+  dispositions.
+- A response with a `yielded` disposition and no obligation ids is rejected.
+- A response with a `no_obligation` disposition and an empty reason is rejected.
+- A response omitting a requirement present in the registry is rejected.
+- No `RequirementMap` is produced from a rejected response.
+- The `UNDISPOSED` value and every code path that assigns it are removed.
+- A response naming a requirement id outside the registry is rejected.
+- A response disposing the same requirement twice is rejected.
+- An `open_question` disposition naming no question the response produced is
+  rejected.
+- A test asserts that the schema sent to the model rejects a `yielded`
+  disposition carrying zero obligation ids.
+- A test asserts that the id constraint still reaches every member of a union
+  item type.
+- The tests, CLI rendering and report sections that referred to the removed
+  disposition are updated rather than left asserting it.
+- `docs/DR-202-decomposition-requirement-mapping.md` records that the
+  disposition set is the three of decision 3, and that completeness is enforced
+  at parse.

--- a/dogfood-logs/217-gate2-run2/judgement.md
+++ b/dogfood-logs/217-gate2-run2/judgement.md
@@ -1,0 +1,30 @@
+# Judgement — #217 Gate 2 run 2
+
+`6ae97fd` → `007966f`. **Not clean.** INCOMPLETE: 7 obligations with
+non-discriminating test evidence. No obligation unaddressed — run 1's true
+positive is resolved.
+
+Mandate coverage 37 of 41. The four declines are scope exclusions pointing at
+#216/#214/#209 plus the `Implementation` section marker, each with a correct
+reason. Those are right outcomes, not gaps.
+
+All unrequested changes are now **[in_service]** — run 1's `separable` flag on
+the `supplied_ids.py` union walk cleared once the mandate named it.
+
+## Acted on
+
+Two recommendations were genuine gaps and are closed in `6c06517`:
+
+- **literal-tag dispatch** was asserted nowhere. Without it a `no_obligation`
+  could be read as a `yielded` whose ids happened to be absent — the
+  contradiction rebuilt inside the parser.
+- the **empty** open-question payload was untested at the schema boundary. The
+  existing test covered a *named but unproduced* id, which is the reconciliation
+  path, not the schema one.
+
+## Not acted on
+
+Recommendations 3, 4 and 5 restate guarantees that already have direct tests
+(`test_a_response_that_never_mentions_a_requirement_is_rejected`, the schema
+assertions, and the existing no-live-call guards). Carried to run 3 to see
+whether they persist.

--- a/dogfood-logs/217-gate2-run2/output.log
+++ b/dogfood-logs/217-gate2-run2/output.log
@@ -1,0 +1,366 @@
+Task completion: INCOMPLETE
+
+7 obligation(s) with non-discriminating test evidence (obligation-unambiguous-literal-discriminators, obligation-yielded-empty-obligations-rejected, obligation-rejected-response-produces-no-map, obligation-pydantic-typed-schemas, obligation-tests-no-live-model-calls, obligation-open-question-empty-rejected, obligation-schema-test-rejects-empty-yielded).
+
+Obligations:
+
+  1. A requirement disposition is limited to exactly three cases: yielded obligations, no obligations needed with a reason, or an open question that prevents an answer.
+       requirements: task-01, constraint-01, exclusion-01
+       code evidence: addressed
+         1.1  src/acceptance/review_state.py#@@ -280,17 +280,18 @@ class Disposition(str, Enum):
+         1.2  src/acceptance/requirement/obligations.py#@@ -13,12 +13,18 @@ obligations — uncertainty is a first-class, expected result (M1.3).
+         1.3  docs/DR-202-decomposition-requirement-mapping.md#@@ -108,6 +108,39 @@ erred. Nothing here asks that. Forcing an answer per requirement makes *silence*
+       test evidence: strongly supported  [tier: static]
+         1.4  tests/requirement/test_requirement_map.py::test_the_disposition_set_is_exactly_the_three_of_decision_3
+         1.5  tests/test_decision_records.py::test_dr_202_records_the_three_disposition_set_and_parse_time_completeness
+
+  2. The Disposition type excludes any UNDISPOSED value.
+       requirements: task-01, task-03, constraint-02, completion-07
+       code evidence: addressed
+         2.1  src/acceptance/review_state.py#@@ -280,17 +280,18 @@ class Disposition(str, Enum):
+         2.2  src/acceptance/review_state.py#@@ -319,10 +320,6 @@ class RequirementDisposition(_Model):
+       test evidence: strongly supported  [tier: static]
+         2.3  tests/requirement/test_requirement_map.py::test_the_disposition_set_is_exactly_the_three_of_decision_3
+         2.4  tests/test_decision_records.py::test_dr_202_records_the_three_disposition_set_and_parse_time_completeness
+
+  3. _RequirementDisposition is modeled as a union with one shape per disposition, and each shape carries only the payload defined by that disposition.
+       requirements: task-03, constraint-03, completion-09
+       code evidence: addressed
+         3.1  src/acceptance/requirement/obligations.py#@@ -173,14 +181,52 @@ class _OpenQuestion(StrictResponseModel):
+       test evidence: strongly supported  [tier: static]
+         3.2  tests/requirement/test_requirement_map.py::test_the_schema_cannot_express_a_yielded_disposition_with_no_obligations
+         3.3  tests/test_supplied_ids.py::test_a_union_of_item_shapes_constrains_every_member
+
+  4. Each disposition shape names its disposition as a literal value so the union is unambiguous at parse time.
+       requirements: task-03, constraint-04
+       code evidence: addressed
+         4.1  src/acceptance/requirement/obligations.py#@@ -173,14 +181,52 @@ class _OpenQuestion(StrictResponseModel):
+       test evidence: nominally supported  [tier: static]
+         4.2  tests/requirement/test_requirement_map.py::test_the_schema_cannot_express_a_yielded_disposition_with_no_obligations
+         4.3  tests/test_supplied_ids.py::test_a_union_of_item_shapes_constrains_every_member
+
+  5. The schema sent to the model uses only keywords accepted by OpenAI strict mode.
+       requirements: constraint-05
+       code evidence: addressed
+         5.1  src/acceptance/requirement/obligations.py#@@ -173,14 +181,52 @@ class _OpenQuestion(StrictResponseModel):
+         5.2  tests/requirement/test_requirement_map.py#@@ -192,16 +235,202 @@ def test_a_yielded_claim_naming_no_real_obligation_is_not_honoured():
+       test evidence: strongly supported  [tier: static]
+         5.3  tests/requirement/test_requirement_map.py::test_the_schema_cannot_express_a_yielded_disposition_with_no_obligations
+         5.4  tests/test_llm.py::test_the_hashed_request_carries_the_inlined_schema
+         5.5  tests/test_llm.py::test_the_schema_sent_to_the_provider_has_no_ref_indirection
+         5.6  tests/test_supplied_ids.py::test_supplied_ids_become_an_enum_on_the_field_the_model_sees
+
+  6. A yielded disposition carries at least one obligation id.
+       requirements: constraint-01, constraint-06
+       code evidence: addressed
+         6.1  src/acceptance/requirement/obligations.py#@@ -173,14 +181,52 @@ class _OpenQuestion(StrictResponseModel):
+       test evidence: strongly supported  [tier: static]
+         6.2  tests/requirement/test_requirement_map.py::test_a_yielded_claim_naming_no_real_obligation_is_rejected
+         6.3  tests/requirement/test_requirement_map.py::test_the_schema_cannot_express_a_yielded_disposition_with_no_obligations
+
+  7. A no_obligation disposition carries a non-empty reason.
+       requirements: constraint-01, constraint-07
+       code evidence: addressed
+         7.1  src/acceptance/requirement/obligations.py#@@ -173,14 +181,52 @@ class _OpenQuestion(StrictResponseModel):
+         7.2  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+       test evidence: strongly supported  [tier: static]
+         7.3  tests/requirement/test_requirement_map.py::test_a_no_obligation_disposition_with_an_empty_reason_is_rejected
+         7.4  tests/test_cli.py::test_a_requirement_that_yielded_nothing_is_visible_in_the_report
+         7.5  tests/test_cli.py::test_the_pipeline_persists_the_requirement_map
+
+  8. An open_question disposition carries at least one open-question id.
+       requirements: constraint-01, constraint-08
+       code evidence: addressed
+         8.1  src/acceptance/requirement/obligations.py#@@ -173,14 +181,52 @@ class _OpenQuestion(StrictResponseModel):
+       test evidence: strongly supported  [tier: static]
+         8.2  tests/coverage/test_open_questions.py::test_diff_does_not_resolve_the_question
+         8.3  tests/coverage/test_open_questions.py::test_diff_resolves_the_question
+         8.4  tests/requirement/test_requirement_map.py::test_an_open_question_disposition_naming_no_real_question_is_rejected
+         8.5  tests/test_verdict.py::test_resolved_open_question_does_not_block
+
+  9. A response that labels a requirement yielded while naming no obligation id fails to parse.
+       requirements: constraint-09, completion-03
+       code evidence: addressed
+         9.1  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+         9.2  tests/requirement/test_requirement_map.py#@@ -146,12 +185,12 @@ def test_a_requirement_the_response_never_mentions_is_recorded_as_undisposed():
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  10. A response that labels a requirement no_obligation with an empty reason fails to parse.
+       requirements: constraint-10, completion-04
+       code evidence: addressed
+         10.1  src/acceptance/review_state.py#@@ -319,10 +320,6 @@ class RequirementDisposition(_Model):
+         10.2  tests/requirement/test_requirement_map.py#@@ -192,16 +235,202 @@ def test_a_yielded_claim_naming_no_real_obligation_is_not_honoured():
+       test evidence: strongly supported  [tier: static]
+         10.3  tests/requirement/test_requirement_map.py::test_a_no_obligation_disposition_with_an_empty_reason_is_rejected
+
+  11. A response that omits any requirement in the registry is rejected.
+       requirements: task-03, constraint-11, completion-05
+       code evidence: addressed
+         11.1  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+         11.2  tests/requirement/test_requirement_map.py#@@ -146,12 +185,12 @@ def test_a_requirement_the_response_never_mentions_is_recorded_as_undisposed():
+       test evidence: strongly supported  [tier: static]
+         11.3  tests/requirement/test_requirement_map.py::test_a_response_that_never_mentions_a_requirement_is_rejected
+         11.4  tests/test_supplied_ids.py::test_a_clean_mapping_records_nothing_and_keeps_its_negative_answers
+
+  12. A response that names a requirement id absent from the registry is rejected.
+       requirements: task-03, constraint-12, completion-08
+       code evidence: addressed
+         12.1  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+         12.2  tests/requirement/test_requirement_map.py#@@ -192,16 +235,202 @@ def test_a_yielded_claim_naming_no_real_obligation_is_not_honoured():
+       test evidence: strongly supported  [tier: static]
+         12.3  tests/evidence/test_mapping.py::test_unknown_ids_are_dropped
+         12.4  tests/requirement/test_requirement_map.py::test_a_response_naming_a_requirement_outside_the_registry_is_rejected
+         12.5  tests/requirement/test_requirement_map.py::test_a_yielded_claim_naming_no_real_obligation_is_rejected
+         12.6  tests/requirement/test_requirement_map.py::test_an_open_question_disposition_naming_no_real_question_is_rejected
+
+  13. A rejected response produces no RequirementMap.
+       requirements: task-02, constraint-13, exclusion-03, completion-06
+       code evidence: addressed
+         13.1  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+         13.2  tests/requirement/test_requirement_map.py#@@ -146,12 +185,12 @@ def test_a_requirement_the_response_never_mentions_is_recorded_as_undisposed():
+       test evidence: partially supported  [tier: static]
+         13.3  tests/requirement/test_requirement_map.py::test_a_requirement_disposed_twice_is_rejected
+         13.4  tests/requirement/test_requirement_map.py::test_a_yielded_claim_naming_no_real_obligation_is_rejected
+         13.5  tests/requirement/test_requirement_map.py::test_an_open_question_disposition_naming_no_real_question_is_rejected
+         13.6  tests/test_cli.py::test_check_json_emits_a_structured_review
+         13.7  tests/test_supplied_ids.py::test_a_clean_mapping_records_nothing_and_keeps_its_negative_answers
+         13.8  tests/test_supplied_ids.py::test_a_review_holding_an_unusable_answer_does_not_come_back_clean
+         13.9  tests/test_supplied_ids.py::test_a_usable_judgment_survives_an_unusable_one_in_the_same_response
+         13.10  tests/test_supplied_ids.py::test_an_obligation_is_indeterminate_not_unmapped_when_an_answer_was_unusable
+         13.11  tests/test_supplied_ids.py::test_an_unusable_answer_leaves_the_obligation_indeterminate
+
+  14. The JSON schema sent to the model cannot express a yielded disposition with zero obligation ids.
+       requirements: constraint-14
+       code evidence: addressed
+         14.1  src/acceptance/requirement/obligations.py#@@ -173,14 +181,52 @@ class _OpenQuestion(StrictResponseModel):
+         14.2  tests/requirement/test_requirement_map.py#@@ -192,16 +235,202 @@ def test_a_yielded_claim_naming_no_real_obligation_is_not_honoured():
+       test evidence: strongly supported  [tier: static]
+         14.3  tests/requirement/test_requirement_map.py::test_the_schema_cannot_express_a_yielded_disposition_with_no_obligations
+
+  15. The reason supplied for declining a requirement is preserved rather than replaced by a diagnostic string.
+       requirements: task-02, constraint-15
+       code evidence: addressed
+         15.1  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+         15.2  tests/requirement/test_requirement_map.py#@@ -192,16 +235,202 @@ def test_a_yielded_claim_naming_no_real_obligation_is_not_honoured():
+       test evidence: strongly supported  [tier: static]
+         15.3  tests/requirement/test_requirement_map.py::test_a_requirement_deliberately_yielding_nothing_carries_its_reason
+         15.4  tests/requirement/test_requirement_map.py::test_a_supplied_reason_is_preserved_rather_than_replaced
+         15.5  tests/test_cli.py::test_the_pipeline_persists_the_requirement_map
+         15.6  tests/test_supplied_ids.py::test_a_review_holding_an_unusable_answer_does_not_come_back_clean
+
+  16. The helper that restricts an id field to supplied ids continues to work when the response model item type is a union, so the requirement-id constraint survives the new shape.
+       requirements: constraint-16
+       code evidence: addressed
+         16.1  src/acceptance/supplied_ids.py#@@ -33,13 +33,17 @@ than dropped. Dropping is what made the original defect invisible.
+         16.2  src/acceptance/supplied_ids.py#@@ -63,16 +67,27 @@ def _constrained_nested(annotation: Any, allowed: Mapping[str, Sequence[str]]) -
+       test evidence: strongly supported  [tier: static]
+         16.3  tests/requirement/test_requirement_map.py::test_a_disposition_naming_a_renamed_obligation_still_links
+         16.4  tests/test_supplied_ids.py::test_a_foreign_id_does_not_validate_against_the_constrained_schema
+         16.5  tests/test_supplied_ids.py::test_a_foreign_obligation_id_is_recorded_not_silently_dropped
+         16.6  tests/test_supplied_ids.py::test_a_list_valued_id_field_constrains_its_items
+         16.7  tests/test_supplied_ids.py::test_a_single_supplied_id_is_still_sent_as_an_enum
+         16.8  tests/test_supplied_ids.py::test_a_union_of_item_shapes_constrains_every_member
+         16.9  tests/test_supplied_ids.py::test_a_usable_judgment_survives_an_unusable_one_in_the_same_response
+         16.10  tests/test_supplied_ids.py::test_an_obligation_is_indeterminate_not_unmapped_when_an_answer_was_unusable
+         16.11  tests/test_supplied_ids.py::test_each_partition_constrains_test_ids_to_its_own_batch
+         16.12  tests/test_supplied_ids.py::test_scan_finds_ids_that_were_never_supplied
+         16.13  tests/test_supplied_ids.py::test_scan_reports_each_unusable_id_once
+         16.14  tests/test_supplied_ids.py::test_supplied_ids_become_an_enum_on_the_field_the_model_sees
+         16.15  tests/test_supplied_ids.py::test_the_pipeline_reports_an_unusable_answer_naming_the_stage_and_the_id
+         16.16  tests/test_supplied_ids.py::test_the_schema_asked_for_differs_from_the_shape_parsed
+
+  17. Typed schemas are implemented as pydantic models.
+       requirements: constraint-17
+       code evidence: addressed
+         17.1  src/acceptance/requirement/obligations.py#@@ -173,14 +181,52 @@ class _OpenQuestion(StrictResponseModel):
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  18. Tests issue no live model calls.
+       requirements: constraint-18
+       code evidence: addressed
+         (no corresponding change)
+       test evidence: nominally supported  [tier: static]
+         18.1  tests/test_cli.py::test_classify_replay_without_transcript_fails_cleanly
+         18.2  tests/test_cli.py::test_decompose_replay_without_transcript_fails_cleanly
+         18.3  tests/test_cli.py::test_retrieval_makes_no_model_call
+
+  19. Every requirement in a parsed RequirementMap carries one of the three dispositions.
+       requirements: task-01, task-03, completion-02
+       code evidence: addressed
+         19.1  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+         19.2  src/acceptance/review_state.py#@@ -280,17 +280,18 @@ class Disposition(str, Enum):
+       test evidence: strongly supported  [tier: static]
+         19.3  tests/requirement/test_requirement_map.py::test_a_fully_accounted_response_disposes_every_requirement
+         19.4  tests/test_cli.py::test_a_requirement_that_yielded_nothing_is_visible_in_the_report
+         19.5  tests/test_cli.py::test_check_json_emits_a_structured_review
+         19.6  tests/test_cli.py::test_the_pipeline_persists_the_requirement_map
+         19.7  tests/test_verdict.py::test_resolved_open_question_does_not_block
+
+  20. An open_question disposition naming no question the response produced is rejected.
+       requirements: completion-10
+       code evidence: addressed
+         20.1  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+         20.2  tests/requirement/test_requirement_map.py#@@ -192,16 +235,202 @@ def test_a_yielded_claim_naming_no_real_obligation_is_not_honoured():
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  21. A test asserts that the schema sent to the model rejects a yielded disposition carrying zero obligation ids.
+       requirements: completion-11
+       code evidence: addressed
+         21.1  tests/requirement/test_requirement_map.py#@@ -192,16 +235,202 @@ def test_a_yielded_claim_naming_no_real_obligation_is_not_honoured():
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  22. A test asserts that the id constraint still reaches every member of a union item type.
+       requirements: completion-12
+       code evidence: addressed
+         22.1  tests/test_supplied_ids.py#@@ -68,6 +88,31 @@ def test_a_list_valued_id_field_constrains_its_items():
+       test evidence: strongly supported  [tier: static]
+         22.2  tests/requirement/test_requirement_map.py::test_one_obligation_serves_two_requirements_rather_than_being_duplicated
+         22.3  tests/test_supplied_ids.py::test_a_foreign_id_does_not_validate_against_the_constrained_schema
+         22.4  tests/test_supplied_ids.py::test_a_foreign_obligation_id_is_recorded_not_silently_dropped
+         22.5  tests/test_supplied_ids.py::test_a_list_valued_id_field_constrains_its_items
+         22.6  tests/test_supplied_ids.py::test_a_single_supplied_id_is_still_sent_as_an_enum
+         22.7  tests/test_supplied_ids.py::test_a_union_of_item_shapes_constrains_every_member
+         22.8  tests/test_supplied_ids.py::test_each_partition_constrains_test_ids_to_its_own_batch
+
+  23. The tests, CLI rendering, and report sections that referred to the removed disposition are updated rather than left asserting it.
+       requirements: exclusion-02, completion-13
+       code evidence: addressed
+         23.1  src/acceptance/cli.py#@@ -286,26 +286,26 @@ def _summary(requirement_map, total: int) -> str:
+         23.2  src/acceptance/cli.py#@@ -344,12 +344,9 @@ def _requirement_block(
+         23.3  src/acceptance/report.py#@@ -207,9 +207,13 @@ def _mandate_coverage_block(requirement_map: RequirementMap) -> list[str]:
+         23.4  tests/test_cli.py#@@ -948,11 +949,14 @@ def test_the_pipeline_persists_the_requirement_map(git_repo, tmp_path, stub_mode
+         23.5  tests/test_cli.py#@@ -973,7 +977,10 @@ def test_the_pipeline_persists_the_requirement_map(git_repo, tmp_path, stub_mode
+         23.6  tests/test_decision_records.py#@@ -42,6 +42,20 @@ def test_dr_202_records_the_requirement_id_decision_as_resolved():
+         23.7  tests/requirement/test_requirement_map.py#@@ -124,14 +150,27 @@ def test_a_fully_accounted_response_leaves_no_requirement_undisposed():
+         23.8  tests/requirement/test_requirement_map.py#@@ -334,10 +562,7 @@ def test_the_cli_lists_every_requirement_including_the_ones_yielding_nothing():
+         23.9  tests/requirement/test_requirement_map.py#@@ -375,35 +610,23 @@ def test_an_obligation_no_requirement_claims_is_still_shown():
+       test evidence: strongly supported  [tier: static]
+         23.10  tests/benchmark/test_labels.py::test_candidate_test_ids_name_real_tests
+         23.11  tests/requirement/test_requirement_map.py::test_an_obligation_no_requirement_claims_is_still_shown
+         23.12  tests/requirement/test_requirement_map.py::test_one_obligation_serves_two_requirements_rather_than_being_duplicated
+         23.13  tests/requirement/test_requirement_map.py::test_text_the_parse_never_read_is_carried_into_the_mapping
+         23.14  tests/requirement/test_requirement_map.py::test_the_cli_lists_every_requirement_including_the_ones_yielding_nothing
+         23.15  tests/requirement/test_requirement_map.py::test_the_cli_says_when_an_obligation_serves_other_requirements
+         23.16  tests/requirement/test_requirement_map.py::test_the_cli_shouts_about_text_that_was_never_read
+         23.17  tests/requirement/test_requirement_map.py::test_the_disposition_set_is_exactly_the_three_of_decision_3
+         23.18  tests/requirement/test_requirement_map.py::test_the_header_counts_declines_without_claiming_a_check_it_no_longer_makes
+         23.19  tests/test_cli.py::test_a_requirement_that_yielded_nothing_is_visible_in_the_report
+         23.20  tests/test_cli.py::test_a_stale_instruction_file_is_removed_and_the_removal_reported
+         23.21  tests/test_cli.py::test_report_shell_renders_all_sections_present_and_empty
+         23.22  tests/test_cli.py::test_the_spec_does_not_frame_the_recommendation_as_a_written_artifact
+         23.23  tests/test_cli.py::test_the_spec_names_the_command_the_cli_actually_accepts
+         23.24  tests/test_cli.py::test_the_spec_no_longer_names_a_written_file
+         23.25  tests/test_decision_records.py::test_dr_202_no_longer_lists_requirement_id_stability_as_open
+         23.26  tests/test_decision_records.py::test_dr_202_records_the_requirement_id_decision_as_resolved
+         23.27  tests/test_decision_records.py::test_dr_202_records_what_the_interim_scheme_defers
+
+  24. The decomposition documentation records that the disposition set is the three of decision 3, and that completeness is enforced at parse.
+       requirements: completion-14
+       code evidence: addressed
+         24.1  docs/DR-202-decomposition-requirement-mapping.md#@@ -108,6 +108,39 @@ erred. Nothing here asks that. Forcing an answer per requirement makes *silence*
+       test evidence: strongly supported  [tier: static]
+         24.2  tests/test_cli.py::test_render_decomposition_lists_obligations_and_open_questions
+         24.3  tests/test_decision_records.py::test_dr_202_records_the_three_disposition_set_and_parse_time_completeness
+
+Mandate coverage: 37 of 41 requirements yielded obligations
+  1. [no_obligation] exclusion-04: Nested-bullet and multi-paragraph parse coverage, which is #216.
+       reason: This exclusion points to work tracked separately (#216) and does not add a direct implementation requirement here.
+  2. [no_obligation] exclusion-05: Whether mandate coverage bounds the completion verdict, which is #214.
+       reason: This exclusion explicitly defers the completion-verdict question to #214 and does not constrain this change directly.
+  3. [no_obligation] exclusion-06: Aligning requirement ids across two versions of a task file, which is #209.
+       reason: This exclusion refers to aligning ids across task-file versions, which is tracked separately (#209) and is outside this change's direct scope.
+  4. [no_obligation] completion-01: Implementation
+       reason: Section marker only.
+
+Unrequested changes:
+  1. [in_service] The CLI summary output was changed to remove the explicit unaccounted-for count and the shouted failure line. The obligations require updating references to the removed disposition, but they do not ask to alter the summary’s wording or to stop reporting the count entirely.
+       src/acceptance/cli.py#@@ -286,26 +286,26 @@ def _summary(requirement_map, total: int) -> str:
+       src/acceptance/cli.py#@@ -344,12 +344,9 @@ def _requirement_block(
+       tests/requirement/test_requirement_map.py#@@ -334,10 +562,7 @@ def test_the_cli_lists_every_requirement_including_the_ones_yielding_nothing():
+       tests/requirement/test_requirement_map.py#@@ -375,35 +610,23 @@ def test_an_obligation_no_requirement_claims_is_still_shown():
+  2. [in_service] `RequirementMap.unyielding()` now has a broader docstring, but more importantly the separate `undisposed()` accessor was removed. The obligations call for removing references to the removed disposition, yet they do not explicitly require deleting this public method; that is an API change beyond the stated update scope.
+       src/acceptance/review_state.py#@@ -364,23 +361,17 @@ class RequirementMap(_Model):
+       tests/test_cli.py#@@ -948,11 +949,14 @@ def test_the_pipeline_persists_the_requirement_map(git_repo, tmp_path, stub_mode
+  3. [in_service] `Disposition` lost the `UNDISPOSED` enum member. Removing the removed disposition is requested, but this is still a public symbol change with external API impact, so it is a notable interface break beyond the minimum needed to satisfy the documentation and parsing requirements.
+       src/acceptance/review_state.py#@@ -280,17 +280,18 @@ class Disposition(str, Enum):
+       src/acceptance/review_state.py#@@ -319,10 +320,6 @@ class RequirementDisposition(_Model):
+       tests/requirement/test_requirement_map.py#@@ -192,16 +235,202 @@ def test_a_yielded_claim_naming_no_real_obligation_is_not_honoured():
+       tests/requirement/test_requirement_map.py#@@ -263,7 +492,6 @@ def test_a_disposition_naming_a_renamed_obligation_still_links():
+       tests/test_cli.py#@@ -4,6 +4,7 @@ import pytest
+  4. [in_service] The parser now rejects duplicate, unknown, missing, and unproduced requirement ids by raising `SchemaValidationError` instead of reconciling them into a map. The obligations require rejection of missing and unknown requirements and no map on rejection, but the duplicate-id rejection and the specific new error paths are extra behavior not explicitly called for.
+       src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+       tests/requirement/test_requirement_map.py#@@ -146,12 +185,12 @@ def test_a_requirement_the_response_never_mentions_is_recorded_as_undisposed():
+       tests/requirement/test_requirement_map.py#@@ -192,16 +235,202 @@ def test_a_yielded_claim_naming_no_real_obligation_is_not_honoured():
+  5. [in_service] The response-model implementation was changed to rely on `Union`, `Literal`, and schema-shape behavior to satisfy strict-mode constraints. The obligations require pydantic typed schemas and strict-mode compatibility, but the added dependency on union-shape encoding details and the new `SchemaValidationError` import are implementation choices beyond the explicit requirements.
+       src/acceptance/requirement/obligations.py#@@ -28,9 +34,11 @@ destroys the one thing the review exists to detect. Pinned by a test.
+       src/acceptance/requirement/obligations.py#@@ -173,14 +181,52 @@ class _OpenQuestion(StrictResponseModel):
+       src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+  6. [in_service] `tests/support.py` now auto-completes empty `requirement_dispositions` into full decline lists for any client helper that returns `[]`. The obligations require tests to avoid live model calls and to cover the new parsing behavior, but they do not ask to change the generic test doubles so that empty lists are rewritten behind the scenes.
+       tests/support.py#@@ -34,10 +34,17 @@ def _fake_response(content: str) -> SimpleNamespace:
+       tests/support.py#@@ -127,7 +134,7 @@ def client_dispatching(
+       tests/support.py#@@ -141,6 +148,57 @@ def client_dispatching(
+  7. [in_service] The benchmark doubles were changed from returning empty disposition lists to synthesizing full decline lists. That is a behavior change in test fixtures beyond merely updating references to the removed disposition, and it is not specifically required by the obligations.
+       tests/benchmark/degenerate_decomposers.py#@@ -35,7 +35,7 @@ from typing import Any
+       tests/benchmark/degenerate_decomposers.py#@@ -80,13 +80,8 @@ def _faithful(labels: GroundTruthLabels) -> dict[str, Any]:
+       tests/benchmark/degenerate_decomposers.py#@@ -143,7 +138,19 @@ def decomposer(labels: GroundTruthLabels, *, behaviour: str) -> ModelClient:
+       tests/benchmark/degenerate_judges.py#@@ -37,7 +37,7 @@ from typing import Any
+       tests/benchmark/degenerate_judges.py#@@ -80,6 +80,7 @@ def _decomposition(obligations: list[dict]) -> dict:
+       tests/benchmark/degenerate_judges.py#@@ -97,7 +98,17 @@ def degenerate_client(obligations: list[dict], *, always_strong: bool) -> ModelC
+  8. [in_service] The requirement-map tests were expanded with many new rejection cases, schema-shape assertions, and filesystem-wide scans for `UNDISPOSED`. The obligations ask for tests covering parse rejection and schema constraints, but not for a repository-wide AST search or the extra broad assertions about every new failure mode.
+       tests/requirement/test_requirement_map.py#@@ -17,9 +17,15 @@ invariant — no live calls.
+       tests/requirement/test_requirement_map.py#@@ -56,12 +62,32 @@ def _obligation(oid: str, description: str, quote: str) -> dict:
+       tests/requirement/test_requirement_map.py#@@ -103,7 +129,7 @@ def test_each_registry_entry_carries_the_span_of_its_requirement():
+       tests/requirement/test_requirement_map.py#@@ -124,14 +150,27 @@ def test_a_fully_accounted_response_leaves_no_requirement_undisposed():
+       tests/requirement/test_requirement_map.py#@@ -146,12 +185,12 @@ def test_a_requirement_the_response_never_mentions_is_recorded_as_undisposed():
+       tests/requirement/test_requirement_map.py#@@ -175,14 +214,18 @@ def test_a_requirement_deliberately_yielding_nothing_carries_its_reason():
+       tests/requirement/test_requirement_map.py#@@ -192,16 +235,202 @@ def test_a_yielded_claim_naming_no_real_obligation_is_not_honoured():
+       tests/requirement/test_requirement_map.py#@@ -263,7 +492,6 @@ def test_a_disposition_naming_a_renamed_obligation_still_links():
+       tests/requirement/test_requirement_map.py#@@ -334,10 +562,7 @@ def test_the_cli_lists_every_requirement_including_the_ones_yielding_nothing():
+       tests/requirement/test_requirement_map.py#@@ -364,9 +589,19 @@ def test_an_obligation_no_requirement_claims_is_still_shown():
+       tests/requirement/test_requirement_map.py#@@ -375,35 +610,23 @@ def test_an_obligation_no_requirement_claims_is_still_shown():
+  9. [in_service] The supplied-ids helper was generalized to recurse through unions and lists. The obligations do require the id constraint to survive union item types, but the broader refactor of the helper’s traversal logic and union-origin handling is an implementation expansion beyond the minimum requested change.
+       src/acceptance/supplied_ids.py#@@ -33,13 +33,17 @@ than dropped. Dropping is what made the original defect invisible.
+       src/acceptance/supplied_ids.py#@@ -63,16 +67,27 @@ def _constrained_nested(annotation: Any, allowed: Mapping[str, Sequence[str]]) -
+       tests/test_supplied_ids.py#@@ -13,6 +13,10 @@ honour is RECORDED rather than dropped.
+       tests/test_supplied_ids.py#@@ -32,6 +36,22 @@ class _Container(StrictResponseModel):
+       tests/test_supplied_ids.py#@@ -68,6 +88,31 @@ def test_a_list_valued_id_field_constrains_its_items():
+
+Recommended tests:
+  1. Parsing can distinguish disposition variants by a literal discriminator field.
+       inputs:  A decomposition response whose `requirement_dispositions` contains two different variant shapes that share the same `requirement_id` field but differ only by the literal `disposition` tag, plus a negative control where the tag is omitted or made non-literal in a hand-built schema/instance. Use at least one `yielded` entry and one `no_obligation` entry so the parser must choose the correct variant by the literal tag, not by `requirement_id` alone.
+       detects: Disposition variants use a non-literal or missing discriminator field, or the union is treated as a plain same-shape union keyed only by `obligation_id`/`requirement_id`, making parse-time matching ambiguous.
+       full detail: acceptance recommendation --criterion obligation-unambiguous-literal-discriminators
+  2. Malformed yielded responses are rejected during parsing.
+       inputs:  A raw `_Decomposition`-shaped payload with a `requirement_dispositions` item whose `disposition` is `yielded` but whose obligation-id payload is empty/missing: specifically omit `obligation_id` and provide `more_obligation_ids: []`. This is the exact shape that should be unrepresentable if the schema is correct.
+       detects: Malformed yielded responses are accepted during parsing even when they name no obligations, allowing an empty yielded disposition to slip through.
+       full detail: acceptance recommendation --criterion obligation-yielded-empty-obligations-rejected
+  3. Parsing failure prevents construction of a RequirementMap.
+       inputs:  A response that is rejected during reconciliation for a single concrete reason, such as one requirement omitted from `requirement_dispositions` or one duplicate requirement id, while the rest of the response is otherwise valid. Use the same task fixture as the existing requirement-map tests so the registry is non-empty and the failure is deterministic.
+       detects: Parsing raises an error but still returns or stores a partial `RequirementMap`, so a rejected response can leak a partially constructed map.
+       full detail: acceptance recommendation --criterion obligation-rejected-response-produces-no-map
+  4. Schema types follow the repository's pydantic-model pattern.
+       inputs:  A schema-introspection test against the response model classes used by decomposition, especially `_Decomposition` and the disposition union. Inspect the generated pydantic schema and the model classes themselves rather than runtime behavior. Include the union member classes and the container model so the test can verify the repository’s pydantic-model pattern end to end.
+       detects: Schema types are implemented with the wrong pattern, such as plain dataclasses/TypedDicts or a tagged union that emits `oneOf` plus `discriminator`, which would not match the repository’s pydantic strict-mode approach.
+       full detail: acceptance recommendation --criterion obligation-pydantic-typed-schemas
+  5. The test suite runs without contacting a live model endpoint.
+       inputs:  A test that exercises the full test suite’s model-call path using a stubbed client or transcript fixture, and a guard that fails if any code path attempts a real network/model endpoint call. The input should be one of the existing offline fixtures that already drives `decompose(...)` or the CLI, so the test can prove the path stays local.
+       detects: A test path actually contacts a live model endpoint instead of replaying or using local fixtures, or a live-call branch exists but is not exercised by the current suite.
+       full detail: acceptance recommendation --criterion obligation-tests-no-live-model-calls
+  6. Open-question responses without question ids are rejected.
+       inputs:  A decomposition response containing an `open_question` disposition item with a literal `disposition: 'open_question'` but no `open_question_id` and an empty `more_open_question_ids` list. Pair it with otherwise valid items so the only failure is the empty open-question payload.
+       detects: Open-question responses without question ids are accepted, allowing an empty open-question disposition to parse when it should be rejected.
+       full detail: acceptance recommendation --criterion obligation-open-question-empty-rejected
+  7. The test suite includes coverage for the yielded-empty schema constraint.
+       inputs:  A schema-level test that feeds the response model an empty-yielded shape and asserts the schema/validation constraint is enforced at the model boundary. Use the exact `_Decomposition` model and its `requirement_dispositions` item schema, with `yielded` missing `obligation_id` and `more_obligation_ids` empty.
+       detects: The test suite lacks coverage for the yielded-empty schema constraint, so a regression could remove the structural requirement while existing tests still pass.
+       full detail: acceptance recommendation --criterion obligation-schema-test-rejects-empty-yielded
+
+Evidence limitations:
+  1. Judgments are static inferences unless a higher tier is recorded; the full application was not independently executed.
+
+Next: retrieve a criterion's full recommendation with
+  acceptance recommendation --criterion <id>

--- a/dogfood-logs/217-gate2-run2/revisions.txt
+++ b/dogfood-logs/217-gate2-run2/revisions.txt
@@ -1,0 +1,2 @@
+base 6ae97fd
+head 007966f

--- a/dogfood-logs/217-gate2-run3/current-task.md
+++ b/dogfood-logs/217-gate2-run3/current-task.md
@@ -1,0 +1,83 @@
+# Task
+DR-202 decision 3 gives a requirement exactly one of three dispositions, each
+carrying something: yielded obligations, deliberately yields none with a reason,
+or raised an open question instead. The implementation added a fourth,
+`UNDISPOSED`, carrying none of them, and reached it two ways: a response that
+never mentioned a requirement, and a response that labelled a requirement
+`yielded` while naming no obligations.
+
+Both are malformed responses, and both are currently absorbed as soft findings.
+`_requirement_map` discards the reason the response supplied, substitutes a
+diagnostic string of its own, and lets the run continue to a verdict on an
+answer that did not account for the mandate.
+
+The registry of requirements is derived deterministically from the parse, and
+the code iterates over that registry. Dropping a requirement is therefore not a
+possible outcome — the only possible bad outcome is a response of poor quality.
+Make that true in the types: every requirement carries one of exactly three
+dispositions, each structurally required to carry its own payload, and a
+response that fails to account for every requirement does not parse. Remove the
+fourth disposition entirely.
+
+## Constraints
+- A requirement disposition is one of exactly three: yielded obligations,
+  no obligations needed with a reason, or an open question that prevents an
+  answer.
+- `Disposition` has no `UNDISPOSED` value.
+- `_RequirementDisposition` is a union of one shape per disposition, each
+  carrying only the payload its own disposition defines.
+- The union is unambiguous at parse: each shape names its disposition as a
+  literal value.
+- The schema sent to the model uses only keywords OpenAI strict mode accepts.
+- A `yielded` disposition carries at least one obligation id.
+- A `no_obligation` disposition carries a reason that is not empty.
+- An `open_question` disposition carries at least one open-question id.
+- A response labelling a requirement `yielded` while naming no obligation id
+  fails to parse.
+- A response labelling a requirement `no_obligation` with an empty reason fails
+  to parse.
+- A response that omits any requirement in the registry is rejected.
+- A response that names a requirement id absent from the registry is rejected.
+- A rejected response produces no `RequirementMap`.
+- The JSON schema sent to the model cannot express a `yielded` disposition with
+  zero obligation ids.
+- The reason a response supplies for declining a requirement is preserved rather
+  than replaced by a diagnostic string.
+- The helper that restricts an id field to the ids a call supplied keeps working
+  when the response model's item type is a union, so the requirement-id
+  constraint survives the new shape.
+- Typed schemas are pydantic models, as the rest of the repository defines them.
+- Tests issue no live model calls.
+
+## Scope exclusions
+- The decomposer declining to yield obligations for scope exclusions, against
+  the instruction already in the decompose prompt. That is a prompt defect
+  tracked separately and costs a transcript re-record.
+- Changing the decompose prompt text.
+- Retrying or repairing a rejected response.
+- Nested-bullet and multi-paragraph parse coverage, which is #216.
+- Whether mandate coverage bounds the completion verdict, which is #214.
+- Aligning requirement ids across two versions of a task file, which is #209.
+
+## Completion expectations
+- Implementation
+- Every requirement in a parsed `RequirementMap` carries one of the three
+  dispositions.
+- A response with a `yielded` disposition and no obligation ids is rejected.
+- A response with a `no_obligation` disposition and an empty reason is rejected.
+- A response omitting a requirement present in the registry is rejected.
+- No `RequirementMap` is produced from a rejected response.
+- The `UNDISPOSED` value and every code path that assigns it are removed.
+- A response naming a requirement id outside the registry is rejected.
+- A response disposing the same requirement twice is rejected.
+- An `open_question` disposition naming no question the response produced is
+  rejected.
+- A test asserts that the schema sent to the model rejects a `yielded`
+  disposition carrying zero obligation ids.
+- A test asserts that the id constraint still reaches every member of a union
+  item type.
+- The tests, CLI rendering and report sections that referred to the removed
+  disposition are updated rather than left asserting it.
+- `docs/DR-202-decomposition-requirement-mapping.md` records that the
+  disposition set is the three of decision 3, and that completeness is enforced
+  at parse.

--- a/dogfood-logs/217-gate2-run3/judgement.md
+++ b/dogfood-logs/217-gate2-run3/judgement.md
@@ -34,3 +34,36 @@ written.
 
 **Nothing here is waved off. No PR until each of the five is either fixed or
 attributed to a filed defect.**
+
+
+## Re-check of all five recommendations (added later)
+
+Each was checked against the actual tests rather than judged from its `detects:`
+line. Four of five held.
+
+| # | obligation | outcome |
+|---|---|---|
+| 3 | `disposition-union-payloads` | **Real gap.** Both its recommendation and #4's asked for MIXED payloads — a `yielded` entry also carrying `reason`. Addressed in `865f6e9`. |
+| 4 | `unambiguous-literal-discriminators` | Same gap, same test. |
+| 17 | `pydantic-typed-schemas` | **#148.** See correction below. |
+| 21 | `schema-test-rejects-empty-yielded` | **#148 category 2.** `test_the_schema_cannot_express_a_yielded_disposition_with_no_obligations` exists and does exactly what the recommendation asks. Nothing can be mapped to "a test asserts X". |
+| 22 | `union-id-test-covers-members` | **#148 category 2.** Same shape; it drew 6 mapped tests including the correct one, where 21 drew none. |
+
+### Correction on obligation 17
+
+It was reported to the human as a **mapping miss (#182)**, on the grounds that
+`test_a_union_of_item_shapes_constrains_every_member` does what recommendation 3
+describes. That was wrong.
+
+The test matches the recommendation's *prescription* — a synthetic pydantic model
+with a union-of-models field, run through the constraining and inlining path —
+but it would pass whether or not the production schemas are pydantic. It cannot
+discriminate the obligation, so the mapper had nothing on-point to miss.
+
+Obligation 17 is #148 category 1, as the #148 comment filed from this same run
+already said. The two accounts were inconsistent and this is the correct one.
+
+**The error shape is worth keeping**: naming a test that resembles the
+recommendation, without checking that the test would fail if the obligation were
+violated. The same shape produced the wrong dismissal recorded above for #218's
+`closing-line-points-at-retrieval-command`.

--- a/dogfood-logs/217-gate2-run3/judgement.md
+++ b/dogfood-logs/217-gate2-run3/judgement.md
@@ -1,0 +1,36 @@
+# Judgement — #217 Gate 2 run 3
+
+`6ae97fd` → `6c06517`. **Not clean.** INCOMPLETE: 5 obligations with
+non-discriminating test evidence, down from 11 (run 1) and 7 (run 2). No
+obligation unaddressed; no `separable` unrequested change; mandate coverage
+unchanged and correct.
+
+Remaining, and **not yet dispositioned** — this is where the session stopped:
+
+| obligation | shape |
+|---|---|
+| `obligation-schema-test-rejects-empty-yielded` | meta: "a test asserts X" |
+| `obligation-union-id-test-covers-members` | meta: "a test asserts X" |
+| `obligation-unambiguous-literal-discriminators` | has a direct, on-point test |
+| `obligation-disposition-union-payloads` | has direct tests |
+| `obligation-pydantic-typed-schemas` | generic; repo-wide convention |
+
+Two are **meta-obligations** — the task file asks that *a test exist*, and the
+evidence stage is being asked to find a test proving a test exists. That is a
+task-file authoring problem more than a tool defect: the completion expectation
+should state the behaviour to be guaranteed, not the artifact.
+
+The other three carry tests written specifically for them
+(`test_the_literal_tag_alone_decides_which_shape_a_disposition_is` was added in
+run 2's response and the obligation still reads non-discriminating). Whether
+that is an evidence-judgement defect (#183) or a mapping defect (#182) is
+**not yet established** and must not be assumed — a clean verdict is only as
+good as the mapping behind it (DR-164).
+
+Recommendation 2 of this run is a legitimate sharpening rather than noise: it
+asks for union members carrying *misleading* fields, which `extra="forbid"`
+turns into the strongest available proof that dispatch is by tag alone. Not yet
+written.
+
+**Nothing here is waved off. No PR until each of the five is either fixed or
+attributed to a filed defect.**

--- a/dogfood-logs/217-gate2-run3/output.log
+++ b/dogfood-logs/217-gate2-run3/output.log
@@ -1,0 +1,377 @@
+Task completion: INCOMPLETE
+
+5 obligation(s) with non-discriminating test evidence (obligation-disposition-union-payloads, obligation-unambiguous-literal-discriminators, obligation-pydantic-typed-schemas, obligation-schema-test-rejects-empty-yielded, obligation-union-id-test-covers-members).
+
+Obligations:
+
+  1. A requirement disposition is limited to exactly three cases: yielded obligations, no obligations needed with a reason, or an open question that prevents an answer.
+       requirements: task-01, constraint-01, exclusion-01
+       code evidence: addressed
+         1.1  src/acceptance/review_state.py#@@ -280,17 +280,18 @@ class Disposition(str, Enum):
+         1.2  src/acceptance/requirement/obligations.py#@@ -13,12 +13,18 @@ obligations — uncertainty is a first-class, expected result (M1.3).
+         1.3  docs/DR-202-decomposition-requirement-mapping.md#@@ -108,6 +108,39 @@ erred. Nothing here asks that. Forcing an answer per requirement makes *silence*
+       test evidence: strongly supported  [tier: static]
+         1.4  tests/requirement/test_requirement_map.py::test_the_disposition_set_is_exactly_the_three_of_decision_3
+         1.5  tests/requirement/test_requirement_map.py::test_the_literal_tag_alone_decides_which_shape_a_disposition_is
+         1.6  tests/test_cli.py::test_check_json_emits_a_structured_review
+
+  2. The Disposition type excludes any UNDISPOSED value.
+       requirements: task-01, task-03, constraint-02, completion-07
+       code evidence: addressed
+         2.1  src/acceptance/review_state.py#@@ -280,17 +280,18 @@ class Disposition(str, Enum):
+         2.2  src/acceptance/review_state.py#@@ -319,10 +320,6 @@ class RequirementDisposition(_Model):
+       test evidence: strongly supported  [tier: static]
+         2.3  tests/requirement/test_requirement_map.py::test_the_disposition_set_is_exactly_the_three_of_decision_3
+         2.4  tests/requirement/test_requirement_map.py::test_the_literal_tag_alone_decides_which_shape_a_disposition_is
+         2.5  tests/test_cli.py::test_check_json_emits_a_structured_review
+         2.6  tests/test_supplied_ids.py::test_scan_finds_ids_that_were_never_supplied
+         2.7  tests/test_supplied_ids.py::test_scan_reports_each_unusable_id_once
+
+  3. _RequirementDisposition is modeled as a union with one shape per disposition, and each shape carries only the payload defined by that disposition.
+       requirements: task-03, constraint-03, completion-09
+       code evidence: addressed
+         3.1  src/acceptance/requirement/obligations.py#@@ -173,14 +181,52 @@ class _OpenQuestion(StrictResponseModel):
+       test evidence: partially supported  [tier: static]
+         3.2  tests/requirement/test_requirement_map.py::test_the_literal_tag_alone_decides_which_shape_a_disposition_is
+
+  4. Each disposition shape names its disposition as a literal value so the union is unambiguous at parse time.
+       requirements: task-03, constraint-04
+       code evidence: addressed
+         4.1  src/acceptance/requirement/obligations.py#@@ -173,14 +181,52 @@ class _OpenQuestion(StrictResponseModel):
+       test evidence: partially supported  [tier: static]
+         4.2  tests/requirement/test_requirement_map.py::test_the_literal_tag_alone_decides_which_shape_a_disposition_is
+
+  5. The schema sent to the model uses only keywords accepted by OpenAI strict mode.
+       requirements: constraint-05
+       code evidence: addressed
+         5.1  src/acceptance/requirement/obligations.py#@@ -173,14 +181,52 @@ class _OpenQuestion(StrictResponseModel):
+         5.2  tests/requirement/test_requirement_map.py#@@ -192,16 +235,273 @@ def test_a_yielded_claim_naming_no_real_obligation_is_not_honoured():
+       test evidence: strongly supported  [tier: static]
+         5.3  tests/requirement/test_requirement_map.py::test_the_schema_cannot_express_a_yielded_disposition_with_no_obligations
+         5.4  tests/test_llm.py::test_the_hashed_request_carries_the_inlined_schema
+         5.5  tests/test_llm.py::test_the_schema_sent_to_the_provider_has_no_ref_indirection
+
+  6. A yielded disposition carries at least one obligation id.
+       requirements: constraint-01, constraint-06
+       code evidence: addressed
+         6.1  src/acceptance/requirement/obligations.py#@@ -173,14 +181,52 @@ class _OpenQuestion(StrictResponseModel):
+       test evidence: strongly supported  [tier: static]
+         6.2  tests/requirement/test_requirement_map.py::test_a_yielded_claim_naming_no_real_obligation_is_rejected
+         6.3  tests/requirement/test_requirement_map.py::test_the_schema_cannot_express_a_yielded_disposition_with_no_obligations
+
+  7. A no_obligation disposition carries a non-empty reason.
+       requirements: constraint-01, constraint-07
+       code evidence: addressed
+         7.1  src/acceptance/requirement/obligations.py#@@ -173,14 +181,52 @@ class _OpenQuestion(StrictResponseModel):
+         7.2  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+       test evidence: strongly supported  [tier: static]
+         7.3  tests/requirement/test_requirement_map.py::test_a_no_obligation_disposition_with_an_empty_reason_is_rejected
+         7.4  tests/test_cli.py::test_a_requirement_that_yielded_nothing_is_visible_in_the_report
+         7.5  tests/test_cli.py::test_the_pipeline_persists_the_requirement_map
+
+  8. An open_question disposition carries at least one open-question id.
+       requirements: constraint-01, constraint-08
+       code evidence: addressed
+         8.1  src/acceptance/requirement/obligations.py#@@ -173,14 +181,52 @@ class _OpenQuestion(StrictResponseModel):
+       test evidence: strongly supported  [tier: static]
+         8.2  tests/coverage/test_open_questions.py::test_diff_does_not_resolve_the_question
+         8.3  tests/coverage/test_open_questions.py::test_diff_resolves_the_question
+         8.4  tests/requirement/test_requirement_map.py::test_an_open_question_disposition_naming_no_real_question_is_rejected
+         8.5  tests/requirement/test_requirement_map.py::test_the_schema_cannot_express_an_open_question_disposition_with_no_questions
+         8.6  tests/test_verdict.py::test_resolved_open_question_does_not_block
+
+  9. A response that labels a requirement yielded while naming no obligation id fails to parse.
+       requirements: constraint-09, completion-03
+       code evidence: addressed
+         9.1  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+         9.2  tests/requirement/test_requirement_map.py#@@ -192,16 +235,273 @@ def test_a_yielded_claim_naming_no_real_obligation_is_not_honoured():
+       test evidence: strongly supported  [tier: static]
+         9.3  tests/requirement/test_requirement_map.py::test_the_schema_cannot_express_a_yielded_disposition_with_no_obligations
+
+  10. A response that labels a requirement no_obligation with an empty reason fails to parse.
+       requirements: constraint-10, completion-04
+       code evidence: addressed
+         10.1  src/acceptance/review_state.py#@@ -319,10 +320,6 @@ class RequirementDisposition(_Model):
+         10.2  tests/requirement/test_requirement_map.py#@@ -192,16 +235,273 @@ def test_a_yielded_claim_naming_no_real_obligation_is_not_honoured():
+       test evidence: strongly supported  [tier: static]
+         10.3  tests/requirement/test_requirement_map.py::test_a_no_obligation_disposition_with_an_empty_reason_is_rejected
+
+  11. A response that omits any requirement in the registry is rejected.
+       requirements: task-03, constraint-11, completion-05
+       code evidence: addressed
+         11.1  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+         11.2  tests/requirement/test_requirement_map.py#@@ -146,12 +185,12 @@ def test_a_requirement_the_response_never_mentions_is_recorded_as_undisposed():
+       test evidence: strongly supported  [tier: static]
+         11.3  tests/requirement/test_requirement_map.py::test_a_response_that_never_mentions_a_requirement_is_rejected
+
+  12. A response that names a requirement id absent from the registry is rejected.
+       requirements: task-03, constraint-12, completion-08
+       code evidence: addressed
+         12.1  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+         12.2  tests/requirement/test_requirement_map.py#@@ -192,16 +235,273 @@ def test_a_yielded_claim_naming_no_real_obligation_is_not_honoured():
+       test evidence: strongly supported  [tier: static]
+         12.3  tests/evidence/test_mapping.py::test_unknown_ids_are_dropped
+         12.4  tests/requirement/test_requirement_map.py::test_a_response_naming_a_requirement_outside_the_registry_is_rejected
+         12.5  tests/requirement/test_requirement_map.py::test_a_yielded_claim_naming_no_real_obligation_is_rejected
+         12.6  tests/requirement/test_requirement_map.py::test_an_open_question_disposition_naming_no_real_question_is_rejected
+         12.7  tests/test_cli.py::test_recommendation_for_an_unknown_criterion_is_empty_not_an_error
+         12.8  tests/test_cli.py::test_run_check_rejects_a_revision_missing_from_the_given_repo
+
+  13. A rejected response produces no RequirementMap.
+       requirements: task-02, constraint-13, exclusion-03, completion-06
+       code evidence: addressed
+         13.1  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+       test evidence: strongly supported  [tier: static]
+         13.2  tests/requirement/test_requirement_map.py::test_a_requirement_disposed_twice_is_rejected
+         13.3  tests/requirement/test_requirement_map.py::test_a_yielded_claim_naming_no_real_obligation_is_rejected
+         13.4  tests/requirement/test_requirement_map.py::test_an_open_question_disposition_naming_no_real_question_is_rejected
+         13.5  tests/test_cli.py::test_check_json_emits_a_structured_review
+         13.6  tests/test_cli.py::test_the_pipeline_persists_the_requirement_map
+
+  14. The JSON schema sent to the model cannot express a yielded disposition with zero obligation ids.
+       requirements: constraint-14
+       code evidence: addressed
+         14.1  src/acceptance/requirement/obligations.py#@@ -173,14 +181,52 @@ class _OpenQuestion(StrictResponseModel):
+         14.2  tests/requirement/test_requirement_map.py#@@ -192,16 +235,273 @@ def test_a_yielded_claim_naming_no_real_obligation_is_not_honoured():
+       test evidence: strongly supported  [tier: static]
+         14.3  tests/requirement/test_requirement_map.py::test_the_schema_cannot_express_a_yielded_disposition_with_no_obligations
+
+  15. The reason supplied for declining a requirement is preserved rather than replaced by a diagnostic string.
+       requirements: task-02, constraint-15
+       code evidence: addressed
+         15.1  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+         15.2  tests/requirement/test_requirement_map.py#@@ -192,16 +235,273 @@ def test_a_yielded_claim_naming_no_real_obligation_is_not_honoured():
+       test evidence: strongly supported  [tier: static]
+         15.3  tests/requirement/test_requirement_map.py::test_a_requirement_deliberately_yielding_nothing_carries_its_reason
+         15.4  tests/requirement/test_requirement_map.py::test_a_supplied_reason_is_preserved_rather_than_replaced
+         15.5  tests/test_cli.py::test_a_requirement_that_yielded_nothing_is_visible_in_the_report
+         15.6  tests/test_cli.py::test_the_pipeline_persists_the_requirement_map
+
+  16. The helper that restricts an id field to supplied ids continues to work when the response model item type is a union, so the requirement-id constraint survives the new shape.
+       requirements: constraint-16
+       code evidence: addressed
+         16.1  src/acceptance/supplied_ids.py#@@ -33,13 +33,17 @@ than dropped. Dropping is what made the original defect invisible.
+         16.2  src/acceptance/supplied_ids.py#@@ -63,16 +67,27 @@ def _constrained_nested(annotation: Any, allowed: Mapping[str, Sequence[str]]) -
+       test evidence: strongly supported  [tier: static]
+         16.3  tests/requirement/test_requirement_map.py::test_a_disposition_naming_a_renamed_obligation_still_links
+         16.4  tests/test_supplied_ids.py::test_a_foreign_id_does_not_validate_against_the_constrained_schema
+         16.5  tests/test_supplied_ids.py::test_a_list_valued_id_field_constrains_its_items
+         16.6  tests/test_supplied_ids.py::test_a_single_supplied_id_is_still_sent_as_an_enum
+         16.7  tests/test_supplied_ids.py::test_a_union_of_item_shapes_constrains_every_member
+         16.8  tests/test_supplied_ids.py::test_each_partition_constrains_test_ids_to_its_own_batch
+         16.9  tests/test_supplied_ids.py::test_supplied_ids_become_an_enum_on_the_field_the_model_sees
+         16.10  tests/test_supplied_ids.py::test_the_schema_asked_for_differs_from_the_shape_parsed
+
+  17. Typed schemas are implemented as pydantic models.
+       requirements: constraint-17
+       code evidence: addressed
+         17.1  src/acceptance/requirement/obligations.py#@@ -173,14 +181,52 @@ class _OpenQuestion(StrictResponseModel):
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  18. Tests issue no live model calls.
+       requirements: constraint-18
+       code evidence: addressed
+         (no corresponding change)
+       test evidence: strongly supported  [tier: static]
+         18.1  tests/test_cli.py::test_classify_replay_without_transcript_fails_cleanly
+         18.2  tests/test_cli.py::test_decompose_replay_without_transcript_fails_cleanly
+         18.3  tests/test_cli.py::test_retrieval_makes_no_model_call
+
+  19. Every requirement in a parsed RequirementMap carries one of the three dispositions.
+       requirements: task-01, task-03, completion-02
+       code evidence: addressed
+         19.1  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+         19.2  src/acceptance/review_state.py#@@ -280,17 +280,18 @@ class Disposition(str, Enum):
+       test evidence: strongly supported  [tier: static]
+         19.3  tests/requirement/test_requirement_map.py::test_a_fully_accounted_response_disposes_every_requirement
+         19.4  tests/test_cli.py::test_a_requirement_that_yielded_nothing_is_visible_in_the_report
+         19.5  tests/test_cli.py::test_check_json_emits_a_structured_review
+         19.6  tests/test_cli.py::test_the_pipeline_persists_the_requirement_map
+         19.7  tests/test_verdict.py::test_resolved_open_question_does_not_block
+
+  20. An open_question disposition naming no question the response produced is rejected.
+       requirements: completion-10
+       code evidence: addressed
+         20.1  src/acceptance/requirement/obligations.py#@@ -173,14 +181,52 @@ class _OpenQuestion(StrictResponseModel):
+         20.2  src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+         20.3  tests/requirement/test_requirement_map.py#@@ -192,16 +235,273 @@ def test_a_yielded_claim_naming_no_real_obligation_is_not_honoured():
+       test evidence: strongly supported  [tier: static]
+         20.4  tests/requirement/test_requirement_map.py::test_the_schema_cannot_express_an_open_question_disposition_with_no_questions
+
+  21. A test asserts that the schema sent to the model rejects a yielded disposition carrying zero obligation ids.
+       requirements: completion-11
+       code evidence: addressed
+         21.1  tests/requirement/test_requirement_map.py#@@ -192,16 +235,273 @@ def test_a_yielded_claim_naming_no_real_obligation_is_not_honoured():
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+
+  22. A test asserts that the id constraint still reaches every member of a union item type.
+       requirements: completion-12
+       code evidence: addressed
+         22.1  tests/test_supplied_ids.py#@@ -68,6 +88,31 @@ def test_a_list_valued_id_field_constrains_its_items():
+       test evidence: partially supported  [tier: static]
+         22.2  tests/requirement/test_requirement_map.py::test_one_obligation_serves_two_requirements_rather_than_being_duplicated
+         22.3  tests/test_supplied_ids.py::test_a_foreign_id_does_not_validate_against_the_constrained_schema
+         22.4  tests/test_supplied_ids.py::test_a_union_of_item_shapes_constrains_every_member
+         22.5  tests/test_supplied_ids.py::test_each_partition_constrains_test_ids_to_its_own_batch
+         22.6  tests/test_supplied_ids.py::test_supplied_ids_become_an_enum_on_the_field_the_model_sees
+         22.7  tests/test_supplied_ids.py::test_the_schema_asked_for_differs_from_the_shape_parsed
+
+  23. The tests, CLI rendering, and report sections that referred to the removed disposition are updated rather than left asserting it.
+       requirements: exclusion-02, completion-13
+       code evidence: addressed
+         23.1  src/acceptance/cli.py#@@ -286,26 +286,26 @@ def _summary(requirement_map, total: int) -> str:
+         23.2  src/acceptance/cli.py#@@ -344,12 +344,9 @@ def _requirement_block(
+         23.3  src/acceptance/report.py#@@ -207,9 +207,13 @@ def _mandate_coverage_block(requirement_map: RequirementMap) -> list[str]:
+         23.4  src/acceptance/review_state.py#@@ -280,17 +280,18 @@ class Disposition(str, Enum):
+         23.5  tests/test_cli.py#@@ -948,11 +949,14 @@ def test_the_pipeline_persists_the_requirement_map(git_repo, tmp_path, stub_mode
+         23.6  tests/test_cli.py#@@ -973,7 +977,10 @@ def test_the_pipeline_persists_the_requirement_map(git_repo, tmp_path, stub_mode
+         23.7  tests/test_decision_records.py#@@ -42,6 +42,20 @@ def test_dr_202_records_the_requirement_id_decision_as_resolved():
+         23.8  tests/requirement/test_requirement_map.py#@@ -124,14 +150,27 @@ def test_a_fully_accounted_response_leaves_no_requirement_undisposed():
+         23.9  tests/requirement/test_requirement_map.py#@@ -334,10 +633,7 @@ def test_the_cli_lists_every_requirement_including_the_ones_yielding_nothing():
+         23.10  tests/requirement/test_requirement_map.py#@@ -375,35 +681,23 @@ def test_an_obligation_no_requirement_claims_is_still_shown():
+       test evidence: strongly supported  [tier: static]
+         23.11  tests/benchmark/test_labels.py::test_candidate_test_ids_name_real_tests
+         23.12  tests/requirement/test_requirement_map.py::test_an_obligation_no_requirement_claims_is_still_shown
+         23.13  tests/requirement/test_requirement_map.py::test_one_obligation_serves_two_requirements_rather_than_being_duplicated
+         23.14  tests/requirement/test_requirement_map.py::test_text_the_parse_never_read_is_carried_into_the_mapping
+         23.15  tests/requirement/test_requirement_map.py::test_the_cli_lists_every_requirement_including_the_ones_yielding_nothing
+         23.16  tests/requirement/test_requirement_map.py::test_the_cli_says_when_an_obligation_serves_other_requirements
+         23.17  tests/requirement/test_requirement_map.py::test_the_cli_shouts_about_text_that_was_never_read
+         23.18  tests/requirement/test_requirement_map.py::test_the_disposition_set_is_exactly_the_three_of_decision_3
+         23.19  tests/test_cli.py::test_a_stale_instruction_file_is_removed_and_the_removal_reported
+         23.20  tests/test_cli.py::test_check_writes_no_instruction_file_even_when_the_review_has_gaps
+         23.21  tests/test_cli.py::test_render_change_set_omits_ignored_section_when_empty
+         23.22  tests/test_cli.py::test_render_change_set_shows_ignored_paths
+         23.23  tests/test_cli.py::test_render_classify_output
+         23.24  tests/test_cli.py::test_render_classify_shows_none_for_no_open_questions
+         23.25  tests/test_cli.py::test_report_shell_renders_all_sections_present_and_empty
+         23.26  tests/test_cli.py::test_run_classify_auto_ignores_the_task_file
+         23.27  tests/test_cli.py::test_task_ignore_pattern_for_a_file_inside_the_repo
+         23.28  tests/test_cli.py::test_task_ignore_pattern_for_a_relative_path
+         23.29  tests/test_cli.py::test_task_ignore_pattern_is_none_outside_the_repo
+         23.30  tests/test_cli.py::test_the_removal_is_reported_in_json_mode_too
+         23.31  tests/test_cli.py::test_the_removal_leaves_the_report_as_the_only_statement_of_status
+         23.32  tests/test_cli.py::test_the_spec_does_not_frame_the_recommendation_as_a_written_artifact
+         23.33  tests/test_cli.py::test_the_spec_names_the_command_the_cli_actually_accepts
+         23.34  tests/test_cli.py::test_the_spec_no_longer_names_a_written_file
+
+  24. The decomposition documentation records that the disposition set is the three of decision 3, and that completeness is enforced at parse.
+       requirements: completion-14
+       code evidence: addressed
+         24.1  docs/DR-202-decomposition-requirement-mapping.md#@@ -108,6 +108,39 @@ erred. Nothing here asks that. Forcing an answer per requirement makes *silence*
+       test evidence: strongly supported  [tier: static]
+         24.2  tests/test_cli.py::test_render_decomposition_lists_obligations_and_open_questions
+         24.3  tests/test_decision_records.py::test_dr_202_no_longer_lists_requirement_id_stability_as_open
+         24.4  tests/test_decision_records.py::test_dr_202_records_the_requirement_id_decision_as_resolved
+         24.5  tests/test_decision_records.py::test_dr_202_records_the_three_disposition_set_and_parse_time_completeness
+         24.6  tests/test_decision_records.py::test_dr_202_records_what_the_interim_scheme_defers
+
+Mandate coverage: 37 of 41 requirements yielded obligations
+  1. [no_obligation] exclusion-04: Nested-bullet and multi-paragraph parse coverage, which is #216.
+       reason: This exclusion points to work tracked separately (#216) and does not add a direct implementation requirement here.
+  2. [no_obligation] exclusion-05: Whether mandate coverage bounds the completion verdict, which is #214.
+       reason: This exclusion explicitly defers the completion-verdict question to #214 and does not constrain this change directly.
+  3. [no_obligation] exclusion-06: Aligning requirement ids across two versions of a task file, which is #209.
+       reason: This exclusion refers to aligning ids across task-file versions, which is tracked separately (#209) and is outside this change's direct scope.
+  4. [no_obligation] completion-01: Implementation
+       reason: Section marker only.
+
+Unrequested changes:
+  1. [in_service] The CLI summary no longer reports an 'unaccounted for' count at all, changing user-visible output beyond merely removing the obsolete disposition. The obligations require updating references to the removed disposition, but do not ask to eliminate this summary field entirely.
+       src/acceptance/cli.py#@@ -286,26 +286,26 @@ def _summary(requirement_map, total: int) -> str:
+  2. [in_service] The requirement block now always renders 'no obligation, deliberately' for any requirement with no obligations and no open questions, even though the previous code distinguished an unaccounted-for failure case. Removing that distinction changes the rendered report behavior beyond the requested disposition removal.
+       src/acceptance/cli.py#@@ -344,12 +344,9 @@ def _requirement_block(
+  3. [in_service] The mandate coverage section text was rewritten to say a requirement that 'produced nothing' cannot appear, which changes report wording and semantics beyond the required update away from the removed disposition.
+       src/acceptance/report.py#@@ -207,9 +207,13 @@ def _mandate_coverage_block(requirement_map: RequirementMap) -> list[str]:
+  4. [in_service] The response model's internal shape changed from a single RequirementDisposition model with list fields to a union of three new model classes with different field names. Even if internal, this is a schema/interface change for the model payload and parser surface beyond the mere removal of UNDISPOSED.
+       src/acceptance/requirement/obligations.py#@@ -173,14 +181,52 @@ class _OpenQuestion(StrictResponseModel):
+  5. [in_service] _requirement_map now raises SchemaValidationError on duplicate, unknown, or missing requirements instead of recording an undisposed disposition. The obligations require rejecting malformed responses and parse-time completeness, but the specific duplicate/unknown/missing error handling and messages are additional behavior changes not explicitly called for.
+       src/acceptance/requirement/obligations.py#@@ -311,56 +357,84 @@ def _requirement_map(
+  6. [separable] Removing the undisposed() accessor changes the public API of RequirementMap. The obligations ask to remove the disposition concept and update references, but do not explicitly require deleting this method rather than leaving it unused or repurposed.
+       src/acceptance/review_state.py#@@ -364,23 +361,17 @@ class RequirementMap(_Model):
+  7. [in_service] The supplied-id constraint walker was generalized to recurse through unions and lists of union members. This is an internal refactor to preserve schema constraints, but the specific implementation change is broader than the obligations explicitly mention.
+       src/acceptance/supplied_ids.py#@@ -33,13 +33,17 @@ than dropped. Dropping is what made the original defect invisible.
+       src/acceptance/supplied_ids.py#@@ -63,16 +67,27 @@ def _constrained_nested(annotation: Any, allowed: Mapping[str, Sequence[str]]) -
+  8. [in_service] The benchmark doubles were changed from returning empty requirement_dispositions to auto-filling declines from supplied ids. The obligations require tests to avoid live model calls and to reflect the new parse-time completeness, but this automatic completion behavior is an extra harness behavior change.
+       tests/benchmark/degenerate_decomposers.py#@@ -35,7 +35,7 @@ from typing import Any
+       tests/benchmark/degenerate_decomposers.py#@@ -80,13 +80,8 @@ def _faithful(labels: GroundTruthLabels) -> dict[str, Any]:
+       tests/benchmark/degenerate_decomposers.py#@@ -143,7 +138,19 @@ def decomposer(labels: GroundTruthLabels, *, behaviour: str) -> ModelClient:
+       tests/benchmark/degenerate_judges.py#@@ -37,7 +37,7 @@ from typing import Any
+       tests/benchmark/degenerate_judges.py#@@ -80,6 +80,7 @@ def _decomposition(obligations: list[dict]) -> dict:
+       tests/benchmark/degenerate_judges.py#@@ -97,7 +98,17 @@ def degenerate_client(obligations: list[dict], *, always_strong: bool) -> ModelC
+       tests/support.py#@@ -34,10 +34,17 @@ def _fake_response(content: str) -> SimpleNamespace:
+       tests/support.py#@@ -127,7 +134,7 @@ def client_dispatching(
+       tests/support.py#@@ -141,6 +148,57 @@ def client_dispatching(
+  9. [in_service] The requirement-map tests now include extensive new assertions about schema structure, union tagging, parse-time rejection, and AST scanning for removed symbols. The obligations require tests covering the new parse enforcement and union-id constraint, but not this broad suite of extra behavioral checks.
+       tests/requirement/test_requirement_map.py#@@ -17,9 +17,15 @@ invariant — no live calls.
+       tests/requirement/test_requirement_map.py#@@ -56,12 +62,32 @@ def _obligation(oid: str, description: str, quote: str) -> dict:
+       tests/requirement/test_requirement_map.py#@@ -103,7 +129,7 @@ def test_each_registry_entry_carries_the_span_of_its_requirement():
+       tests/requirement/test_requirement_map.py#@@ -124,14 +150,27 @@ def test_a_fully_accounted_response_leaves_no_requirement_undisposed():
+       tests/requirement/test_requirement_map.py#@@ -146,12 +185,12 @@ def test_a_requirement_the_response_never_mentions_is_recorded_as_undisposed():
+       tests/requirement/test_requirement_map.py#@@ -175,14 +214,18 @@ def test_a_requirement_deliberately_yielding_nothing_carries_its_reason():
+       tests/requirement/test_requirement_map.py#@@ -192,16 +235,273 @@ def test_a_yielded_claim_naming_no_real_obligation_is_not_honoured():
+       tests/requirement/test_requirement_map.py#@@ -263,7 +563,6 @@ def test_a_disposition_naming_a_renamed_obligation_still_links():
+       tests/requirement/test_requirement_map.py#@@ -334,10 +633,7 @@ def test_the_cli_lists_every_requirement_including_the_ones_yielding_nothing():
+       tests/requirement/test_requirement_map.py#@@ -364,9 +660,19 @@ def test_an_obligation_no_requirement_claims_is_still_shown():
+       tests/requirement/test_requirement_map.py#@@ -375,35 +681,23 @@ def test_an_obligation_no_requirement_claims_is_still_shown():
+  10. [in_service] The CLI test now asserts every stored disposition is NO_OBLIGATION and has a reason, which is stronger than simply updating references away from UNDISPOSED. That extra assertion changes test scope beyond the requested update.
+       tests/test_cli.py#@@ -948,11 +949,14 @@ def test_the_pipeline_persists_the_requirement_map(git_repo, tmp_path, stub_mode
+       tests/test_cli.py#@@ -973,7 +977,10 @@ def test_the_pipeline_persists_the_requirement_map(git_repo, tmp_path, stub_mode
+  11. [in_service] The decision-records test adds a new assertion about the amended DR text and parse-time completeness. The documentation update is requested, but this specific extra test coverage is not explicitly required by the obligations.
+       tests/test_decision_records.py#@@ -42,6 +42,20 @@ def test_dr_202_records_the_requirement_id_decision_as_resolved():
+  12. [in_service] The supplied-ids tests add a new union-shaped fixture and validation case. The obligations require preserving the id constraint through union item types, but this particular extra fixture and validation path go beyond the minimal requested coverage.
+       tests/test_supplied_ids.py#@@ -13,6 +13,10 @@ honour is RECORDED rather than dropped.
+       tests/test_supplied_ids.py#@@ -32,6 +36,22 @@ class _Container(StrictResponseModel):
+       tests/test_supplied_ids.py#@@ -68,6 +88,31 @@ def test_a_list_valued_id_field_constrains_its_items():
+
+Changes since 007966f0:
+  closed:
+    - A response that labels a requirement yielded while naming no obligation id fails to parse.
+        code evidence: addressed -> addressed
+        test evidence: unsupported -> strongly supported
+    - A rejected response produces no RequirementMap.
+        code evidence: addressed -> addressed
+        test evidence: partially supported -> strongly supported
+    - Tests issue no live model calls.
+        code evidence: addressed -> addressed
+        test evidence: nominally supported -> strongly supported
+    - An open_question disposition naming no question the response produced is rejected.
+        code evidence: addressed -> addressed
+        test evidence: unsupported -> strongly supported
+  moved:
+    - _RequirementDisposition is modeled as a union with one shape per disposition, and each shape carries only the payload defined by that disposition.
+        test evidence: strongly supported -> partially supported
+    - Each disposition shape names its disposition as a literal value so the union is unambiguous at parse time.
+        test evidence: nominally supported -> partially supported
+    - A test asserts that the id constraint still reaches every member of a union item type.
+        test evidence: strongly supported -> partially supported
+
+Recommended tests:
+  1. Each parsed disposition variant contains only its own required fields: obligation ids, reason, or open-question ids.
+       inputs:  Build a decomposition response that is otherwise valid but intentionally gives each disposition variant an extra field from another variant: e.g. a yielded entry that also includes `reason`, and a no_obligation entry that also includes `obligation_id`/`more_obligation_ids` (or an open_question entry with obligation fields). Use at least one requirement of each variant so the parser must choose whether to accept or reject the mixed payload.
+       detects: Developer gives the yielded variant extra fields like `reason` or the no_obligation variant obligation-id fields, and the current tests do not catch that the union payload is not actually exclusive.
+       full detail: acceptance recommendation --criterion obligation-disposition-union-payloads
+  2. Parsing can distinguish disposition variants by a literal discriminator field.
+       inputs:  Construct two disposition objects that are identical except for the literal `disposition` tag, then add misleading fields that would tempt field-based dispatch: for example, a `no_obligation` entry that also contains `obligation_id` and `more_obligation_ids`, and a `yielded` entry that also contains `reason`. The key input is that the non-tag fields are intentionally ambiguous while the literal tags differ.
+       detects: Developer keeps literal tags but also relies on other fields for dispatch, making the union not truly unambiguous; the current tests only partially cover this and could miss field-based fallback behavior.
+       full detail: acceptance recommendation --criterion obligation-unambiguous-literal-discriminators
+  3. Schema types follow the repository's pydantic-model pattern.
+       inputs:  Use a small synthetic pydantic model with a union-of-models field and run it through the repository’s schema-constraining/inlining path, then inspect the generated JSON schema. The input should be chosen so the only way to preserve the id restriction is to recurse through pydantic model members inside the union.
+       detects: Schema types do not follow the repository's pydantic-model pattern, or the union is not preserved as a pydantic schema shape; the current evidence is unsupported and needs a test that exercises the actual schema generation path.
+       full detail: acceptance recommendation --criterion obligation-pydantic-typed-schemas
+  4. The test suite includes coverage for the yielded-empty schema constraint.
+       inputs:  Create a minimal `_Decomposition`-shaped payload where one requirement is tagged `yielded` but omits `obligation_id` and has an empty `more_obligation_ids` list. This must be a payload that would have been accepted if the schema only checked the list contents, so the defect changes the outcome.
+       detects: The test suite lacks coverage for the yielded-empty schema constraint, so a developer could regress the structural guarantee and still pass existing tests.
+       full detail: acceptance recommendation --criterion obligation-schema-test-rejects-empty-yielded
+  5. The test suite verifies id restriction across union members.
+       inputs:  Use a union-of-models container where the same constrained id field appears in every member, then validate both the schema and runtime behavior with an allowed id and a disallowed id. The input must force the helper to recurse into each union member rather than only the top-level container.
+       detects: Developer changes the test helper so it no longer verifies union-member constraints at all, allowing the id restriction to disappear from one or more union branches without detection.
+       full detail: acceptance recommendation --criterion obligation-union-id-test-covers-members
+
+Evidence limitations:
+  1. Judgments are static inferences unless a higher tier is recorded; the full application was not independently executed.
+
+Next: retrieve a criterion's full recommendation with
+  acceptance recommendation --criterion <id>

--- a/dogfood-logs/217-gate2-run3/revisions.txt
+++ b/dogfood-logs/217-gate2-run3/revisions.txt
@@ -1,0 +1,2 @@
+base 6ae97fd
+head 6c06517

--- a/session-state.md
+++ b/session-state.md
@@ -8,151 +8,109 @@ Committed, so it survives a context reset or a machine change — but still a
 scratch record, not a plan. **The GitHub issue stays authoritative** (#168).
 Clear it out when the task lands rather than letting it accrete.
 
-*Last updated: 2026-08-05*
+*Last updated: 2026-08-06*
 
 ---
 
 ## Task in flight
 
-**None.** #202 landed (`95a3856`, PR #215) and CI was green. `main` is clean.
+**#217 — M1.2.r2**, branch `issue-217-disposition-unrepresentable`, three commits
+(`76b847b`, `007966f`, `6c06517`). Not pushed, no PR.
 
-`current-task.md` still holds #202's mandate — it refers back to a finished task,
-which is expected.
+**Gate 2 is NOT clean.** Do not open a PR. See *Where it stands* below.
 
-## Next up
+## How #217 came to exist
 
-Board order is set. **#216 is first**, and the ordering deliberately puts
-measurement ahead of the DR-202 siblings:
+#216 was the intended task. Its **Gate 1 never passed**: 8 of 31 requirements
+came back `yielded` with an empty id list. The transcript showed the model had
+supplied a substantive `no_obligation` reason for every one, and
+`_requirement_map` discarded it because the label disagreed with the payload,
+recording the requirement as unaccounted-for instead.
 
-| order | issue | |
-|---|---|---|
-| 413.05 | **#216** | nested bullets dropped silently, guard reports zero |
-| 413.10 | **#211** | rebuild #195's suite; link precision vs coverage |
-| 413.15 | #210 | mapping over-merges onto adjacent requirements |
-| 413.2–413.6 | #204, #205, #206, #144, #207 | the DR-202 siblings |
-| 413.7–413.85 | #214, #213, #212, #209 | |
+So the fourth disposition `M1.2.r1` added, `UNDISPOSED`, was turning malformed
+responses into soft findings that still reached a verdict. #202 is correctly
+closed — its acceptance genuinely passed — and #217 supersedes it.
 
-**Why this differs from DR-202's stated sequencing**, which put #144 immediately
-after #202:
+**#216 is still open and still unstarted.** Its Gate 1 must be re-run after #217
+lands; the run that exposed all this is in `dogfood-logs/216-gate1-run1/`.
 
-- **#144's premise was falsified.** DR-202 decision 2 reframed it on the claim
-  that anchoring to identified requirements removes over-merging risk. #210
-  showed the reframe *relocates* over-merging into requirement linking. #144
-  needs a design revisit, not just a build. Commented on #144.
-- **#144 changes the obligation set**, so without #211 it gets judged by eyeball —
-  which is what `tests/fixtures/decompose-stability/` exists to prevent.
-- **#204/#205/#206 all edit the decompose prompt.** Each edit forces a transcript
-  re-record and makes accuracy non-comparable. Do them as one batch, not
-  interleaved with #144.
+## What #217 delivered
 
-**#214 probably wants a `decision` label and a short DR before building** — how
-mandate coverage bounds the verdict is a design question. Instinct: it should
-bound the verdict the way `Indeterminate` does rather than being averaged in.
+- three disposition shapes, each carrying only its own payload; `UNDISPOSED` and
+  every path assigning it deleted
+- reconciliation raises `SchemaValidationError` on a missing requirement, a
+  duplicate, an unknown id, or a claim naming only outputs never produced
+- a supplied reason is preserved, never replaced by a diagnostic
+- `constrain()` walks unions — **without this the `requirement_id` constraint
+  would have vanished silently** under the new shape, with every test still green
+- DR-202 decision 3 amended in place
 
-## What #202 delivered
+772 tests pass, ruff clean.
 
-- requirement registry from the parse; ids `task-01` / `constraint-01` / … are
-  **assigned by the code**. Interim — cross-version identity is #209.
-- `Decomposition` and `Review` carry a many-to-many `RequirementMap`. Every
-  requirement carries exactly one disposition, and the **code** marks
-  `UNDISPOSED` anything the response failed to account for. That last part is
-  load-bearing: without it a short disposition list is as well-formed as a
-  complete one and the schema change buys nothing.
-- `_user_prompt` passes typed identified fields, never `parsed.source`.
-- the mapping renders requirement-major in the CLI and the §16 report.
-- **a parse regression #202 itself introduced**: `parse_task_file` kept only the
-  first `# Task` paragraph. Free while the model got `parsed.source`; silent data
-  loss once the parse became authoritative. Fixed, plus `unread_source`.
+## Two things not to rediscover
 
-**Accepted Gate 2 residue** (recorded on #202): one true-positive coverage gap —
-`exclusion-01` claims *"the derivation is untouched"*, which is false — plus two
-obligations attributed to #213. Note this was a **third disposition** CLAUDE.md
-does not contemplate: accepting a true positive is neither "address it" nor
-"attribute it to a tracked tool defect".
+- **A pydantic tagged union cannot go on the wire.** `Field(discriminator=...)`
+  renders `oneOf` + `discriminator`; OpenAI strict mode accepts neither, and
+  `inline_schema_refs` leaves the mapping pointing at `$defs` it just inlined.
+  Plain `Union` renders `anyOf`, which works; `Literal` tags still disambiguate.
+- **"At least one" cannot be `min_length` either** — strict mode rejects
+  `minItems`. It is a required scalar field beside a list (`obligation_id` +
+  `more_obligation_ids`), so the guarantee is carried by the shape.
 
-## Read this before trusting any Gate 2 number
+## Where it stands — the 5 open findings
 
-**#214: `derive_verdict` never receives the requirement map**, so mandate
-coverage cannot move the verdict. A decomposer that drops requirements therefore
-scores *better* — dropped requirements cannot generate gaps.
+Gate 2 run 3 (`6ae97fd` → `6c06517`): INCOMPLETE, 5 obligations with
+non-discriminating test evidence. Down from 11 → 7 → 5. Nothing unaddressed, no
+`separable` change, mandate coverage correct.
 
-Demonstrated live in #202's Gate 2 run 2: **every headline number improved while
-mandate coverage fell 46/47 → 42/52**, because nine scope exclusions stopped
-producing obligations and fewer obligations means fewer things that can lack
-evidence. #190 and #195 both shipped on residues read under this blindness.
+Judgement in `dogfood-logs/217-gate2-run3/judgement.md`. In short:
 
-## Can the decomposer still drop a requirement? Yes — four ways
+- **2 are meta-obligations** — the task file asks that *a test exist*, so the
+  evidence stage is hunting for a test proving a test exists. Probably a
+  task-file authoring fix: state the behaviour, not the artifact.
+- **3 have direct, on-point tests** and still read non-discriminating. Whether
+  that is #183 (judgement) or #182 (mapping) is **not established** — check the
+  mapping transcript before assuming (DR-164).
 
-Asked and answered after #202 merged. What #202 closed is the *top-level silent*
-drop only.
+Each of the five needs a fix or a filed defect before a PR. None may be waived.
 
-1. **#216 — nested bullets and second paragraphs inside a list item vanish**, and
-   `unclaimed` is empty, so the guard prints `unaccounted for: 0`. Silence under
-   a clean bill of health, which is worse than #202's original bug. Our task
-   files happen not to nest bullets, which is why seven runs missed it.
-2. **`no_obligation` with a plausible reason** — visible as a claim, but nothing
-   is produced, and per #214 it does not touch the verdict.
-3. **Compound clause inside one bullet** — one bullet is one requirement id; half
-   a bullet can be lost with the disposition reading `yielded`.
-4. **False link (#210)** — disposed `yielded` against an obligation that does not
-   state it. Covered on paper, dropped in substance.
+Run 3's recommendation 2 is worth writing regardless: union members carrying
+*misleading* fields, which `extra="forbid"` turns into the strongest proof that
+dispatch is by literal tag alone.
 
-## Findings worth not re-deriving
+## Still open from the same root
 
-- **A lossy parse is safe exactly until it is authoritative** (DR-202). Any stage
-  that stops passing source and starts passing structure owes a report of what
-  its structure does not cover.
-- **Coverage is not quality.** #210's false links moved between runs while the
-  count held flat.
-- **Measure mapping from the persisted review, not `.acceptance/cache/`** — the
-  cache pools every run ever made and read 45% where the review read 80%.
-- **Mapping quality must be filtered to the current task's obligation ids.**
-  #189's Gate 2 read 76% unfiltered, 97% filtered; DR-164's failure was ~17%.
-- **A stable obligation count can conceal a re-split.** Compare aligned sets.
-- **Single-run readings are unreliable — three were withdrawn in one session**
-  (the `exclusion-04` "inversion"; "the reference rule fixed the declines"; "Gate
-  2 run 2 is much better"). Each was internally coherent when written. This is
-  the argument for #211 before any further decomposition work.
+**The decomposer declines scope exclusions outright** — 7 of 8 in #216's Gate 1,
+against the instruction already at `obligations.py:150`. #217 makes those
+declines visible and reasoned; it does not make them right. **Not yet filed.**
+Belongs in the #204/#205/#206 prompt batch, where the re-record is paid once.
 
-## The inference to avoid (DR-180)
+## The re-record cost was paid
 
-> *The diff was purely additive; added tests cannot weaken evidence; therefore a
-> rating that fell did so for reasons outside the diff.*
+`request_key` hashes the response schema (`llm.py:81-87`), so changing
+`_RequirementDisposition` invalidated **every** recorded decompose transcript.
+Decomposition-accuracy figures are non-comparable across this change.
 
-Both premises true, conclusion false. **Instability is not a licence to dismiss a
-finding.**
+## Known open, not this task's problem
 
-## Known open, not the next task's problem
-
-- **#153** — scope exclusions demanding evidence that cannot exist. Did **not**
-  fire in #202's Gate 2 runs 2–3, because the exclusions produced no obligations
-  to demand evidence for. The condition that suppressed it is worse than it.
-- **#191**, **#196**, **#178**, **#193** — judgement and decomposition defects.
-- **#129** — materialization flake in `materialize_archetype`, not a test flake.
-
-## Outstanding, small (carried, not started)
-
-- **`docs/DR-180` §Open is stale** — lists two settled questions. Own small PR.
-- **The instability harness has never been run live.** DR-202 names its first
-  live run: `decompose_case` over #195's cases with `RunConfig.model` varied.
-- **Semantic open-question aligner** — #195 matches by id + observed aliases.
+- **#210** — false links; fired again in #217's own Gate 1 (five exclusions
+  linked to an obligation that does not state them).
+- **#216** — nested bullets dropped silently; unstarted.
+- **#153**, **#191**, **#196**, **#178**, **#193**, **#214**, **#129**.
 
 ## Traps
 
-- **`acceptance decompose|check --mode record` writes nothing to stdout when
-  redirected**, though replay does. Record once, then re-run in replay to
-  capture. Still not filed.
-- **A `pgrep -f` pattern that matches your own waiter never exits.** Cost ~10 min.
-- **`ModelClient` is a plain class, not pydantic.** Hook is `_completion_fn`.
+- **`decompose|check --mode record` writes nothing to stdout when redirected.**
+  Record once, then re-run in replay to capture. Cost real time this session.
+- **A text search for a removed symbol flags its own explanation.** Use an AST
+  walk for "no code references X" so the docstrings recording *why* survive.
+- **Test doubles returning `requirement_dispositions: []` no longer parse.**
+  `tests/support.py::declining_dispositions` completes them from the ids the
+  call supplied, read off the outgoing schema's enum.
 - **Python here is 3.10** — no `enum.StrEnum`. Use `(str, Enum)`.
 - **The repo is `alipeles/acceptance-review`**, not the local dir name.
-- **`tee FILE | head -N` writes an empty file** — redirect first, then read.
 - **`gh api ... -f` sends strings**; sub-issue ids need `-F` for integers.
 - **Adding a sub-issue returns the PARENT**, so `-q .number` echoes the umbrella.
-- **pytest may import a test module under a different name** — patch `globals()`.
-- **Project `Order` IS readable** as the `order` key in `item-list --format json`;
-  writing it needs `item-edit --field-id PVTF_lAHOAYe6HM4Bd8dTzhYaetU
-  --project-id PVT_kwHOAYe6HM4Bd8dT --number <n>`.
 
 ## What to ignore
 

--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -40,7 +40,7 @@ from acceptance.report import render_report
 from acceptance.rerun import find_prior_review
 from acceptance.requirement.obligations import Decomposition, Obligation, decompose
 from acceptance.requirement.task_file import parse_task_file
-from acceptance.review_state import ChangeSet, Disposition, OpenQuestion, Review
+from acceptance.review_state import ChangeSet, OpenQuestion, Review
 from acceptance.review_store import ReviewStore
 
 
@@ -286,26 +286,26 @@ def _summary(requirement_map, total: int) -> str:
     defect back behind a number that looks the same either way — a smaller
     version of the flat list's own problem.
 
-    `unaccounted` is printed even when zero, because zero is the assurance a
-    reader wants and an absent line does not give it.
+    There is no "unaccounted for" count. It used to be printed even when zero,
+    as the assurance a reader wants — but the assurance is now structural: a
+    response that leaves a requirement unaccounted for does not parse, so a
+    rendered map cannot contain one (M1.2.r2). A line reporting zero every time
+    is noise that reads as a check being performed.
     """
-    declined = questioned = unaccounted = 0
+    declined = questioned = 0
     for entry in requirement_map.dispositions:
         if entry.obligation_ids:
             continue
-        if entry.disposition is Disposition.UNDISPOSED:
-            unaccounted += 1
-        elif entry.open_question_ids:
+        if entry.open_question_ids:
             questioned += 1
         else:
             declined += 1
 
-    parts = [f"Requirements: {total}", f"with obligations: {total - declined - questioned - unaccounted}"]
+    parts = [f"Requirements: {total}", f"with obligations: {total - declined - questioned}"]
     if questioned:
         parts.append(f"raised a question: {questioned}")
     if declined:
         parts.append(f"deliberately none: {declined}")
-    parts.append(f"UNACCOUNTED FOR: {unaccounted}" if unaccounted else "unaccounted for: 0")
     return "   ".join(parts)
 
 
@@ -344,12 +344,9 @@ def _requirement_block(
         lines.extend(_wrap(text, indent="       ", hang="       "))
 
     if not entry.obligation_ids and not entry.open_question_ids:
-        # Shouted only for the failure. A deliberate decline is a correct
-        # outcome and reads as one; an unaccounted requirement is the defect.
-        if entry.disposition is Disposition.UNDISPOSED:
-            lines.append("    !! UNACCOUNTED FOR — the decomposer did not address this")
-        else:
-            lines.append("    -- no obligation, deliberately")
+        # A deliberate decline is a correct outcome and reads as one. The
+        # failure case it used to be distinguished from no longer reaches here.
+        lines.append("    -- no obligation, deliberately")
         if entry.reason:
             lines.extend(_wrap(entry.reason, indent="       ", hang="       "))
 

--- a/src/acceptance/report.py
+++ b/src/acceptance/report.py
@@ -207,9 +207,13 @@ def _mandate_coverage_block(requirement_map: RequirementMap) -> list[str]:
     yielded no obligation used simply not to appear anywhere in the review, so a
     breakdown covering 20 of 29 requirements read exactly like one covering all
     29 — the reader was told nothing was missing because nothing was there to
-    say it. Rendering the empty case is the whole point: an `undisposed`
-    requirement is a claim about the REVIEW, not about the code, and it belongs
-    in front of the person who can act on it.
+    say it. Rendering the empty case is the whole point: a requirement that
+    produced nothing is a claim about the REVIEW, not about the code, and it
+    belongs in front of the person who can act on it.
+
+    Every entry here is now a decision the decomposer *made* — declined with a
+    reason, or turned into an open question. A requirement it simply failed to
+    address cannot appear, because that response no longer parses (M1.2.r2).
     """
     total = len(requirement_map.requirements)
     if not total:

--- a/src/acceptance/requirement/obligations.py
+++ b/src/acceptance/requirement/obligations.py
@@ -13,11 +13,17 @@ obligations — uncertainty is a first-class, expected result (M1.3).
 
 **What decomposition returns is a mapping, not a list** (M1.2.r1, DR-202). The
 call is asked for one disposition per identified requirement, so a requirement
-that produced nothing is a recorded fact rather than an absence; the code then
-marks as `UNDISPOSED` every requirement the response failed to mention. A flat
+that produced nothing is a recorded fact rather than an absence. A flat
 obligation list made a response covering 20 of 29 requirements exactly as
 well-formed as one covering all 29, which is how #195's Gate 1 lost 4 of 15
 Completion expectations and 5 of 8 Scope exclusions without the review saying so.
+
+**A response that does not account for the mandate is rejected, not recorded**
+(M1.2.r2). Each disposition is one of three shapes, each structurally carrying
+what its name claims, and reconciliation raises on anything else: a missing
+requirement, a duplicate, an id outside the registry, or a claim naming outputs
+the response never produced. `M1.2.r1` recorded those as a fourth disposition
+instead, which let a malformed response reach a verdict as a soft finding.
 
 **The decomposer is code-blind** (DR-202 decision 8): it takes a parsed task
 file and a client, and never a `ChangeSet`, a repository path or a head
@@ -28,9 +34,11 @@ destroys the one thing the review exists to detect. Pinned by a test.
 
 from __future__ import annotations
 
+from typing import Literal, Union
+
 from pydantic import Field
 
-from acceptance.llm import ModelClient, StrictResponseModel
+from acceptance.llm import ModelClient, SchemaValidationError, StrictResponseModel
 from acceptance.model_base import PersistableModel
 from acceptance.requirement.registry import build_registry
 from acceptance.requirement.task_file import ParsedTaskFile
@@ -173,12 +181,50 @@ class _OpenQuestion(StrictResponseModel):
     source_quote: str
 
 
-class _RequirementDisposition(StrictResponseModel):
+class _Yielded(StrictResponseModel):
+    """Obligations were derived. At least one, structurally."""
+
     requirement_id: str
-    disposition: str
-    obligation_ids: list[str]
-    open_question_ids: list[str]
+    disposition: Literal["yielded"]
+    # Split rather than `list[str]` with a minimum, because a minimum cannot be
+    # expressed on the wire: OpenAI strict mode rejects `minItems`. One required
+    # field plus the rest makes "at least one" a property of the SHAPE, so the
+    # empty case is unrepresentable in the schema the model is given rather than
+    # merely rejected after it answers.
+    obligation_id: str
+    more_obligation_ids: list[str]
+
+    def ids(self) -> list[str]:
+        return [self.obligation_id, *self.more_obligation_ids]
+
+
+class _NoObligation(StrictResponseModel):
+    """Deliberately yields none. The reason is the disposition's whole content,
+    so the shape has nowhere to put obligations."""
+
+    requirement_id: str
+    disposition: Literal["no_obligation"]
     reason: str
+
+
+class _RaisedOpenQuestion(StrictResponseModel):
+    """An open question prevents answering. At least one, structurally."""
+
+    requirement_id: str
+    disposition: Literal["open_question"]
+    open_question_id: str
+    more_open_question_ids: list[str]
+
+    def ids(self) -> list[str]:
+        return [self.open_question_id, *self.more_open_question_ids]
+
+
+# A plain `Union`, deliberately not `Field(discriminator=...)`: pydantic renders
+# a tagged union as `oneOf` + `discriminator`, and strict mode accepts neither,
+# while `inline_schema_refs` would leave the discriminator mapping pointing at
+# `$defs` it had just inlined. A plain union renders `anyOf`, which strict mode
+# does accept, and the `Literal` tags still make the match unambiguous.
+_RequirementDisposition = Union[_Yielded, _NoObligation, _RaisedOpenQuestion]
 
 
 class _Decomposition(StrictResponseModel):
@@ -311,69 +357,89 @@ def _requirement_map(
 ) -> RequirementMap:
     """Reconcile the returned dispositions against the registry.
 
-    Two things happen here, and the second is the point of the whole change:
+    The registry is derived deterministically from the parse and this loop walks
+    it, so **dropping a requirement is not a reachable outcome** — the worst a
+    model can do is answer badly. That is why there is no fourth disposition
+    here. `M1.2.r1` added one, `UNDISPOSED`, for a requirement the response
+    failed to account for, and it turned two kinds of malformed response into a
+    soft finding that flowed on to a verdict. A response that does not account
+    for the mandate is not a review with a gap in it; it is not a review.
 
-    1. Ids the response invented are dropped, since a disposition can only name
-       outputs the same response actually produced.
-    2. **Every registry requirement the response did not account for — or
-       accounted for with nothing usable — is recorded as `UNDISPOSED`.** The
-       registry is the work list, so absence from the response is a fact about
-       the response rather than a fact about the task file. Without this step the
-       schema change buys nothing: a short disposition list would be as
-       well-formed as a complete one, which is the defect one level up.
+    So every disagreement between the registry and the response raises. What
+    survives is a map in which every requirement carries one of decision 3's
+    three dispositions, each holding what its name claims.
     """
-    by_requirement = {entry.requirement_id: entry for entry in returned}
+    by_requirement: dict[str, _RequirementDisposition] = {}
+    for entry in returned:
+        if entry.requirement_id in by_requirement:
+            raise SchemaValidationError(
+                f"requirement '{entry.requirement_id}' was disposed more than once"
+            )
+        by_requirement[entry.requirement_id] = entry
+
+    known = {requirement.id for requirement in registry}
+    unknown = sorted(set(by_requirement) - known)
+    if unknown:
+        raise SchemaValidationError(
+            f"response disposed requirement ids not in the registry: {', '.join(unknown)}"
+        )
+    missing = [requirement.id for requirement in registry if requirement.id not in by_requirement]
+    if missing:
+        raise SchemaValidationError(
+            f"response did not account for {len(missing)} of {len(registry)} "
+            f"requirements: {', '.join(missing)}"
+        )
+
     dispositions: list[RequirementDisposition] = []
-
     for requirement in registry:
-        entry = by_requirement.get(requirement.id)
-        if entry is None:
-            dispositions.append(_undisposed(requirement.id, "not accounted for in the response"))
-            continue
+        entry = by_requirement[requirement.id]
 
-        obligation_ids = _resolve(entry.obligation_ids, obligation_final)
-        open_question_ids = _resolve(entry.open_question_ids, question_final)
-        reason = entry.reason.strip() or None
-
-        if obligation_ids:
-            disposition = Disposition.YIELDED
-        elif open_question_ids:
-            disposition = Disposition.OPEN_QUESTION
-        elif entry.disposition == Disposition.NO_OBLIGATION.value and reason:
-            disposition = Disposition.NO_OBLIGATION
-        else:
-            # Claimed something it did not deliver: `yielded` naming no
-            # surviving obligation, or `no_obligation` with no reason. The claim
-            # is not honoured, because honouring it would let a requirement be
-            # marked handled while nothing was said about it.
+        if isinstance(entry, _NoObligation):
             dispositions.append(
-                _undisposed(
-                    requirement.id,
-                    f"disposition '{entry.disposition}' named no usable output",
+                RequirementDisposition(
+                    requirement_id=requirement.id,
+                    disposition=Disposition.NO_OBLIGATION,
+                    reason=entry.reason,
                 )
             )
             continue
 
+        # Ids the response invented are still dropped — a disposition may only
+        # name outputs the same response produced. But dropping them all is not
+        # a survivable state: it leaves a claim that obligations exist with none
+        # to point at, which is the contradiction this change exists to remove.
+        if isinstance(entry, _Yielded):
+            obligation_ids = _resolve(entry.ids(), obligation_final)
+            if not obligation_ids:
+                raise SchemaValidationError(
+                    f"requirement '{requirement.id}' was disposed 'yielded' naming "
+                    f"{len(entry.ids())} obligation id(s), none of which the response produced"
+                )
+            dispositions.append(
+                RequirementDisposition(
+                    requirement_id=requirement.id,
+                    disposition=Disposition.YIELDED,
+                    obligation_ids=obligation_ids,
+                )
+            )
+            continue
+
+        open_question_ids = _resolve(entry.ids(), question_final)
+        if not open_question_ids:
+            raise SchemaValidationError(
+                f"requirement '{requirement.id}' was disposed 'open_question' naming "
+                f"{len(entry.ids())} question id(s), none of which the response produced"
+            )
         dispositions.append(
             RequirementDisposition(
                 requirement_id=requirement.id,
-                disposition=disposition,
-                obligation_ids=obligation_ids,
+                disposition=Disposition.OPEN_QUESTION,
                 open_question_ids=open_question_ids,
-                reason=reason,
             )
         )
 
     return RequirementMap(
         requirements=registry, dispositions=dispositions, unread_source=unread
-    )
-
-
-def _undisposed(requirement_id: str, reason: str) -> RequirementDisposition:
-    return RequirementDisposition(
-        requirement_id=requirement_id,
-        disposition=Disposition.UNDISPOSED,
-        reason=reason,
     )
 
 

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -280,17 +280,18 @@ class Disposition(str, Enum):
     response covering 20 of 29 requirements was exactly as well-formed as one
     covering all 29.
 
-    `UNDISPOSED` is the fourth value and the load-bearing one: it is assigned by
-    the CODE, never returned by the model, for a requirement the response failed
-    to account for. Without it a model omission is once again invisible, and the
-    schema change would buy nothing — the same shape as DR-164's schema-valid
-    empty `obligation_ids`.
+    There are exactly three, and there is deliberately no fourth for "the
+    response did not say" (M1.2.r2). The registry is derived from the parse and
+    the reconciliation walks it, so a requirement cannot be dropped by the code;
+    a response that fails to account for one is malformed and is rejected at
+    parse rather than recorded. A fourth value would be a state no correct run
+    can produce, and its only effect was to turn a malformed response into a
+    soft finding that still reached a verdict.
     """
 
     YIELDED = "yielded"
     NO_OBLIGATION = "no_obligation"
     OPEN_QUESTION = "open_question"
-    UNDISPOSED = "undisposed"
 
 
 class RequirementDisposition(_Model):
@@ -319,10 +320,6 @@ class RequirementDisposition(_Model):
             )
         if self.disposition is Disposition.NO_OBLIGATION and not (self.reason or "").strip():
             raise ValueError("a 'no_obligation' disposition must carry a reason")
-        if self.disposition is Disposition.UNDISPOSED and (
-            self.obligation_ids or self.open_question_ids
-        ):
-            raise ValueError("an 'undisposed' requirement produced nothing by definition")
         return self
 
 
@@ -364,23 +361,17 @@ class RequirementMap(_Model):
                 return requirement
         return None
 
-    def undisposed(self) -> list[RequirementDisposition]:
-        """Requirements the decomposer failed to account for — the recall gap,
-        as a list a reader and a benchmark case can both read."""
-        return [
-            entry
-            for entry in self.dispositions
-            if entry.disposition is Disposition.UNDISPOSED
-        ]
-
     def unyielding(self) -> list[RequirementDisposition]:
         """Every requirement that produced no obligation, for whatever reason.
 
-        Broader than `undisposed()`: it also covers the requirements the
-        decomposer deliberately declined and those it turned into a question.
-        This is the set the report shows, because a reader auditing a mandate
-        cares that a requirement produced nothing before they care whose
-        decision that was.
+        Covers the requirements the decomposer deliberately declined and those
+        it turned into a question. This is the set the report shows, because a
+        reader auditing a mandate cares that a requirement produced nothing
+        before they care whose decision that was.
+
+        There is no companion listing requirements the response never accounted
+        for: since M1.2.r2 such a response does not parse, so no `RequirementMap`
+        containing one exists to query.
         """
         return [entry for entry in self.dispositions if not entry.obligation_ids]
 

--- a/src/acceptance/supplied_ids.py
+++ b/src/acceptance/supplied_ids.py
@@ -33,12 +33,16 @@ than dropped. Dropping is what made the original defect invisible.
 
 from __future__ import annotations
 
+import types
 from collections.abc import Container, Iterable, Mapping, Sequence
-from typing import Any, Literal, TypeVar, get_args, get_origin
+from typing import Any, Literal, TypeVar, Union, get_args, get_origin
 
 from pydantic import BaseModel, create_model
 
 ModelT = TypeVar("ModelT", bound=BaseModel)
+
+# `Union[A, B]` and `A | B` are distinct origins on 3.10; both reach here.
+_UNION_ORIGINS = (Union, types.UnionType)
 
 
 def _literal(ids: Sequence[str]) -> Any:
@@ -63,16 +67,27 @@ def _constrained_nested(annotation: Any, allowed: Mapping[str, Sequence[str]]) -
     The id fields live on the *item* model (`_TestMapping.obligation_ids`), not
     on the container the call returns (`_Mappings.mappings`), so the walk has to
     descend rather than look only at top-level fields.
+
+    A union is walked member by member. Without that, a response model whose
+    item type is a union of per-disposition shapes (`obligations.py`) would
+    quietly lose its id constraint: the walk would find no `BaseModel` to
+    descend into, return None, and the guarantee would vanish with nothing
+    failing — the shape of defect this walk exists to prevent.
     """
     if isinstance(annotation, type) and issubclass(annotation, BaseModel):
         nested = constrain(annotation, allowed)
         return None if nested is annotation else nested
+    if get_origin(annotation) in _UNION_ORIGINS:
+        members = get_args(annotation)
+        rebuilt = [_constrained_nested(member, allowed) or member for member in members]
+        if all(new is old for new, old in zip(rebuilt, members)):
+            return None
+        return Union[tuple(rebuilt)]
     if get_origin(annotation) is list:
         args = get_args(annotation)
         item = args[0] if args else None
-        if isinstance(item, type) and issubclass(item, BaseModel):
-            nested = constrain(item, allowed)
-            return None if nested is item else list[nested]  # type: ignore[valid-type]
+        nested = _constrained_nested(item, allowed) if item is not None else None
+        return None if nested is None else list[nested]  # type: ignore[valid-type]
     return None
 
 

--- a/tests/benchmark/degenerate_decomposers.py
+++ b/tests/benchmark/degenerate_decomposers.py
@@ -35,7 +35,7 @@ from typing import Any
 from acceptance.benchmark.case import GroundTruthLabels
 from acceptance.config import DEFAULT_MODEL
 from acceptance.llm import Mode, ModelClient, TranscriptStore
-from tests.support import _EMPTY_BY_SCHEMA, _fake_response
+from tests.support import _EMPTY_BY_SCHEMA, _fake_response, declining_dispositions
 
 # Obligations the permissive decomposer adds on top of a faithful set, standing
 # in for "splits every sentence into its own obligation". They align to nothing
@@ -80,13 +80,8 @@ def _faithful(labels: GroundTruthLabels) -> dict[str, Any]:
             for q in labels.open_questions
             if q.should_be_raised
         ],
-        # Empty, and deliberately so. These doubles are seeded from a case's
-        # LABELS, which name obligations and questions but no requirement ids —
-        # those come from the parse, which a double bypasses. What #195 scores is
-        # the obligation and open-question content, and that is unaffected: a
-        # missing disposition makes every requirement `undisposed`, which the
-        # scoring path does not read. Scoring the mapping itself is the
-        # superseding issue DR-202 sequences after this change.
+        # Filled in by `decomposer`'s completion_fn, which can see the
+        # requirement ids the call supplied; a label-seeded builder cannot.
         "requirement_dispositions": [],
     }
 
@@ -143,7 +138,19 @@ def decomposer(labels: GroundTruthLabels, *, behaviour: str) -> ModelClient:
         spec = kwargs["response_format"]["json_schema"]
         name = spec["name"]
         if name == "_Decomposition":
-            return _fake_response(json.dumps(build(labels)))
+            response = build(labels)
+            # Seeded from a case's LABELS, which name obligations and questions
+            # but no requirement ids — those come from the parse a double
+            # bypasses. Every requirement is therefore declined, which leaves
+            # the obligation and open-question content these cases score
+            # untouched while keeping the response well-formed. Since M1.2.r2 a
+            # response disposing nothing does not parse, so the empty list these
+            # doubles used to send is no longer a neutral choice.
+            response = {**response, "requirement_dispositions": declining_dispositions(
+                reason="seeded from ground-truth labels, which carry no requirement ids",
+                **kwargs,
+            )}
+            return _fake_response(json.dumps(response))
         return _fake_response(json.dumps(_EMPTY_BY_SCHEMA[name]))
 
     return ModelClient(

--- a/tests/benchmark/degenerate_judges.py
+++ b/tests/benchmark/degenerate_judges.py
@@ -37,7 +37,7 @@ from typing import Any
 
 from acceptance.config import DEFAULT_MODEL
 from acceptance.llm import Mode, ModelClient, TranscriptStore
-from tests.support import _EMPTY_BY_SCHEMA, _fake_response
+from tests.support import _EMPTY_BY_SCHEMA, _fake_response, declining_dispositions
 
 import tempfile
 
@@ -80,6 +80,7 @@ def _decomposition(obligations: list[dict]) -> dict:
             for o in obligations
         ],
         "open_questions": [],
+        # Filled in by the caller, which can see the supplied requirement ids.
         "requirement_dispositions": [],
     }
 
@@ -97,7 +98,17 @@ def degenerate_client(obligations: list[dict], *, always_strong: bool) -> ModelC
         name, schema = spec["name"], spec["schema"]
 
         if name == "_Decomposition":
-            return _fake_response(json.dumps(_decomposition(obligations)))
+            # Declined rather than empty: what this suite steers is the evidence
+            # judgement, and the obligations reach it regardless of how the
+            # requirements were disposed. An empty disposition list no longer
+            # parses (M1.2.r2).
+            return _fake_response(json.dumps({
+                **_decomposition(obligations),
+                "requirement_dispositions": declining_dispositions(
+                    reason="seeded obligations; this suite does not exercise the mapping",
+                    **kwargs,
+                ),
+            }))
 
         if name == "_Mappings":
             # Map every test to every obligation the call allows. A permissive

--- a/tests/requirement/test_requirement_map.py
+++ b/tests/requirement/test_requirement_map.py
@@ -283,6 +283,77 @@ def test_the_schema_cannot_express_a_yielded_disposition_with_no_obligations():
     assert "discriminator" not in schema["properties"]["requirement_dispositions"]["items"]
 
 
+def test_the_literal_tag_alone_decides_which_shape_a_disposition_is():
+    """The union is plain, so the `disposition` literal is the only thing that
+    picks a member. Two entries sharing every other field must still land on
+    different shapes, or a `no_obligation` could be read as a `yielded` whose
+    ids happened to be absent — the contradiction rebuilt inside the parser.
+    """
+    parsed = _Decomposition.model_validate(
+        {
+            "obligations": [],
+            "open_questions": [],
+            "requirement_dispositions": [
+                {
+                    "requirement_id": "task-01",
+                    "disposition": "yielded",
+                    "obligation_id": "ob-1",
+                    "more_obligation_ids": [],
+                },
+                {
+                    "requirement_id": "constraint-01",
+                    "disposition": "no_obligation",
+                    "reason": "Declined.",
+                },
+            ],
+        }
+    )
+
+    first, second = parsed.requirement_dispositions
+    assert type(first).__name__ != type(second).__name__
+    assert first.ids() == ["ob-1"]
+    assert second.reason == "Declined."
+
+    # An unknown tag matches no member at all, rather than falling back to one.
+    with pytest.raises(ValidationError):
+        _Decomposition.model_validate(
+            {
+                "obligations": [],
+                "open_questions": [],
+                "requirement_dispositions": [
+                    {"requirement_id": "task-01", "disposition": "undisposed", "reason": "x"}
+                ],
+            }
+        )
+
+
+def test_the_schema_cannot_express_an_open_question_disposition_with_no_questions():
+    """The twin of the yielded case, at the schema boundary rather than at
+    reconciliation: `open_question_id` is required, so the empty payload has no
+    encoding to send."""
+    with pytest.raises(ValidationError):
+        _Decomposition.model_validate(
+            {
+                "obligations": [],
+                "open_questions": [],
+                "requirement_dispositions": [
+                    {
+                        "requirement_id": "task-01",
+                        "disposition": "open_question",
+                        "more_open_question_ids": [],
+                    }
+                ],
+            }
+        )
+
+    schema = inline_schema_refs(_Decomposition.model_json_schema())
+    members = schema["properties"]["requirement_dispositions"]["items"]["anyOf"]
+    questioned = next(
+        member for member in members if "open_question_id" in member.get("properties", {})
+    )
+    assert "open_question_id" in questioned["required"]
+
+
 def test_a_no_obligation_disposition_with_an_empty_reason_is_rejected():
     """`no_obligation` carries nothing BUT the reason, so an empty one is a
     requirement declined without saying why — the state whose reason M1.2.r1

--- a/tests/requirement/test_requirement_map.py
+++ b/tests/requirement/test_requirement_map.py
@@ -17,7 +17,9 @@ invariant — no live calls.
 
 from __future__ import annotations
 
+import ast
 import inspect
+from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
@@ -302,6 +304,108 @@ def test_a_no_obligation_disposition_with_an_empty_reason_is_rejected():
 
     with pytest.raises((SchemaValidationError, ValidationError, ValueError)):
         decompose(parsed, _client_returning(response))
+
+
+def test_the_disposition_set_is_exactly_the_three_of_decision_3():
+    """No fourth value, and no path that could assign one.
+
+    Asserted on the enum rather than on behaviour because that is the whole
+    claim: `UNDISPOSED` encoded a state no correct run produces, and leaving the
+    value in place while removing its call sites would invite it back.
+    """
+    assert [d.value for d in Disposition] == ["yielded", "no_obligation", "open_question"]
+    assert not hasattr(Disposition, "UNDISPOSED")
+
+    # Executable references only. The docstrings that explain why the value is
+    # gone are the record of a decision that cost a Gate 1 run to find, and a
+    # text search would forbid exactly the prose worth keeping.
+    source = Path(inspect.getfile(decompose)).parent.parent
+    offenders: list[str] = []
+    for path in source.rglob("*.py"):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            named = (
+                isinstance(node, ast.Attribute) and node.attr == "UNDISPOSED"
+            ) or (isinstance(node, ast.Name) and node.id == "UNDISPOSED")
+            if named:
+                offenders.append(f"{path.relative_to(source).as_posix()}:{node.lineno}")
+    assert offenders == [], f"the removed disposition is still referenced at {offenders}"
+
+
+def test_an_open_question_disposition_naming_no_real_question_is_rejected():
+    """The `yielded` hole has a twin on the open-question side, and closing one
+    without the other leaves the same contradiction reachable by another name."""
+    parsed = parse_task_file(TASK)
+    response = {
+        "obligations": [
+            _obligation("render-lines", "Render each invoice line.", "Render each invoice line."),
+        ],
+        "open_questions": [],
+        "requirement_dispositions": [
+            _disposition("task-01", "yielded", obligation_ids=["render-lines"]),
+            _disposition("constraint-01", "open_question", open_question_ids=["never-asked"]),
+            _disposition("constraint-02", "no_obligation", reason="Not applicable."),
+            _disposition("exclusion-01", "no_obligation", reason="Not applicable."),
+            _disposition("completion-01", "no_obligation", reason="Not applicable."),
+        ],
+    }
+
+    with pytest.raises(SchemaValidationError) as raised:
+        decompose(parsed, _client_returning(response))
+
+    assert "constraint-01" in str(raised.value)
+
+
+def test_a_response_naming_a_requirement_outside_the_registry_is_rejected():
+    """Constrained decoding makes a foreign id unrepresentable, but the
+    guarantee degrades when a provider ignores the constraint (#163), so the
+    local check has to exist and has to raise rather than drop."""
+    parsed = parse_task_file(TASK)
+    response = {
+        "obligations": [
+            _obligation("render-lines", "Render each invoice line.", "Render each invoice line."),
+        ],
+        "open_questions": [],
+        "requirement_dispositions": [
+            _disposition("task-01", "yielded", obligation_ids=["render-lines"]),
+            _disposition("constraint-01", "no_obligation", reason="Not applicable."),
+            _disposition("constraint-02", "no_obligation", reason="Not applicable."),
+            _disposition("exclusion-01", "no_obligation", reason="Not applicable."),
+            _disposition("completion-01", "no_obligation", reason="Not applicable."),
+            _disposition("constraint-99", "no_obligation", reason="No such requirement."),
+        ],
+    }
+
+    with pytest.raises(SchemaValidationError) as raised:
+        decompose(parsed, _client_returning(response))
+
+    assert "constraint-99" in str(raised.value)
+
+
+def test_a_requirement_disposed_twice_is_rejected():
+    """Two dispositions for one requirement is a response contradicting itself,
+    and picking either one silently would be the reader's problem, not the
+    model's."""
+    parsed = parse_task_file(TASK)
+    response = {
+        "obligations": [
+            _obligation("render-lines", "Render each invoice line.", "Render each invoice line."),
+        ],
+        "open_questions": [],
+        "requirement_dispositions": [
+            _disposition("task-01", "yielded", obligation_ids=["render-lines"]),
+            _disposition("task-01", "no_obligation", reason="Also declined."),
+            _disposition("constraint-01", "no_obligation", reason="Not applicable."),
+            _disposition("constraint-02", "no_obligation", reason="Not applicable."),
+            _disposition("exclusion-01", "no_obligation", reason="Not applicable."),
+            _disposition("completion-01", "no_obligation", reason="Not applicable."),
+        ],
+    }
+
+    with pytest.raises(SchemaValidationError) as raised:
+        decompose(parsed, _client_returning(response))
+
+    assert "more than once" in str(raised.value)
 
 
 def test_a_supplied_reason_is_preserved_rather_than_replaced():

--- a/tests/requirement/test_requirement_map.py
+++ b/tests/requirement/test_requirement_map.py
@@ -19,7 +19,11 @@ from __future__ import annotations
 
 import inspect
 
-from acceptance.requirement.obligations import _user_prompt, decompose
+import pytest
+from pydantic import ValidationError
+
+from acceptance.llm import SchemaValidationError, inline_schema_refs
+from acceptance.requirement.obligations import _Decomposition, _user_prompt, decompose
 from acceptance.requirement.registry import build_registry
 from acceptance.requirement.task_file import parse_task_file
 from acceptance.review_state import Disposition, RequirementSection
@@ -56,12 +60,32 @@ def _obligation(oid: str, description: str, quote: str) -> dict:
 
 
 def _disposition(rid: str, disposition: str, **kwargs) -> dict:
+    """Build one disposition in the shape the response schema now defines.
+
+    Each shape carries only its own payload (M1.2.r2), so this cannot express a
+    `yielded` disposition with no obligations — which is the point, and why the
+    tests that used to construct that case now assert on the raw dict instead.
+    """
+    if disposition == "yielded":
+        ids = kwargs["obligation_ids"]
+        return {
+            "requirement_id": rid,
+            "disposition": "yielded",
+            "obligation_id": ids[0],
+            "more_obligation_ids": list(ids[1:]),
+        }
+    if disposition == "open_question":
+        ids = kwargs["open_question_ids"]
+        return {
+            "requirement_id": rid,
+            "disposition": "open_question",
+            "open_question_id": ids[0],
+            "more_open_question_ids": list(ids[1:]),
+        }
     return {
         "requirement_id": rid,
-        "disposition": disposition,
-        "obligation_ids": kwargs.get("obligation_ids", []),
-        "open_question_ids": kwargs.get("open_question_ids", []),
-        "reason": kwargs.get("reason", ""),
+        "disposition": "no_obligation",
+        "reason": kwargs["reason"],
     }
 
 
@@ -103,7 +127,7 @@ def test_each_registry_entry_carries_the_span_of_its_requirement():
 # --- the mapping ------------------------------------------------------------
 
 
-def test_a_fully_accounted_response_leaves_no_requirement_undisposed():
+def test_a_fully_accounted_response_disposes_every_requirement():
     parsed = parse_task_file(TASK)
     response = {
         "obligations": [
@@ -124,14 +148,27 @@ def test_a_fully_accounted_response_leaves_no_requirement_undisposed():
 
     result = decompose(parsed, _client_returning(response))
 
-    assert result.requirement_map.undisposed() == []
+    assert [entry.requirement_id for entry in result.requirement_map.dispositions] == [
+        "task-01",
+        "constraint-01",
+        "constraint-02",
+        "exclusion-01",
+        "completion-01",
+    ]
     assert result.requirement_map.unyielding() == []
 
 
-def test_a_requirement_the_response_never_mentions_is_recorded_as_undisposed():
-    """The load-bearing case. The response is well-formed and internally
-    consistent; it simply says nothing about two of the five requirements, which
-    is precisely what the old flat list could not express."""
+def test_a_response_that_never_mentions_a_requirement_is_rejected():
+    """The load-bearing case, and the one M1.2.r1 got wrong. The response is
+    well-formed and internally consistent; it simply says nothing about two of
+    the five requirements.
+
+    M1.2.r1 recorded those two as a fourth disposition and carried on to a
+    verdict. They are not a gap in the review — they mean there is no review,
+    because the mandate was never read. The registry is derived from the parse
+    and the reconciliation walks it, so the code cannot drop a requirement; only
+    a malformed response can, and a malformed response is refused.
+    """
     parsed = parse_task_file(TASK)
     response = {
         "obligations": [
@@ -146,12 +183,12 @@ def test_a_requirement_the_response_never_mentions_is_recorded_as_undisposed():
         ],
     }
 
-    result = decompose(parsed, _client_returning(response))
+    with pytest.raises(SchemaValidationError) as raised:
+        decompose(parsed, _client_returning(response))
 
-    undisposed = [entry.requirement_id for entry in result.requirement_map.undisposed()]
-    assert undisposed == ["constraint-02", "exclusion-01"]
-    for entry in result.requirement_map.undisposed():
-        assert entry.reason, "an undisposed requirement must say why it is undisposed"
+    message = str(raised.value)
+    assert "constraint-02" in message and "exclusion-01" in message
+    assert "2 of 5" in message
 
 
 def test_a_requirement_deliberately_yielding_nothing_carries_its_reason():
@@ -175,14 +212,18 @@ def test_a_requirement_deliberately_yielding_nothing_carries_its_reason():
     declined = result.requirement_map.disposition_for("constraint-01")
     assert declined.disposition is Disposition.NO_OBLIGATION
     assert declined.reason == "A section marker, not a requirement."
-    # Declined is not the same as unread, and the two must stay distinguishable.
-    assert result.requirement_map.undisposed() == []
     assert len(result.requirement_map.unyielding()) == 4
 
 
-def test_a_yielded_claim_naming_no_real_obligation_is_not_honoured():
+def test_a_yielded_claim_naming_no_real_obligation_is_rejected():
     """A disposition may not launder a requirement into 'handled' by naming an
-    obligation the same response never produced."""
+    obligation the same response never produced.
+
+    The shape guarantees at least one id is NAMED; it cannot guarantee the id
+    refers to something. So the one hole the schema leaves — every named id
+    dropped as invented — closes here, and closes by raising rather than by
+    recording a requirement as unaddressed.
+    """
     parsed = parse_task_file(TASK)
     response = {
         "obligations": [
@@ -192,16 +233,100 @@ def test_a_yielded_claim_naming_no_real_obligation_is_not_honoured():
         "requirement_dispositions": [
             _disposition("task-01", "yielded", obligation_ids=["render-lines"]),
             _disposition("constraint-01", "yielded", obligation_ids=["never-emitted"]),
-            _disposition("constraint-02", "yielded", obligation_ids=[]),
-            _disposition("exclusion-01", "no_obligation", reason=""),
-            _disposition("completion-01", "yielded", obligation_ids=["never-emitted"]),
+            _disposition("constraint-02", "no_obligation", reason="Not applicable."),
+            _disposition("exclusion-01", "no_obligation", reason="Not applicable."),
+            _disposition("completion-01", "no_obligation", reason="Not applicable."),
+        ],
+    }
+
+    with pytest.raises(SchemaValidationError) as raised:
+        decompose(parsed, _client_returning(response))
+
+    assert "constraint-01" in str(raised.value)
+
+
+def test_the_schema_cannot_express_a_yielded_disposition_with_no_obligations():
+    """The guarantee is structural, not a validation rule applied afterwards.
+
+    `yielded` requires `obligation_id`, so the empty case has no encoding — in
+    the schema sent to the model as much as in the parse. A minimum on a list
+    would not do: OpenAI strict mode rejects `minItems`, so it would either be
+    stripped from the wire schema or make the call fail.
+    """
+    with pytest.raises(ValidationError):
+        _Decomposition.model_validate(
+            {
+                "obligations": [],
+                "open_questions": [],
+                "requirement_dispositions": [
+                    {
+                        "requirement_id": "task-01",
+                        "disposition": "yielded",
+                        "more_obligation_ids": [],
+                    }
+                ],
+            }
+        )
+
+    # The schema as it actually goes out, refs inlined the way `complete` sends
+    # it — the wire form is what constrains the model, not the pydantic form.
+    schema = inline_schema_refs(_Decomposition.model_json_schema())
+    members = schema["properties"]["requirement_dispositions"]["items"]["anyOf"]
+    yielded = next(
+        member for member in members if "obligation_id" in member.get("properties", {})
+    )
+    assert "obligation_id" in yielded["required"]
+    # Strict mode rejects both, and a tagged union would emit them.
+    assert "oneOf" not in schema["properties"]["requirement_dispositions"]["items"]
+    assert "discriminator" not in schema["properties"]["requirement_dispositions"]["items"]
+
+
+def test_a_no_obligation_disposition_with_an_empty_reason_is_rejected():
+    """`no_obligation` carries nothing BUT the reason, so an empty one is a
+    requirement declined without saying why — the state whose reason M1.2.r1
+    discarded and replaced with a diagnostic of its own."""
+    parsed = parse_task_file(TASK)
+    response = {
+        "obligations": [
+            _obligation("render-lines", "Render each invoice line.", "Render each invoice line."),
+        ],
+        "open_questions": [],
+        "requirement_dispositions": [
+            _disposition("task-01", "yielded", obligation_ids=["render-lines"]),
+            _disposition("constraint-01", "no_obligation", reason=""),
+            _disposition("constraint-02", "no_obligation", reason="Not applicable."),
+            _disposition("exclusion-01", "no_obligation", reason="Not applicable."),
+            _disposition("completion-01", "no_obligation", reason="Not applicable."),
+        ],
+    }
+
+    with pytest.raises((SchemaValidationError, ValidationError, ValueError)):
+        decompose(parsed, _client_returning(response))
+
+
+def test_a_supplied_reason_is_preserved_rather_than_replaced():
+    """M1.2.r1 discarded the model's reason whenever it disagreed with the
+    label, substituting a diagnostic string — so eight reasoned declines in
+    #216's Gate 1 were reported as requirements nothing had been said about."""
+    parsed = parse_task_file(TASK)
+    reason = "A scope exclusion pointing at a separate issue; it adds no checkable behavior."
+    response = {
+        "obligations": [
+            _obligation("render-lines", "Render each invoice line.", "Render each invoice line."),
+        ],
+        "open_questions": [],
+        "requirement_dispositions": [
+            _disposition("task-01", "yielded", obligation_ids=["render-lines"]),
+            _disposition("constraint-01", "no_obligation", reason="Not applicable."),
+            _disposition("constraint-02", "no_obligation", reason="Not applicable."),
+            _disposition("exclusion-01", "no_obligation", reason=reason),
+            _disposition("completion-01", "no_obligation", reason="Not applicable."),
         ],
     }
 
     result = decompose(parsed, _client_returning(response))
 
-    undisposed = [entry.requirement_id for entry in result.requirement_map.undisposed()]
-    assert undisposed == ["constraint-01", "constraint-02", "exclusion-01", "completion-01"]
+    assert result.requirement_map.disposition_for("exclusion-01").reason == reason
 
 
 def test_one_obligation_serves_two_requirements_rather_than_being_duplicated():
@@ -263,7 +388,6 @@ def test_a_disposition_naming_a_renamed_obligation_still_links():
 
     assert [o.id for o in result.obligations] == ["dup", "dup-2"]
     assert result.requirement_map.disposition_for("task-01").obligation_ids == ["dup"]
-    assert result.requirement_map.undisposed() == []
 
 
 # --- the decomposer stays code-blind (DR-202 decision 8) --------------------
@@ -334,10 +458,7 @@ def test_the_cli_lists_every_requirement_including_the_ones_yielding_nothing():
         assert requirement_id in output, f"{requirement_id} is missing from the rendered mapping"
     assert "no obligation, deliberately" in output
     assert "Covered by the CSV suite." in output
-    # A deliberate decline is a correct outcome; only an unaccounted requirement
-    # is a failure, and the header must not merge the two into one number.
     assert "deliberately none: 1" in output
-    assert "unaccounted for: 0" in output
 
 
 def test_the_cli_says_when_an_obligation_serves_other_requirements():
@@ -364,9 +485,19 @@ def test_an_obligation_no_requirement_claims_is_still_shown():
     response = {
         "obligations": [
             _obligation("orphan", "An obligation no requirement claims.", "Render each invoice line."),
+            _obligation("render-lines", "Render each invoice line.", "Render each invoice line."),
         ],
         "open_questions": [],
-        "requirement_dispositions": [],
+        # Every requirement is accounted for, and one obligation is still
+        # claimed by none of them — the response must be complete for the
+        # orphan to be the only thing under test.
+        "requirement_dispositions": [
+            _disposition("task-01", "yielded", obligation_ids=["render-lines"]),
+            _disposition("constraint-01", "no_obligation", reason="Not applicable."),
+            _disposition("constraint-02", "no_obligation", reason="Not applicable."),
+            _disposition("exclusion-01", "no_obligation", reason="Not applicable."),
+            _disposition("completion-01", "no_obligation", reason="Not applicable."),
+        ],
     }
 
     output = render_decomposition(decompose(parsed, _client_returning(response)))
@@ -375,35 +506,23 @@ def test_an_obligation_no_requirement_claims_is_still_shown():
     assert "orphan" in output
 
 
-def test_the_header_separates_a_deliberate_decline_from_an_unaccounted_requirement():
-    """One "yielding none" figure reads as a defect count, and only one of its
-    three components is one. A bare section marker declined with a reason is a
-    correct outcome; a requirement the decomposer never addressed is the recall
-    failure the stage exists to surface. Merging them puts the defect back behind
-    a number that looks the same either way."""
+def test_the_header_counts_declines_without_claiming_a_check_it_no_longer_makes():
+    """M1.2.r1's header carried `unaccounted for: N`, printed even at zero
+    because zero was the assurance a reader wanted.
+
+    The assurance is now structural — a response leaving a requirement
+    unaccounted for does not parse — so the line would report a constant. A
+    permanent zero reads as a check being performed and passing, which is
+    exactly the false comfort #216 recorded when the guard printed it over
+    three lost requirements.
+    """
     from acceptance.cli import render_decomposition
 
-    parsed = parse_task_file(TASK)
-    response = {
-        "obligations": [
-            _obligation("render-lines", "Render each invoice line.", "Render each invoice line."),
-        ],
-        "open_questions": [],
-        "requirement_dispositions": [
-            _disposition("task-01", "yielded", obligation_ids=["render-lines"]),
-            _disposition("constraint-01", "no_obligation", reason="A bare section marker."),
-            # constraint-02, exclusion-01 and completion-01 go unmentioned.
-        ],
-    }
+    output = render_decomposition(_decomposition_with_a_shared_and_a_declined_requirement())
 
-    output = render_decomposition(decompose(parsed, _client_returning(response)))
-
-    assert "with obligations: 1" in output
+    assert "with obligations: 4" in output
     assert "deliberately none: 1" in output
-    assert "UNACCOUNTED FOR: 3" in output
-    assert output.count("!! UNACCOUNTED FOR") == 3
-    # The correct decline is not shouted at.
-    assert "!! UNACCOUNTED FOR — the decomposer did not address this\n       A bare section marker." not in output
+    assert "unaccounted" not in output.lower()
 
 
 # --- unread source reaches the reader (M1.2.r1) -----------------------------

--- a/tests/requirement/test_requirement_map.py
+++ b/tests/requirement/test_requirement_map.py
@@ -327,6 +327,63 @@ def test_the_literal_tag_alone_decides_which_shape_a_disposition_is():
         )
 
 
+def test_a_disposition_cannot_carry_another_disposition_s_payload():
+    """Exclusivity is what stops the contradiction returning in a new costume.
+
+    A `yielded` entry that also carries `reason` is a response claiming both
+    dispositions at once — M1.2.r1's defect wearing different clothes. If it
+    parsed, it would bind to `_Yielded`, which has no `reason` field, so the
+    reason would be dropped on the floor exactly as it was before.
+
+    It rejects today only because `StrictResponseModel` sets `extra="forbid"`,
+    and that exists for an unrelated reason: OpenAI strict mode requires every
+    object in the schema to forbid extra properties. Nothing else records that
+    this union depends on it, so relaxing `extra` elsewhere would reopen the gap
+    with every other test still green. Hence this guard.
+    """
+    def parse(entry: dict):
+        return _Decomposition.model_validate(
+            {"obligations": [], "open_questions": [], "requirement_dispositions": [entry]}
+        )
+
+    # Claims `yielded` and supplies a decline reason alongside it.
+    with pytest.raises(ValidationError):
+        parse(
+            {
+                "requirement_id": "task-01",
+                "disposition": "yielded",
+                "obligation_id": "ob-1",
+                "more_obligation_ids": [],
+                "reason": "declined because it adds no checkable behavior",
+            }
+        )
+
+    # The mirror: were members selected by which fields are present rather than
+    # by the literal tag, this would match `_Yielded` and turn a decline into a
+    # yield.
+    with pytest.raises(ValidationError):
+        parse(
+            {
+                "requirement_id": "task-01",
+                "disposition": "no_obligation",
+                "reason": "Not applicable.",
+                "obligation_id": "ob-1",
+                "more_obligation_ids": [],
+            }
+        )
+
+    # The control, so neither assertion above can pass vacuously.
+    clean = parse(
+        {
+            "requirement_id": "task-01",
+            "disposition": "yielded",
+            "obligation_id": "ob-1",
+            "more_obligation_ids": [],
+        }
+    )
+    assert clean.requirement_dispositions[0].ids() == ["ob-1"]
+
+
 def test_the_schema_cannot_express_an_open_question_disposition_with_no_questions():
     """The twin of the yielded case, at the schema boundary rather than at
     reconciliation: `open_question_id` is required, so the empty payload has no

--- a/tests/support.py
+++ b/tests/support.py
@@ -34,10 +34,17 @@ def _fake_response(content: str) -> SimpleNamespace:
 
 
 def client_returning(response: dict, model: str = _DEFAULT_MODEL) -> ModelClient:
-    """A client whose every call returns the same fixed response."""
+    """A client whose every call returns the same fixed response.
+
+    A `requirement_dispositions` of `[]` is completed from the requirements the
+    call supplied, so a test about obligations does not have to restate the
+    fixture's whole requirement list to stay well-formed. It is a convenience
+    for tests that are not about dispositions; a test that IS about them names
+    them explicitly and this leaves it alone.
+    """
 
     def completion_fn(**kwargs):
-        return _fake_response(json.dumps(response))
+        return _fake_response(json.dumps(_completed(response, **kwargs)))
 
     return ModelClient(
         model=model,
@@ -127,7 +134,7 @@ def client_dispatching(
 
     def completion_fn(**kwargs):
         schema_name = kwargs["response_format"]["json_schema"]["name"]
-        return _fake_response(json.dumps(responses_by_schema[schema_name]))
+        return _fake_response(json.dumps(_completed(responses_by_schema[schema_name], **kwargs)))
 
     return ModelClient(
         model=model,
@@ -139,6 +146,57 @@ def client_dispatching(
         seed=seed,
         completion_fn=completion_fn,
     )
+
+
+def supplied_requirement_ids(**kwargs) -> list[str]:
+    """The requirement ids a decomposition call supplied, read back off the
+    schema it sent.
+
+    `constrain` restricts `requirement_id` to a `Literal` of the registry ids,
+    so the enum in the outgoing schema is the work list — which lets a double
+    answer a call completely without being told the fixture's requirements
+    separately, and keeps it honest if they change.
+    """
+    schema = kwargs["response_format"]["json_schema"]["schema"]
+    items = schema["properties"]["requirement_dispositions"]["items"]
+    ids: list[str] = []
+    for member in items.get("anyOf", [items]):
+        enum = member.get("properties", {}).get("requirement_id", {}).get("enum") or []
+        for value in enum:
+            if value not in ids:
+                ids.append(value)
+    return ids
+
+
+def declining_dispositions(reason: str = "not exercised by this fixture", **kwargs) -> list[dict]:
+    """One `no_obligation` disposition per supplied requirement.
+
+    The honest "found nothing" for decomposition since M1.2.r2. A response
+    disposing nothing is malformed and raises, so a double that returns an
+    empty list is not a no-op checker — it is a broken one.
+    """
+    return [
+        {"requirement_id": requirement_id, "disposition": "no_obligation", "reason": reason}
+        for requirement_id in supplied_requirement_ids(**kwargs)
+    ]
+
+
+def _completed(response: dict, **kwargs) -> dict:
+    """Fill in an empty `requirement_dispositions` from the requirements the
+    call supplied.
+
+    Since M1.2.r2 a decomposition response that disposes nothing does not
+    parse, so `[]` is not the neutral stand-in it used to be. Rather than make
+    every fixture restate its task file's whole requirement list, the doubles
+    complete it as a full set of declines — which keeps them well-formed while
+    leaving the obligations and questions they are actually about untouched. A
+    test that IS about dispositions names them, and this leaves it alone.
+    """
+    if not isinstance(response, dict) or response.get("requirement_dispositions") != []:
+        return response
+    if "requirement_dispositions" not in response:
+        return response
+    return {**response, "requirement_dispositions": declining_dispositions(**kwargs)}
 
 
 # An empty result per pipeline response schema (schemas are strict, so each

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import pytest
 
 from acceptance.cli import main, run_check
 from acceptance.config import DEFAULT_SEED, RunConfig
+from acceptance.review_state import Disposition
 from acceptance.review_store import ReviewStore
 from tests.support import client_finding_nothing
 
@@ -948,11 +949,14 @@ def test_the_pipeline_persists_the_requirement_map(git_repo, tmp_path, stub_mode
     """Wiring, not the function (CLAUDE.md).
 
     `decompose` building a mapping is worth nothing if `run_review` drops it on
-    the floor — the shape of hole defect injection keeps finding here. The stub
-    client accounts for no requirement at all, so every one of them must come
-    back `undisposed`: a review that persisted an empty or absent map would be
-    indistinguishable from one whose decomposer read the whole mandate, which is
-    the exact defect M1.2.r1 exists to close.
+    the floor — the shape of hole defect injection keeps finding here. A review
+    that persisted an empty or absent map would be indistinguishable from one
+    whose decomposer read the whole mandate, which is the exact defect M1.2.r1
+    exists to close.
+
+    The stub declines every requirement, which since M1.2.r2 is the only way a
+    decomposer can produce nothing and still answer: a response that accounts
+    for no requirement at all no longer parses.
     """
     task = tmp_path / "task.md"
     task.write_text(
@@ -973,7 +977,10 @@ def test_the_pipeline_persists_the_requirement_map(git_repo, tmp_path, stub_mode
         "constraint-02",
         "exclusion-01",
     ]
-    assert len(stored.requirement_map.undisposed()) == 4
+    assert len(stored.requirement_map.unyielding()) == 4
+    for entry in stored.requirement_map.dispositions:
+        assert entry.disposition is Disposition.NO_OBLIGATION
+        assert entry.reason
 
 
 def test_a_requirement_that_yielded_nothing_is_visible_in_the_report(

--- a/tests/test_decision_records.py
+++ b/tests/test_decision_records.py
@@ -42,6 +42,20 @@ def test_dr_202_records_the_requirement_id_decision_as_resolved():
     assert "`section + ordinal`" in flat
 
 
+def test_dr_202_records_the_three_disposition_set_and_parse_time_completeness():
+    """M1.2.r2 (#217). Decision 3 named three dispositions and the
+    implementation shipped four, so the DR and the code disagreed while both
+    read as settled. A reader arriving at decision 3 must meet the amendment
+    there rather than infer it from the absence of `UNDISPOSED` in the code.
+    """
+    flat = _flat(DR_202.read_text())
+
+    assert "Amended by M1.2.r2" in flat
+    assert "UNDISPOSED" in flat and "has been removed" in flat
+    # The mechanism, not just the fact: enforcement moved to parse time.
+    assert "Completeness is now enforced at parse" in flat
+
+
 def test_dr_202_no_longer_lists_requirement_id_stability_as_open():
     """The half that matters. Adding a Resolved section while leaving the
     question under Open records the decision and hides it at the same time."""

--- a/tests/test_supplied_ids.py
+++ b/tests/test_supplied_ids.py
@@ -13,6 +13,10 @@ honour is RECORDED rather than dropped.
 """
 
 import json
+from typing import Literal, Union
+
+import pytest
+from pydantic import ValidationError
 
 from acceptance.evidence.discovery import DiscoveredTest, DiscoveryReason
 from acceptance.evidence.mapping import map_tests_to_obligations
@@ -30,6 +34,22 @@ class _Item(StrictResponseModel):
 
 class _Container(StrictResponseModel):
     items: list[_Item]
+
+
+class _FirstShape(StrictResponseModel):
+    kind: Literal["first"]
+    obligation_id: str
+    rationale: str
+
+
+class _SecondShape(StrictResponseModel):
+    kind: Literal["second"]
+    obligation_id: str
+    note: str
+
+
+class _UnionContainer(StrictResponseModel):
+    items: list[Union[_FirstShape, _SecondShape]]
 
 
 def _test(test_id: str, source: str = "def t():\n    pass") -> DiscoveredTest:
@@ -66,6 +86,31 @@ def test_a_list_valued_id_field_constrains_its_items():
 
     field = schema["properties"]["items"]["items"]["properties"]["obligation_ids"]
     assert field["items"]["enum"] == ["ob-1"]
+
+
+def test_a_union_of_item_shapes_constrains_every_member():
+    """The walk must descend through a union, not stop at it.
+
+    `_Decomposition` returns a union of per-disposition shapes (M1.2.r2), and
+    every member carries the same `requirement_id`. Before this, the walk found
+    no `BaseModel` to descend into, returned None, and the constraint vanished
+    with nothing failing — the guarantee would have been silently gone while
+    every existing test still passed, which is the shape of defect the walk
+    exists to prevent.
+    """
+    constrained = constrain(_UnionContainer, {"obligation_id": ["ob-1", "ob-2"]})
+    schema = inline_schema_refs(constrained.model_json_schema())
+
+    members = schema["properties"]["items"]["items"]["anyOf"]
+    assert len(members) == 2
+    for member in members:
+        assert member["properties"]["obligation_id"]["enum"] == ["ob-1", "ob-2"]
+
+    # And it still refuses an id outside the supplied set, through the union.
+    with pytest.raises(ValidationError):
+        constrained.model_validate(
+            {"items": [{"kind": "first", "obligation_id": "ob-9", "rationale": "."}]}
+        )
 
 
 def test_a_foreign_id_does_not_validate_against_the_constrained_schema():


### PR DESCRIPTION
Closes #217. Supersedes #202 (`M1.2.r1`), which stays closed — its acceptance genuinely passed.

## What was wrong

DR-202 decision 3 gives a requirement exactly one of **three** dispositions, each carrying something. The implementation added a fourth, `UNDISPOSED`, carrying none of them, reached from two unrelated conditions: a response that never mentioned a requirement, and a response labelling one `yielded` while naming no obligations. Both are malformed. Both became soft findings that flowed on to a verdict.

Found by #216's Gate 1. Eight of 31 requirements came back `yielded` with an empty id list — **and a substantive reason**:

```
exclusion-05  reason='This is a scope exclusion pointing to a separate issue (#144)
                      and does not add a checkable requirement for this change.'
```

No invented ids; `_resolve` dropped nothing. The model wrote a textbook `no_obligation` reason and put the wrong label on it. `_requirement_map` required the label to match, fell through to `else`, discarded the reason, and substituted `"disposition 'yielded' named no usable output"`.

The registry is derived from the parse and reconciliation walks it, so the code cannot drop a requirement. A disposition meaning "the response did not say" encoded a state no correct run produces.

## What this does

- Each disposition is its own response shape carrying only its own payload. `yielded` structurally requires an obligation id; `no_obligation` a reason.
- Reconciliation raises on a missing requirement, a duplicate, an id outside the registry, or a claim naming only outputs the response never produced.
- `Disposition.UNDISPOSED` and every path assigning it are deleted.
- A supplied reason is preserved, never replaced by a diagnostic.
- DR-202 decision 3 amended in place.

## Two things worth not rediscovering

**A pydantic tagged union cannot go on the wire.** `Field(discriminator=...)` renders `oneOf` + `discriminator`; OpenAI strict mode accepts neither, and `inline_schema_refs` would leave the discriminator mapping pointing at `$defs` it had just inlined. A plain `Union` renders `anyOf`, which strict mode accepts, and the `Literal` tags still disambiguate.

**"At least one" cannot be `min_length`.** Strict mode rejects `minItems`. It is a required scalar beside a list (`obligation_id` + `more_obligation_ids`), so the guarantee is carried by the shape and survives onto the wire.

`constrain()` also had to learn to walk unions. Without that the `requirement_id` constraint would have vanished silently under the new shape — with every existing test still green.

## Cost

`request_key` hashes the response schema by design (`llm.py:81-87`), so this **invalidated every recorded decompose transcript**. Decomposition-accuracy figures are not comparable across this change.

## Dogfooding

`dogfood-logs/216-gate1-run1/` (the run that found it), `217-gate1-run1/`, `217-gate2-run{1,2,3}/` — each with its task file, output, revisions and judgement.

**Gate 2 is not clean**, and this is a deliberate, recorded deviation. Weak obligations went 11 → 7 → 5 across three runs. All five are attributed, none waived:

| finding | attribution |
|---|---|
| `typed-schemas-are-pydantic-models` | **#148** — design/approach obligation; no test can evidence it |
| `schema-test-rejects-empty-yielded` | **#148** category 2 — "a test asserts X"; the test exists |
| `union-id-test-covers-members` | **#148** category 2 — same; drew 6 mapped tests where the one above drew none |
| `disposition-union-payloads` | **acted on** — mixed-payload exclusivity guard added |
| `unambiguous-literal-discriminators` | **acted on** — same guard |

Evidence from these runs is attached to #148, which now blocks Gate 2 on consecutive PRs.

A re-check of all five is recorded in `dogfood-logs/217-gate2-run3/judgement.md`, including a **correction**: obligation 17 was first reported as a mapping miss (#182) because a test matched the recommendation's prescription. That was wrong — the test would pass whether or not the production schemas are pydantic, so it cannot discriminate the obligation.

773 tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
