### PR TITLE
Render recommendations under their obligation, and reject a missing one (#218)

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,83 +1,65 @@
 # Task
-DR-202 decision 3 gives a requirement exactly one of three dispositions, each
-carrying something: yielded obligations, deliberately yields none with a reason,
-or raised an open question instead. The implementation added a fourth,
-`UNDISPOSED`, carrying none of them, and reached it two ways: a response that
-never mentioned a requirement, and a response that labelled a requirement
-`yielded` while naming no obligations.
+The §16 report prints test recommendations in their own block at the foot of the
+report. An obligation whose test evidence is weak says nothing about the
+recommendation that explains it, and the recommendation identifies its
+obligation only through a `--criterion` slug that appears nowhere in the
+obligation's own block. Joining the two is manual, and in the run that prompted
+this they sat about two hundred lines apart.
 
-Both are malformed responses, and both are currently absorbed as soft findings.
-`_requirement_map` discards the reason the response supplied, substitutes a
-diagnostic string of its own, and lets the run continue to a verdict on an
-answer that did not account for the mandate.
+§16 already rules this out: output is organised by obligation so that a
+criterion's axes sit together rather than in separate lists the reader must join
+by eye. A recommendation is a third axis and received exactly the treatment §16
+forbids. The join key already exists, because `TestRecommendation.obligation_id`
+is what builds the `--criterion` command.
 
-The registry of requirements is derived deterministically from the parse, and
-the code iterates over that registry. Dropping a requirement is therefore not a
-possible outcome — the only possible bad outcome is a response of poor quality.
-Make that true in the types: every requirement carries one of exactly three
-dispositions, each structurally required to carry its own payload, and a
-response that fails to account for every requirement does not parse. Remove the
-fourth disposition entirely.
+Separately, `coverage/recommendations.py::recommend_tests` iterates the
+recommendations a response returned and never reconciles them against the weak
+obligations it asked about. A response returning three recommendations for five
+weak obligations produces a report in which two weak obligations carry none, and
+nothing distinguishes that from a complete answer.
+
+Render each recommendation with the obligation it explains, and make a missing
+recommendation an error rather than an absence.
 
 ## Constraints
-- A requirement disposition is one of exactly three: yielded obligations,
-  no obligations needed with a reason, or an open question that prevents an
-  answer.
-- `Disposition` has no `UNDISPOSED` value.
-- `_RequirementDisposition` is a union of one shape per disposition, each
-  carrying only the payload its own disposition defines.
-- The union is unambiguous at parse: each shape names its disposition as a
-  literal value.
-- The schema sent to the model uses only keywords OpenAI strict mode accepts.
-- A `yielded` disposition carries at least one obligation id.
-- A `no_obligation` disposition carries a reason that is not empty.
-- An `open_question` disposition carries at least one open-question id.
-- A response labelling a requirement `yielded` while naming no obligation id
-  fails to parse.
-- A response labelling a requirement `no_obligation` with an empty reason fails
-  to parse.
-- A response that omits any requirement in the registry is rejected.
-- A response that names a requirement id absent from the registry is rejected.
-- A rejected response produces no `RequirementMap`.
-- The JSON schema sent to the model cannot express a `yielded` disposition with
-  zero obligation ids.
-- The reason a response supplies for declining a requirement is preserved rather
-  than replaced by a diagnostic string.
-- The helper that restricts an id field to the ids a call supplied keeps working
-  when the response model's item type is a union, so the requirement-id
-  constraint survives the new shape.
+- A recommendation is rendered inside the block of the obligation it names.
+- A recommendation is rendered on the test-evidence axis, which is the axis it
+  explains.
+- The report contains no standalone recommendations section.
+- The `--criterion` retrieval line stays with each recommendation.
+- The report keeps its closing line pointing at the retrieval command.
+- An obligation whose test evidence is below strongly supported carries a
+  recommendation.
+- An obligation whose test evidence is strongly supported carries none.
+- A response that omits a recommendation for a weak obligation the call supplied
+  is rejected.
+- A response naming an obligation that is not weak is rejected rather than
+  silently dropped.
+- The count of recommendations in a produced review equals the count of weak
+  obligations.
+- The verdict summary counts weak obligations from the obligations themselves,
+  not from the recommendation list.
 - Typed schemas are pydantic models, as the rest of the repository defines them.
 - Tests issue no live model calls.
 
 ## Scope exclusions
-- The decomposer declining to yield obligations for scope exclusions, against
-  the instruction already in the decompose prompt. That is a prompt defect
-  tracked separately and costs a transcript re-record.
-- Changing the decompose prompt text.
+- Whether an obligation needs test evidence at all, which is #148. The rule
+  built here is that a recommendation exists exactly when test evidence is below
+  strongly supported; the further condition that tests are the right evidence
+  for the obligation is not computable until #148 lands.
+- Changing the strength classifier, or what counts as weak.
+- Changing what a recommendation contains.
 - Retrying or repairing a rejected response.
-- Nested-bullet and multi-paragraph parse coverage, which is #216.
-- Whether mandate coverage bounds the completion verdict, which is #214.
-- Aligning requirement ids across two versions of a task file, which is #209.
+- The separate rendering of open questions and unrequested changes.
 
 ## Completion expectations
 - Implementation
-- Every requirement in a parsed `RequirementMap` carries one of the three
-  dispositions.
-- A response with a `yielded` disposition and no obligation ids is rejected.
-- A response with a `no_obligation` disposition and an empty reason is rejected.
-- A response omitting a requirement present in the registry is rejected.
-- No `RequirementMap` is produced from a rejected response.
-- The `UNDISPOSED` value and every code path that assigns it are removed.
-- A response naming a requirement id outside the registry is rejected.
-- A response disposing the same requirement twice is rejected.
-- An `open_question` disposition naming no question the response produced is
+- A report containing weak obligations has no standalone recommendations
+  section.
+- Each weak obligation's rendered block contains its own recommendation.
+- A strongly supported obligation's rendered block contains no recommendation.
+- A response omitting a recommendation for a supplied weak obligation is
   rejected.
-- A test asserts that the schema sent to the model rejects a `yielded`
-  disposition carrying zero obligation ids.
-- A test asserts that the id constraint still reaches every member of a union
-  item type.
-- The tests, CLI rendering and report sections that referred to the removed
-  disposition are updated rather than left asserting it.
-- `docs/DR-202-decomposition-requirement-mapping.md` records that the
-  disposition set is the three of decision 3, and that completeness is enforced
-  at parse.
+- A response naming a non-weak obligation is rejected.
+- A review carrying weak obligations has one recommendation per weak obligation.
+- A report with no weak obligations renders no recommendation text.

--- a/dogfood-logs/218-gate1-run1/current-task.md
+++ b/dogfood-logs/218-gate1-run1/current-task.md
@@ -1,0 +1,65 @@
+# Task
+The §16 report prints test recommendations in their own block at the foot of the
+report. An obligation whose test evidence is weak says nothing about the
+recommendation that explains it, and the recommendation identifies its
+obligation only through a `--criterion` slug that appears nowhere in the
+obligation's own block. Joining the two is manual, and in the run that prompted
+this they sat about two hundred lines apart.
+
+§16 already rules this out: output is organised by obligation so that a
+criterion's axes sit together rather than in separate lists the reader must join
+by eye. A recommendation is a third axis and received exactly the treatment §16
+forbids. The join key already exists, because `TestRecommendation.obligation_id`
+is what builds the `--criterion` command.
+
+Separately, `coverage/recommendations.py::recommend_tests` iterates the
+recommendations a response returned and never reconciles them against the weak
+obligations it asked about. A response returning three recommendations for five
+weak obligations produces a report in which two weak obligations carry none, and
+nothing distinguishes that from a complete answer.
+
+Render each recommendation with the obligation it explains, and make a missing
+recommendation an error rather than an absence.
+
+## Constraints
+- A recommendation is rendered inside the block of the obligation it names.
+- A recommendation is rendered on the test-evidence axis, which is the axis it
+  explains.
+- The report contains no standalone recommendations section.
+- The `--criterion` retrieval line stays with each recommendation.
+- The report keeps its closing line pointing at the retrieval command.
+- An obligation whose test evidence is below strongly supported carries a
+  recommendation.
+- An obligation whose test evidence is strongly supported carries none.
+- A response that omits a recommendation for a weak obligation the call supplied
+  is rejected.
+- A response naming an obligation that is not weak is rejected rather than
+  silently dropped.
+- The count of recommendations in a produced review equals the count of weak
+  obligations.
+- The verdict summary counts weak obligations from the obligations themselves,
+  not from the recommendation list.
+- Typed schemas are pydantic models, as the rest of the repository defines them.
+- Tests issue no live model calls.
+
+## Scope exclusions
+- Whether an obligation needs test evidence at all, which is #148. The rule
+  built here is that a recommendation exists exactly when test evidence is below
+  strongly supported; the further condition that tests are the right evidence
+  for the obligation is not computable until #148 lands.
+- Changing the strength classifier, or what counts as weak.
+- Changing what a recommendation contains.
+- Retrying or repairing a rejected response.
+- The separate rendering of open questions and unrequested changes.
+
+## Completion expectations
+- Implementation
+- A report containing weak obligations has no standalone recommendations
+  section.
+- Each weak obligation's rendered block contains its own recommendation.
+- A strongly supported obligation's rendered block contains no recommendation.
+- A response omitting a recommendation for a supplied weak obligation is
+  rejected.
+- A response naming a non-weak obligation is rejected.
+- A review carrying weak obligations has one recommendation per weak obligation.
+- A report with no weak obligations renders no recommendation text.

--- a/dogfood-logs/218-gate1-run1/judgement.md
+++ b/dogfood-logs/218-gate1-run1/judgement.md
@@ -1,0 +1,24 @@
+# Judgement — #218 Gate 1 run 1
+
+At `6ae97fd` (main), pre-implementation. **Gate 1 passed.**
+
+`Requirements: 30   with obligations: 25   deliberately none: 5   unaccounted for: 0`
+
+Zero open questions, so step 3 had nothing to triage. The 25 obligations match
+the 25 substantive requirements; nothing invented, nothing missing.
+
+## One finding, filed
+
+Four of five scope exclusions were declined as `no_obligation`, each with a
+reason that performs the positive reframing and then declines anyway:
+
+    [exclusion-04] Retrying or repairing a rejected response.
+        -- no obligation, deliberately
+           Scope exclusion only; it preserves the absence of retry/repair behavior.
+
+"It preserves X" *is* the obligation, written into the reason field instead of
+yielded. Against the instruction already at `obligations.py:150`. Second Gate 1
+in a row — **filed as #219**, child of #181, for the #204/#205/#206 prompt batch.
+
+Note this run used **main's decomposer**, which still carries the pre-#217
+four-disposition model. #217 is unmerged and on its own branch.

--- a/dogfood-logs/218-gate1-run1/output.log
+++ b/dogfood-logs/218-gate1-run1/output.log
@@ -1,0 +1,192 @@
+Requirements: 30   with obligations: 25   deliberately none: 5   unaccounted for: 0
+
+[task-01] The §16 report prints test recommendations in their own block at the foot of
+    the report. An obligation whose test evidence is weak says nothing about the
+    recommendation that explains it, and the recommendation identifies its obligation
+    only through a `--criterion` slug that appears nowhere in the obligation's own
+    block. Joining the two is manual, and in the run that prompted this they sat about
+    two hundred lines apart.
+    -> render-recommendation-with-obligation  [functional/explicit]   (also serves task-02, task-04, constraint-01, completion-03)
+       Render each test recommendation inside the block for the obligation it explains,
+       so the recommendation and its obligation appear together.
+    -> criterion-retrieval-line-stays-with-recommendation  [compatibility/explicit]   (also serves task-02, constraint-04)
+       Keep the `--criterion` retrieval line attached to each recommendation.
+
+[task-02] §16 already rules this out: output is organised by obligation so that a
+    criterion's axes sit together rather than in separate lists the reader must join by
+    eye. A recommendation is a third axis and received exactly the treatment §16
+    forbids. The join key already exists, because `TestRecommendation.obligation_id` is
+    what builds the `--criterion` command.
+    -> recommendation-on-test-evidence-axis  [functional/explicit]   (also serves constraint-02)
+       Render each recommendation on the test-evidence axis, matching the axis it
+       explains.
+    -> render-recommendation-with-obligation  [functional/explicit]   (also serves task-01, task-04, constraint-01, completion-03)
+       Render each test recommendation inside the block for the obligation it explains,
+       so the recommendation and its obligation appear together.
+    -> criterion-retrieval-line-stays-with-recommendation  [compatibility/explicit]   (also serves task-01, constraint-04)
+       Keep the `--criterion` retrieval line attached to each recommendation.
+
+[task-03] Separately, `coverage/recommendations.py::recommend_tests` iterates the
+    recommendations a response returned and never reconciles them against the weak
+    obligations it asked about. A response returning three recommendations for five weak
+    obligations produces a report in which two weak obligations carry none, and nothing
+    distinguishes that from a complete answer.
+    -> reject-missing-recommendation-for-weak-obligation  [error_handling/explicit]   (also serves task-04, constraint-08, completion-05)
+       Reject a response that omits a recommendation for any supplied weak obligation.
+    -> reject-recommendation-for-nonweak-obligation  [error_handling/explicit]   (also serves constraint-09, completion-06)
+       Reject a response that names an obligation that is not weak instead of silently
+       dropping it.
+    -> recommendation-count-matches-weak-obligation-count  [invariant/explicit]   (also serves constraint-10, completion-07)
+       Ensure the number of recommendations in a produced review equals the number of
+       weak obligations.
+    -> verdict-summary-counts-weak-obligations-from-obligations  [functional/explicit]   (also serves constraint-11)
+       Compute the verdict summary's weak-obligation count from the obligations
+       themselves rather than from the recommendation list.
+
+[task-04] Render each recommendation with the obligation it explains, and make a missing
+    recommendation an error rather than an absence.
+    -> render-recommendation-with-obligation  [functional/explicit]   (also serves task-01, task-02, constraint-01, completion-03)
+       Render each test recommendation inside the block for the obligation it explains,
+       so the recommendation and its obligation appear together.
+    -> reject-missing-recommendation-for-weak-obligation  [error_handling/explicit]   (also serves task-03, constraint-08, completion-05)
+       Reject a response that omits a recommendation for any supplied weak obligation.
+
+[constraint-01] A recommendation is rendered inside the block of the obligation it
+    names.
+    -> render-recommendation-with-obligation  [functional/explicit]   (also serves task-01, task-02, task-04, completion-03)
+       Render each test recommendation inside the block for the obligation it explains,
+       so the recommendation and its obligation appear together.
+
+[constraint-02] A recommendation is rendered on the test-evidence axis, which is the
+    axis it explains.
+    -> recommendation-on-test-evidence-axis  [functional/explicit]   (also serves task-02)
+       Render each recommendation on the test-evidence axis, matching the axis it
+       explains.
+
+[constraint-03] The report contains no standalone recommendations section.
+    -> no-standalone-recommendations-section  [invariant/explicit]   (also serves completion-02, completion-08)
+       Preserve the report structure so it contains no standalone recommendations
+       section.
+
+[constraint-04] The `--criterion` retrieval line stays with each recommendation.
+    -> criterion-retrieval-line-stays-with-recommendation  [compatibility/explicit]   (also serves task-01, task-02)
+       Keep the `--criterion` retrieval line attached to each recommendation.
+
+[constraint-05] The report keeps its closing line pointing at the retrieval command.
+    -> closing-line-points-at-retrieval-command  [compatibility/explicit]
+       Preserve the report's closing line so it points at the retrieval command.
+
+[constraint-06] An obligation whose test evidence is below strongly supported carries a
+    recommendation.
+    -> weak-obligation-carries-recommendation  [functional/explicit]
+       Ensure every obligation whose test evidence is below strongly supported carries a
+       recommendation.
+
+[constraint-07] An obligation whose test evidence is strongly supported carries none.
+    -> strongly-supported-obligation-carries-none  [invariant/explicit]   (also serves completion-04)
+       Preserve the behavior that strongly supported obligations carry no
+       recommendation.
+
+[constraint-08] A response that omits a recommendation for a weak obligation the call
+    supplied is rejected.
+    -> reject-missing-recommendation-for-weak-obligation  [error_handling/explicit]   (also serves task-03, task-04, completion-05)
+       Reject a response that omits a recommendation for any supplied weak obligation.
+
+[constraint-09] A response naming an obligation that is not weak is rejected rather than
+    silently dropped.
+    -> reject-recommendation-for-nonweak-obligation  [error_handling/explicit]   (also serves task-03, completion-06)
+       Reject a response that names an obligation that is not weak instead of silently
+       dropping it.
+
+[constraint-10] The count of recommendations in a produced review equals the count of
+    weak obligations.
+    -> recommendation-count-matches-weak-obligation-count  [invariant/explicit]   (also serves task-03, completion-07)
+       Ensure the number of recommendations in a produced review equals the number of
+       weak obligations.
+
+[constraint-11] The verdict summary counts weak obligations from the obligations
+    themselves, not from the recommendation list.
+    -> verdict-summary-counts-weak-obligations-from-obligations  [functional/explicit]   (also serves task-03)
+       Compute the verdict summary's weak-obligation count from the obligations
+       themselves rather than from the recommendation list.
+
+[constraint-12] Typed schemas are pydantic models, as the rest of the repository defines
+    them.
+    -> typed-schemas-are-pydantic-models  [compatibility/explicit]
+       Represent typed schemas as pydantic models, consistent with the rest of the
+       repository.
+
+[constraint-13] Tests issue no live model calls.
+    -> tests-avoid-live-model-calls  [regression/explicit]
+       Keep tests free of live model calls.
+
+[exclusion-01] Whether an obligation needs test evidence at all, which is #148. The rule
+    built here is that a recommendation exists exactly when test evidence is below
+    strongly supported; the further condition that tests are the right evidence for the
+    obligation is not computable until #148 lands.
+    -> recommendation-exists-exactly-when-test-evidence-below-strongly-supported  [functional/inferred]
+       Make recommendation existence depend exactly on test evidence being below
+       strongly supported, while preserving the separate #148 rule about whether test
+       evidence is needed at all.
+
+[exclusion-02] Changing the strength classifier, or what counts as weak.
+    -- no obligation, deliberately
+       Scope exclusion only; it preserves the existing strength classifier and
+       weak/strong threshold unchanged.
+
+[exclusion-03] Changing what a recommendation contains.
+    -- no obligation, deliberately
+       Scope exclusion only; it preserves the existing recommendation contents
+       unchanged.
+
+[exclusion-04] Retrying or repairing a rejected response.
+    -- no obligation, deliberately
+       Scope exclusion only; it preserves the absence of retry/repair behavior.
+
+[exclusion-05] The separate rendering of open questions and unrequested changes.
+    -- no obligation, deliberately
+       Scope exclusion only; it preserves the separate rendering of open questions and
+       unrequested changes.
+
+[completion-01] Implementation
+    -- no obligation, deliberately
+       Section marker only; it introduces no checkable requirement.
+
+[completion-02] A report containing weak obligations has no standalone recommendations
+    section.
+    -> no-standalone-recommendations-section  [invariant/explicit]   (also serves constraint-03, completion-08)
+       Preserve the report structure so it contains no standalone recommendations
+       section.
+
+[completion-03] Each weak obligation's rendered block contains its own recommendation.
+    -> render-recommendation-with-obligation  [functional/explicit]   (also serves task-01, task-02, task-04, constraint-01)
+       Render each test recommendation inside the block for the obligation it explains,
+       so the recommendation and its obligation appear together.
+
+[completion-04] A strongly supported obligation's rendered block contains no
+    recommendation.
+    -> strongly-supported-obligation-carries-none  [invariant/explicit]   (also serves constraint-07)
+       Preserve the behavior that strongly supported obligations carry no
+       recommendation.
+
+[completion-05] A response omitting a recommendation for a supplied weak obligation is
+    rejected.
+    -> reject-missing-recommendation-for-weak-obligation  [error_handling/explicit]   (also serves task-03, task-04, constraint-08)
+       Reject a response that omits a recommendation for any supplied weak obligation.
+
+[completion-06] A response naming a non-weak obligation is rejected.
+    -> reject-recommendation-for-nonweak-obligation  [error_handling/explicit]   (also serves task-03, constraint-09)
+       Reject a response that names an obligation that is not weak instead of silently
+       dropping it.
+
+[completion-07] A review carrying weak obligations has one recommendation per weak
+    obligation.
+    -> recommendation-count-matches-weak-obligation-count  [invariant/explicit]   (also serves task-03, constraint-10)
+       Ensure the number of recommendations in a produced review equals the number of
+       weak obligations.
+
+[completion-08] A report with no weak obligations renders no recommendation text.
+    -> no-standalone-recommendations-section  [invariant/explicit]   (also serves constraint-03, completion-02)
+       Preserve the report structure so it contains no standalone recommendations
+       section.
+

--- a/dogfood-logs/218-gate2-run1/current-task.md
+++ b/dogfood-logs/218-gate2-run1/current-task.md
@@ -1,0 +1,65 @@
+# Task
+The §16 report prints test recommendations in their own block at the foot of the
+report. An obligation whose test evidence is weak says nothing about the
+recommendation that explains it, and the recommendation identifies its
+obligation only through a `--criterion` slug that appears nowhere in the
+obligation's own block. Joining the two is manual, and in the run that prompted
+this they sat about two hundred lines apart.
+
+§16 already rules this out: output is organised by obligation so that a
+criterion's axes sit together rather than in separate lists the reader must join
+by eye. A recommendation is a third axis and received exactly the treatment §16
+forbids. The join key already exists, because `TestRecommendation.obligation_id`
+is what builds the `--criterion` command.
+
+Separately, `coverage/recommendations.py::recommend_tests` iterates the
+recommendations a response returned and never reconciles them against the weak
+obligations it asked about. A response returning three recommendations for five
+weak obligations produces a report in which two weak obligations carry none, and
+nothing distinguishes that from a complete answer.
+
+Render each recommendation with the obligation it explains, and make a missing
+recommendation an error rather than an absence.
+
+## Constraints
+- A recommendation is rendered inside the block of the obligation it names.
+- A recommendation is rendered on the test-evidence axis, which is the axis it
+  explains.
+- The report contains no standalone recommendations section.
+- The `--criterion` retrieval line stays with each recommendation.
+- The report keeps its closing line pointing at the retrieval command.
+- An obligation whose test evidence is below strongly supported carries a
+  recommendation.
+- An obligation whose test evidence is strongly supported carries none.
+- A response that omits a recommendation for a weak obligation the call supplied
+  is rejected.
+- A response naming an obligation that is not weak is rejected rather than
+  silently dropped.
+- The count of recommendations in a produced review equals the count of weak
+  obligations.
+- The verdict summary counts weak obligations from the obligations themselves,
+  not from the recommendation list.
+- Typed schemas are pydantic models, as the rest of the repository defines them.
+- Tests issue no live model calls.
+
+## Scope exclusions
+- Whether an obligation needs test evidence at all, which is #148. The rule
+  built here is that a recommendation exists exactly when test evidence is below
+  strongly supported; the further condition that tests are the right evidence
+  for the obligation is not computable until #148 lands.
+- Changing the strength classifier, or what counts as weak.
+- Changing what a recommendation contains.
+- Retrying or repairing a rejected response.
+- The separate rendering of open questions and unrequested changes.
+
+## Completion expectations
+- Implementation
+- A report containing weak obligations has no standalone recommendations
+  section.
+- Each weak obligation's rendered block contains its own recommendation.
+- A strongly supported obligation's rendered block contains no recommendation.
+- A response omitting a recommendation for a supplied weak obligation is
+  rejected.
+- A response naming a non-weak obligation is rejected.
+- A review carrying weak obligations has one recommendation per weak obligation.
+- A report with no weak obligations renders no recommendation text.

--- a/dogfood-logs/218-gate2-run1/judgement.md
+++ b/dogfood-logs/218-gate2-run1/judgement.md
@@ -1,0 +1,32 @@
+# Judgement — #218 Gate 2 run 1
+
+`6ae97fd` → `c61e3cf`. **Not clean.** INCOMPLETE, 5 weak obligations.
+
+The change is visibly working on itself: 5 inline `recommended test:` lines, 0
+standalone `Recommended tests:` sections. The tool dogfooded its own fix.
+
+## Acted on
+
+**Recommendation 11 was the substantive one** — *"the summary counts weak
+obligations from the recommendation list instead of from the obligations
+input, so missing recommendations reduce the weak count"*. That would be the
+#214 blindness one axis over: answering less scoring better.
+
+It is not present — `derive_verdict` (`verdict.py:76-84`) builds the count from
+`obligations`, and never receives the recommendations at all. But nothing pinned
+it, and a later refactor threading them in would look harmless. Test added.
+
+## Attributed
+
+- **`typed-schemas-are-pydantic-models`** — `unsupported / no mapped test`.
+  Verbatim the #148 case that blocked #217's Gate 2, in a second consecutive PR.
+  Evidence attached to #148.
+- **`tests-avoid-live-model-calls`** — a standing repo invariant rather than
+  this change's behaviour. Same shape.
+
+## Deferred as tautology-adjacent
+
+Recommendations for `no-standalone-recommendations-section` and
+`closing-line-points-at-retrieval-command` both amount to asserting the code
+says what it says. The first turned out to have a fair core and was addressed in
+run 3; see that judgement.

--- a/dogfood-logs/218-gate2-run1/output.log
+++ b/dogfood-logs/218-gate2-run1/output.log
@@ -1,0 +1,184 @@
+Task completion: INCOMPLETE
+
+5 obligation(s) with non-discriminating test evidence (no-standalone-recommendations-section, closing-line-points-at-retrieval-command, verdict-summary-counts-weak-obligations-from-obligations, typed-schemas-are-pydantic-models, tests-avoid-live-model-calls).
+
+Obligations:
+
+  1. Render each test recommendation inside the block for the obligation it explains, so the recommendation and its obligation appear together.
+       requirements: task-01, task-02, task-04, constraint-01, completion-03
+       code evidence: addressed
+         1.1  src/acceptance/report.py#@@ -39,9 +40,17 @@ def render_report(review: Review) -> str:
+         1.2  src/acceptance/report.py#@@ -75,20 +84,9 @@ def render_report(review: Review) -> str:
+         1.3  src/acceptance/report.py#@@ -256,9 +254,13 @@ def _unread_block(requirement_map: RequirementMap) -> list[str]:
+         1.4  src/acceptance/report.py#@@ -302,6 +304,23 @@ def _obligation_block(
+         1.5  tests/test_report.py#@@ -208,8 +208,47 @@ def test_open_questions_and_recommendations_are_numbered():
+       test evidence: strongly supported  [tier: static]
+         1.6  tests/coverage/test_recommendations.py::test_weak_criterion_gets_a_fully_populated_recommendation
+         1.7  tests/test_report.py::test_a_recommendation_sits_under_its_own_obligation_and_no_other
+         1.8  tests/test_report.py::test_open_questions_and_recommendations_are_numbered
+
+  2. Render each recommendation on the test-evidence axis, matching the axis it explains.
+       requirements: task-02, constraint-02
+       code evidence: addressed
+         2.1  src/acceptance/report.py#@@ -302,6 +304,23 @@ def _obligation_block(
+         2.2  tests/test_report.py#@@ -208,8 +208,47 @@ def test_open_questions_and_recommendations_are_numbered():
+         2.3  tests/test_report.py#@@ -208,8 +208,47 @@ def test_open_questions_and_recommendations_are_numbered():
+       test evidence: strongly supported  [tier: static]
+         2.4  tests/coverage/test_recommendations.py::test_weak_criterion_gets_a_fully_populated_recommendation
+         2.5  tests/test_report.py::test_a_recommendation_sits_under_its_own_obligation_and_no_other
+         2.6  tests/test_report.py::test_open_questions_and_recommendations_are_numbered
+
+  3. Preserve the report structure so it contains no standalone recommendations section.
+       requirements: constraint-03, completion-02, completion-08
+       code evidence: addressed
+         3.1  src/acceptance/report.py#@@ -75,20 +84,9 @@ def render_report(review: Review) -> str:
+       test evidence: partially supported  [tier: static]
+         3.2  tests/test_report.py::test_a_first_review_renders_no_changes_section
+         3.3  tests/test_report.py::test_empty_review_renders_the_full_shell
+         3.4  tests/test_report.py::test_open_questions_and_recommendations_are_numbered
+         recommended test: The report output does not include a separate recommendations section header or block.
+           inputs:  Build a review/report fixture with at least one weak obligation that has a recommendation, then render the report and inspect the entire text for any extra blank or unlabeled block after the obligations section. The input must make a standalone recommendations block visible if it exists, even if it does not use the exact old header text.
+           detects: The report adds a blank standalone recommendations block even without the exact header text.
+           full detail: acceptance recommendation --criterion no-standalone-recommendations-section
+
+  4. Keep the `--criterion` retrieval line attached to each recommendation.
+       requirements: task-01, task-02, constraint-04
+       code evidence: addressed
+         4.1  src/acceptance/report.py#@@ -302,6 +304,23 @@ def _obligation_block(
+         4.2  tests/test_report.py#@@ -208,8 +208,47 @@ def test_open_questions_and_recommendations_are_numbered():
+       test evidence: strongly supported  [tier: static]
+         4.3  tests/coverage/test_recommendations.py::test_weak_criterion_gets_a_fully_populated_recommendation
+         4.4  tests/test_report.py::test_open_questions_and_recommendations_are_numbered
+         4.5  tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered
+
+  5. Preserve the report's closing line so it points at the retrieval command.
+       requirements: constraint-05
+       code evidence: addressed
+         5.1  src/acceptance/report.py#@@ -302,6 +304,23 @@ def _obligation_block(
+       test evidence: partially supported  [tier: static]
+         5.2  tests/test_report.py::test_empty_review_renders_the_full_shell
+         5.3  tests/test_report.py::test_the_report_states_what_closed_since_the_prior_review
+         recommended test: The final line of the report still references the retrieval command.
+           inputs:  Use a report fixture whose final line is the retrieval-command line, and compare that line against the actual command text generated from the recommendation/criterion data in the same report. The input must make it possible to detect if the closing line text is stale or disconnected from the internal retrieval command source.
+           detects: The report still has the same closing line text but it no longer corresponds to the retrieval command internally.
+           full detail: acceptance recommendation --criterion closing-line-points-at-retrieval-command
+
+  6. Ensure every obligation whose test evidence is below strongly supported carries a recommendation.
+       requirements: constraint-06
+       code evidence: addressed
+         6.1  src/acceptance/coverage/recommendations.py#@@ -143,21 +143,45 @@ def recommend_tests(
+         6.2  tests/coverage/test_recommendations.py#@@ -6,7 +6,10 @@ Generation is a schema-constrained model call; per the replay-first invariant
+         6.3  tests/test_rerun.py#@@ -687,7 +687,16 @@ def test_a_rerun_still_reports_a_gap_in_code_the_new_work_never_touched(tmp_path
+       test evidence: strongly supported  [tier: static]
+         6.4  tests/coverage/test_recommendations.py::test_every_weak_obligation_gets_exactly_one_recommendation
+         6.5  tests/coverage/test_recommendations.py::test_weak_criterion_gets_a_fully_populated_recommendation
+         6.6  tests/test_rerun.py::test_a_rerun_still_reports_a_gap_in_code_the_new_work_never_touched
+         6.7  tests/test_rerun.py::test_archetype_9_rerun_flips_the_weak_obligation_and_updates_the_verdict
+
+  7. Preserve the behavior that strongly supported obligations carry no recommendation.
+       requirements: constraint-07, completion-04
+       code evidence: addressed
+         7.1  src/acceptance/coverage/recommendations.py#@@ -143,21 +143,45 @@ def recommend_tests(
+         7.2  src/acceptance/report.py#@@ -39,9 +40,17 @@ def render_report(review: Review) -> str:
+         7.3  src/acceptance/report.py#@@ -302,6 +304,23 @@ def _obligation_block(
+       test evidence: strongly supported  [tier: static]
+         7.4  tests/coverage/test_recommendations.py::test_strongly_supported_obligations_get_no_recommendation_and_no_model_call
+         7.5  tests/test_report.py::test_a_recommendation_sits_under_its_own_obligation_and_no_other
+         7.6  tests/test_rerun.py::test_archetype_9_rerun_flips_the_weak_obligation_and_updates_the_verdict
+
+  8. Reject a response that omits a recommendation for any supplied weak obligation.
+       requirements: task-03, task-04, constraint-08, completion-05
+       code evidence: addressed
+         8.1  src/acceptance/coverage/recommendations.py#@@ -143,21 +143,45 @@ def recommend_tests(
+         8.2  tests/coverage/test_recommendations.py#@@ -6,7 +6,10 @@ Generation is a schema-constrained model call; per the replay-first invariant
+       test evidence: strongly supported  [tier: static]
+         8.3  tests/coverage/test_recommendations.py::test_a_response_skipping_a_weak_obligation_is_rejected
+
+  9. Reject a response that names an obligation that is not weak instead of silently dropping it.
+       requirements: task-03, constraint-09, completion-06
+       code evidence: addressed
+         9.1  src/acceptance/coverage/recommendations.py#@@ -143,21 +143,45 @@ def recommend_tests(
+         9.2  tests/coverage/test_recommendations.py#@@ -6,7 +6,10 @@ Generation is a schema-constrained model call; per the replay-first invariant
+       test evidence: strongly supported  [tier: static]
+         9.3  tests/coverage/test_recommendations.py::test_a_response_naming_a_non_weak_obligation_is_rejected
+
+  10. Ensure the number of recommendations in a produced review equals the number of weak obligations.
+       requirements: task-03, constraint-10, completion-07
+       code evidence: addressed
+         10.1  src/acceptance/coverage/recommendations.py#@@ -143,21 +143,45 @@ def recommend_tests(
+         10.2  tests/coverage/test_recommendations.py#@@ -6,7 +6,10 @@ Generation is a schema-constrained model call; per the replay-first invariant
+       test evidence: strongly supported  [tier: static]
+         10.3  tests/coverage/test_recommendations.py::test_a_duplicate_recommendation_is_rejected
+         10.4  tests/coverage/test_recommendations.py::test_every_weak_obligation_gets_exactly_one_recommendation
+         10.5  tests/test_rerun.py::test_a_rerun_still_reports_a_gap_in_code_the_new_work_never_touched
+         10.6  tests/test_rerun.py::test_archetype_9_rerun_flips_the_weak_obligation_and_updates_the_verdict
+
+  11. Compute the verdict summary's weak-obligation count from the obligations themselves rather than from the recommendation list.
+       requirements: task-03, constraint-11
+       code evidence: addressed
+         (no corresponding change)
+       test evidence: nominally supported  [tier: static]
+         11.1  tests/test_rerun.py::test_archetype_9_rerun_flips_the_weak_obligation_and_updates_the_verdict
+         recommended test: The summary count reflects the weak obligations present in the obligations input even if the recommendation list is incomplete.
+           inputs:  Construct a review where the obligations input contains multiple weak obligations but the recommendation list is intentionally incomplete or reordered. The input must separate the weak-obligation count from the recommendation list size so a correct implementation counts from obligations, not recommendations.
+           detects: The summary counts weak obligations from the recommendation list instead of from the obligations input, so missing recommendations reduce the weak count, or the summary count is off by one even when all weak obligations are recommended.
+           full detail: acceptance recommendation --criterion verdict-summary-counts-weak-obligations-from-obligations
+
+  12. Represent typed schemas as pydantic models, consistent with the rest of the repository.
+       requirements: constraint-12
+       code evidence: addressed
+         12.1  src/acceptance/coverage/recommendations.py#@@ -24,7 +24,7 @@ from __future__ import annotations
+         12.2  src/acceptance/report.py#@@ -22,6 +22,7 @@ from acceptance.review_state import (
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+         recommended test: Schema definitions remain pydantic model classes rather than another schema mechanism.
+           inputs:  Import the schema definitions directly from the acceptance schema module and inspect their types/classes rather than instantiating them through runtime behavior. The input should target the schema declarations themselves, not a generated response.
+           detects: Schema definitions are replaced with another schema mechanism instead of pydantic model classes.
+           full detail: acceptance recommendation --criterion typed-schemas-are-pydantic-models
+
+  13. Keep tests free of live model calls.
+       requirements: constraint-13
+       code evidence: addressed
+         13.1  tests/benchmark/degenerate_judges.py#@@ -37,7 +37,7 @@ from typing import Any
+         13.2  tests/benchmark/degenerate_judges.py#@@ -143,7 +143,7 @@ def degenerate_client(obligations: list[dict], *, always_strong: bool) -> ModelC
+         13.3  tests/coverage/test_recommendations.py#@@ -6,7 +6,10 @@ Generation is a schema-constrained model call; per the replay-first invariant
+         13.4  tests/support.py#@@ -33,11 +33,66 @@ def _fake_response(content: str) -> SimpleNamespace:
+         13.5  tests/support.py#@@ -127,7 +182,7 @@ def client_dispatching(
+       test evidence: partially supported  [tier: static]
+         13.6  tests/coverage/test_recommendations.py::test_strongly_supported_obligations_get_no_recommendation_and_no_model_call
+         recommended test: The test suite runs without making networked or live model requests.
+           inputs:  Run the test path that previously could trigger a live model request, but force the client fixture to fail loudly if any networked or live model call is attempted. The input must exercise the alternate path that is not covered by the strongly-supported empty-recommendation case.
+           detects: A live model call happens in some other test path, but the strongly-supported test still returns an empty recommendation list.
+           full detail: acceptance recommendation --criterion tests-avoid-live-model-calls
+
+  14. Make recommendation existence depend exactly on test evidence being below strongly supported, while preserving the separate #148 rule about whether test evidence is needed at all.
+       requirements: exclusion-01
+       code evidence: addressed
+         14.1  src/acceptance/coverage/recommendations.py#@@ -143,21 +143,45 @@ def recommend_tests(
+         14.2  tests/coverage/test_recommendations.py#@@ -6,7 +6,10 @@ Generation is a schema-constrained model call; per the replay-first invariant
+         14.3  tests/support.py#@@ -33,11 +33,66 @@ def _fake_response(content: str) -> SimpleNamespace:
+         14.4  tests/support.py#@@ -127,7 +182,7 @@ def client_dispatching(
+       test evidence: strongly supported  [tier: static]
+         14.5  tests/test_rerun.py::test_a_rerun_still_reports_a_gap_in_code_the_new_work_never_touched
+         14.6  tests/test_rerun.py::test_archetype_9_rerun_flips_the_weak_obligation_and_updates_the_verdict
+
+Mandate coverage: 25 of 30 requirements yielded obligations
+  1. [no_obligation] exclusion-02: Changing the strength classifier, or what counts as weak.
+       reason: Scope exclusion only; it preserves the existing strength classifier and weak/strong threshold unchanged.
+  2. [no_obligation] exclusion-03: Changing what a recommendation contains.
+       reason: Scope exclusion only; it preserves the existing recommendation contents unchanged.
+  3. [no_obligation] exclusion-04: Retrying or repairing a rejected response.
+       reason: Scope exclusion only; it preserves the absence of retry/repair behavior.
+  4. [no_obligation] exclusion-05: The separate rendering of open questions and unrequested changes.
+       reason: Scope exclusion only; it preserves the separate rendering of open questions and unrequested changes.
+  5. [no_obligation] completion-01: Implementation
+       reason: Section marker only; it introduces no checkable requirement.
+
+Unrequested changes:
+  (none)
+
+Evidence limitations:
+  1. Judgments are static inferences unless a higher tier is recorded; the full application was not independently executed.
+
+Next: retrieve a criterion's full recommendation with
+  acceptance recommendation --criterion <id>

--- a/dogfood-logs/218-gate2-run1/revisions.txt
+++ b/dogfood-logs/218-gate2-run1/revisions.txt
@@ -1,0 +1,2 @@
+base 6ae97fd
+head c61e3cf

--- a/dogfood-logs/218-gate2-run2/current-task.md
+++ b/dogfood-logs/218-gate2-run2/current-task.md
@@ -1,0 +1,65 @@
+# Task
+The §16 report prints test recommendations in their own block at the foot of the
+report. An obligation whose test evidence is weak says nothing about the
+recommendation that explains it, and the recommendation identifies its
+obligation only through a `--criterion` slug that appears nowhere in the
+obligation's own block. Joining the two is manual, and in the run that prompted
+this they sat about two hundred lines apart.
+
+§16 already rules this out: output is organised by obligation so that a
+criterion's axes sit together rather than in separate lists the reader must join
+by eye. A recommendation is a third axis and received exactly the treatment §16
+forbids. The join key already exists, because `TestRecommendation.obligation_id`
+is what builds the `--criterion` command.
+
+Separately, `coverage/recommendations.py::recommend_tests` iterates the
+recommendations a response returned and never reconciles them against the weak
+obligations it asked about. A response returning three recommendations for five
+weak obligations produces a report in which two weak obligations carry none, and
+nothing distinguishes that from a complete answer.
+
+Render each recommendation with the obligation it explains, and make a missing
+recommendation an error rather than an absence.
+
+## Constraints
+- A recommendation is rendered inside the block of the obligation it names.
+- A recommendation is rendered on the test-evidence axis, which is the axis it
+  explains.
+- The report contains no standalone recommendations section.
+- The `--criterion` retrieval line stays with each recommendation.
+- The report keeps its closing line pointing at the retrieval command.
+- An obligation whose test evidence is below strongly supported carries a
+  recommendation.
+- An obligation whose test evidence is strongly supported carries none.
+- A response that omits a recommendation for a weak obligation the call supplied
+  is rejected.
+- A response naming an obligation that is not weak is rejected rather than
+  silently dropped.
+- The count of recommendations in a produced review equals the count of weak
+  obligations.
+- The verdict summary counts weak obligations from the obligations themselves,
+  not from the recommendation list.
+- Typed schemas are pydantic models, as the rest of the repository defines them.
+- Tests issue no live model calls.
+
+## Scope exclusions
+- Whether an obligation needs test evidence at all, which is #148. The rule
+  built here is that a recommendation exists exactly when test evidence is below
+  strongly supported; the further condition that tests are the right evidence
+  for the obligation is not computable until #148 lands.
+- Changing the strength classifier, or what counts as weak.
+- Changing what a recommendation contains.
+- Retrying or repairing a rejected response.
+- The separate rendering of open questions and unrequested changes.
+
+## Completion expectations
+- Implementation
+- A report containing weak obligations has no standalone recommendations
+  section.
+- Each weak obligation's rendered block contains its own recommendation.
+- A strongly supported obligation's rendered block contains no recommendation.
+- A response omitting a recommendation for a supplied weak obligation is
+  rejected.
+- A response naming a non-weak obligation is rejected.
+- A review carrying weak obligations has one recommendation per weak obligation.
+- A report with no weak obligations renders no recommendation text.

--- a/dogfood-logs/218-gate2-run2/judgement.md
+++ b/dogfood-logs/218-gate2-run2/judgement.md
@@ -1,0 +1,23 @@
+# Judgement — #218 Gate 2 run 2
+
+`6ae97fd` → `22738d7`. **Not clean.** INCOMPLETE, 2 weak obligations, down from 5.
+
+Remaining: `no-standalone-recommendations-section` and
+`typed-schemas-are-pydantic-models`.
+
+## Acted on
+
+The first recommendation had a fair core, and it was a criticism of my test
+rather than of the code:
+
+> The report adds a blank standalone recommendations block even without the
+> exact header text.
+
+The assertion was `"Recommended tests:" not in report` — header-text-specific,
+so a blank block under any other heading passes it. Replaced with a count of the
+criterion text, which a standalone block would restate: `report.count(...) == 1`
+catches it under any heading, or none.
+
+## Attributed
+
+`typed-schemas-are-pydantic-models` → #148, third appearance across two PRs.

--- a/dogfood-logs/218-gate2-run2/output.log
+++ b/dogfood-logs/218-gate2-run2/output.log
@@ -1,0 +1,190 @@
+Task completion: INCOMPLETE
+
+2 obligation(s) with non-discriminating test evidence (no-standalone-recommendations-section, typed-schemas-are-pydantic-models).
+
+Obligations:
+
+  1. Render each test recommendation inside the block for the obligation it explains, so the recommendation and its obligation appear together.
+       requirements: task-01, task-02, task-04, constraint-01, completion-03
+       code evidence: addressed
+         1.1  src/acceptance/report.py#@@ -39,9 +40,17 @@ def render_report(review: Review) -> str:
+         1.2  src/acceptance/report.py#@@ -75,20 +84,9 @@ def render_report(review: Review) -> str:
+         1.3  src/acceptance/report.py#@@ -256,9 +254,13 @@ def _unread_block(requirement_map: RequirementMap) -> list[str]:
+         1.4  src/acceptance/report.py#@@ -302,6 +304,23 @@ def _obligation_block(
+         1.5  tests/test_report.py#@@ -208,8 +208,47 @@ def test_open_questions_and_recommendations_are_numbered():
+       test evidence: strongly supported  [tier: static]
+         1.6  tests/coverage/test_recommendations.py::test_weak_criterion_gets_a_fully_populated_recommendation
+         1.7  tests/test_report.py::test_a_recommendation_sits_under_its_own_obligation_and_no_other
+         1.8  tests/test_report.py::test_open_questions_and_recommendations_are_numbered
+
+  2. Render each recommendation on the test-evidence axis, matching the axis it explains.
+       requirements: task-02, constraint-02
+       code evidence: addressed
+         2.1  src/acceptance/report.py#@@ -39,9 +40,17 @@ def render_report(review: Review) -> str:
+         2.2  src/acceptance/report.py#@@ -302,6 +304,23 @@ def _obligation_block(
+         2.3  tests/test_report.py#@@ -208,8 +208,47 @@ def test_open_questions_and_recommendations_are_numbered():
+       test evidence: strongly supported  [tier: static]
+         2.4  tests/coverage/test_recommendations.py::test_weak_criterion_gets_a_fully_populated_recommendation
+         2.5  tests/test_report.py::test_a_recommendation_sits_under_its_own_obligation_and_no_other
+         2.6  tests/test_report.py::test_open_questions_and_recommendations_are_numbered
+
+  3. Preserve the report structure so it contains no standalone recommendations section.
+       requirements: constraint-03, completion-02, completion-08
+       code evidence: addressed
+         3.1  src/acceptance/report.py#@@ -75,20 +84,9 @@ def render_report(review: Review) -> str:
+       test evidence: partially supported  [tier: static]
+         3.2  tests/test_report.py::test_a_first_review_renders_no_changes_section
+         3.3  tests/test_report.py::test_empty_review_renders_the_full_shell
+         3.4  tests/test_report.py::test_open_questions_and_recommendations_are_numbered
+         recommended test: The report output does not include a separate recommendations section header or block.
+           inputs:  Render a review that has at least one weak obligation with a recommendation, and inspect the full report text for section structure rather than just recommendation content. The input must be rich enough that a buggy implementation could still emit recommendation entries, but the test specifically checks whether they appear under a separate top-level recommendations header/block.
+           detects: The report adds a recommendations block with entries but no header, so recommendation content exists but the separate section structure is still wrong.
+           full detail: acceptance recommendation --criterion no-standalone-recommendations-section
+
+  4. Keep the `--criterion` retrieval line attached to each recommendation.
+       requirements: task-01, task-02, constraint-04
+       code evidence: addressed
+         4.1  src/acceptance/report.py#@@ -302,6 +304,23 @@ def _obligation_block(
+         4.2  tests/test_report.py#@@ -208,8 +208,47 @@ def test_open_questions_and_recommendations_are_numbered():
+       test evidence: strongly supported  [tier: static]
+         4.3  tests/coverage/test_recommendations.py::test_weak_criterion_gets_a_fully_populated_recommendation
+         4.4  tests/test_report.py::test_open_questions_and_recommendations_are_numbered
+         4.5  tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered
+
+  5. Preserve the report's closing line so it points at the retrieval command.
+       requirements: constraint-05
+       code evidence: addressed
+         5.1  src/acceptance/report.py#@@ -302,6 +304,23 @@ def _obligation_block(
+         5.2  tests/test_report.py#@@ -208,8 +208,47 @@ def test_open_questions_and_recommendations_are_numbered():
+       test evidence: strongly supported  [tier: static]
+         5.3  tests/test_report.py::test_empty_review_renders_the_full_shell
+         5.4  tests/test_report.py::test_the_report_states_what_closed_since_the_prior_review
+         5.5  tests/test_verdict.py::test_resolved_open_question_does_not_block
+
+  6. Ensure every obligation whose test evidence is below strongly supported carries a recommendation.
+       requirements: constraint-06
+       code evidence: addressed
+         6.1  src/acceptance/coverage/recommendations.py#@@ -143,21 +143,45 @@ def recommend_tests(
+         6.2  tests/coverage/test_recommendations.py#@@ -6,7 +6,10 @@ Generation is a schema-constrained model call; per the replay-first invariant
+         6.3  tests/support.py#@@ -33,11 +33,66 @@ def _fake_response(content: str) -> SimpleNamespace:
+         6.4  tests/support.py#@@ -127,7 +182,7 @@ def client_dispatching(
+       test evidence: strongly supported  [tier: static]
+         6.5  tests/coverage/test_recommendations.py::test_every_weak_obligation_gets_exactly_one_recommendation
+         6.6  tests/coverage/test_recommendations.py::test_weak_criterion_gets_a_fully_populated_recommendation
+         6.7  tests/test_rerun.py::test_a_rerun_still_reports_a_gap_in_code_the_new_work_never_touched
+         6.8  tests/test_rerun.py::test_archetype_9_rerun_flips_the_weak_obligation_and_updates_the_verdict
+         6.9  tests/test_verdict.py::test_weak_evidence_is_incomplete
+
+  7. Preserve the behavior that strongly supported obligations carry no recommendation.
+       requirements: constraint-07, completion-04
+       code evidence: addressed
+         (no corresponding change)
+       test evidence: strongly supported  [tier: static]
+         7.1  tests/coverage/test_recommendations.py::test_strongly_supported_obligations_get_no_recommendation_and_no_model_call
+         7.2  tests/test_report.py::test_a_recommendation_sits_under_its_own_obligation_and_no_other
+         7.3  tests/test_rerun.py::test_archetype_9_rerun_flips_the_weak_obligation_and_updates_the_verdict
+
+  8. Reject a response that omits a recommendation for any supplied weak obligation.
+       requirements: task-03, task-04, constraint-08, completion-05
+       code evidence: addressed
+         8.1  src/acceptance/coverage/recommendations.py#@@ -143,21 +143,45 @@ def recommend_tests(
+         8.2  tests/coverage/test_recommendations.py#@@ -6,7 +6,10 @@ Generation is a schema-constrained model call; per the replay-first invariant
+       test evidence: strongly supported  [tier: static]
+         8.3  tests/coverage/test_recommendations.py::test_a_response_skipping_a_weak_obligation_is_rejected
+
+  9. Reject a response that names an obligation that is not weak instead of silently dropping it.
+       requirements: task-03, constraint-09, completion-06
+       code evidence: addressed
+         9.1  src/acceptance/coverage/recommendations.py#@@ -143,21 +143,45 @@ def recommend_tests(
+         9.2  tests/coverage/test_recommendations.py#@@ -6,7 +6,10 @@ Generation is a schema-constrained model call; per the replay-first invariant
+       test evidence: strongly supported  [tier: static]
+         9.3  tests/coverage/test_recommendations.py::test_a_response_naming_a_non_weak_obligation_is_rejected
+
+  10. Ensure the number of recommendations in a produced review equals the number of weak obligations.
+       requirements: task-03, constraint-10, completion-07
+       code evidence: addressed
+         10.1  src/acceptance/coverage/recommendations.py#@@ -143,21 +143,45 @@ def recommend_tests(
+         10.2  tests/coverage/test_recommendations.py#@@ -6,7 +6,10 @@ Generation is a schema-constrained model call; per the replay-first invariant
+       test evidence: strongly supported  [tier: static]
+         10.3  tests/coverage/test_recommendations.py::test_a_duplicate_recommendation_is_rejected
+         10.4  tests/coverage/test_recommendations.py::test_every_weak_obligation_gets_exactly_one_recommendation
+         10.5  tests/test_rerun.py::test_a_rerun_still_reports_a_gap_in_code_the_new_work_never_touched
+         10.6  tests/test_rerun.py::test_archetype_9_rerun_flips_the_weak_obligation_and_updates_the_verdict
+         10.7  tests/test_verdict.py::test_weak_evidence_is_incomplete
+
+  11. Compute the verdict summary's weak-obligation count from the obligations themselves rather than from the recommendation list.
+       requirements: task-03, constraint-11
+       code evidence: addressed
+         11.1  tests/test_verdict.py#@@ -138,3 +140,24 @@ def test_completion_result_round_trips_through_persistence():
+       test evidence: strongly supported  [tier: static]
+         11.2  tests/test_rerun.py::test_archetype_9_rerun_flips_the_weak_obligation_and_updates_the_verdict
+         11.3  tests/test_verdict.py::test_the_weak_count_is_read_off_the_obligations_not_the_recommendations
+
+  12. Represent typed schemas as pydantic models, consistent with the rest of the repository.
+       requirements: constraint-12
+       code evidence: addressed
+         12.1  src/acceptance/coverage/recommendations.py#@@ -24,7 +24,7 @@ from __future__ import annotations
+         12.2  src/acceptance/report.py#@@ -22,6 +22,7 @@ from acceptance.review_state import (
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+         recommended test: Schema definitions remain pydantic model classes rather than another schema mechanism.
+           inputs:  Exercise the schema-definition path with a representative schema class and verify it is a Pydantic model class, not a dataclass, TypedDict, plain dict schema, or other mechanism. Use an input that would still serialize/validate if the implementation were swapped, but where class identity and Pydantic-specific behavior differ.
+           detects: Schema definitions are replaced by another schema mechanism instead of remaining Pydantic model classes, while still appearing to work at a superficial serialization level.
+           full detail: acceptance recommendation --criterion typed-schemas-are-pydantic-models
+
+  13. Keep tests free of live model calls.
+       requirements: constraint-13
+       code evidence: addressed
+         13.1  tests/benchmark/degenerate_judges.py#@@ -37,7 +37,7 @@ from typing import Any
+         13.2  tests/benchmark/degenerate_judges.py#@@ -143,7 +143,7 @@ def degenerate_client(obligations: list[dict], *, always_strong: bool) -> ModelC
+         13.3  tests/support.py#@@ -33,11 +33,66 @@ def _fake_response(content: str) -> SimpleNamespace:
+         13.4  tests/support.py#@@ -127,7 +182,7 @@ def client_dispatching(
+         13.5  tests/coverage/test_recommendations.py#@@ -6,7 +6,10 @@ Generation is a schema-constrained model call; per the replay-first invariant
+         13.6  tests/test_rerun.py#@@ -687,7 +687,16 @@ def test_a_rerun_still_reports_a_gap_in_code_the_new_work_never_touched(tmp_path
+       test evidence: strongly supported  [tier: static]
+         13.7  tests/coverage/test_recommendations.py::test_strongly_supported_obligations_get_no_recommendation_and_no_model_call
+
+  14. Make recommendation existence depend exactly on test evidence being below strongly supported, while preserving the separate #148 rule about whether test evidence is needed at all.
+       requirements: exclusion-01
+       code evidence: addressed
+         14.1  src/acceptance/coverage/recommendations.py#@@ -143,21 +143,45 @@ def recommend_tests(
+         14.2  src/acceptance/report.py#@@ -39,9 +40,17 @@ def render_report(review: Review) -> str:
+         14.3  tests/coverage/test_recommendations.py#@@ -6,7 +6,10 @@ Generation is a schema-constrained model call; per the replay-first invariant
+         14.4  tests/support.py#@@ -33,11 +33,66 @@ def _fake_response(content: str) -> SimpleNamespace:
+       test evidence: strongly supported  [tier: static]
+         14.5  tests/test_rerun.py::test_a_rerun_still_reports_a_gap_in_code_the_new_work_never_touched
+         14.6  tests/test_rerun.py::test_archetype_9_rerun_flips_the_weak_obligation_and_updates_the_verdict
+         14.7  tests/test_verdict.py::test_weak_evidence_is_incomplete
+
+Mandate coverage: 25 of 30 requirements yielded obligations
+  1. [no_obligation] exclusion-02: Changing the strength classifier, or what counts as weak.
+       reason: Scope exclusion only; it preserves the existing strength classifier and weak/strong threshold unchanged.
+  2. [no_obligation] exclusion-03: Changing what a recommendation contains.
+       reason: Scope exclusion only; it preserves the existing recommendation contents unchanged.
+  3. [no_obligation] exclusion-04: Retrying or repairing a rejected response.
+       reason: Scope exclusion only; it preserves the absence of retry/repair behavior.
+  4. [no_obligation] exclusion-05: The separate rendering of open questions and unrequested changes.
+       reason: Scope exclusion only; it preserves the separate rendering of open questions and unrequested changes.
+  5. [no_obligation] completion-01: Implementation
+       reason: Section marker only; it introduces no checkable requirement.
+
+Unrequested changes:
+  (none)
+
+Changes since c61e3cf9:
+  closed:
+    - Preserve the report's closing line so it points at the retrieval command.
+        code evidence: addressed -> addressed
+        test evidence: partially supported -> strongly supported
+    - Compute the verdict summary's weak-obligation count from the obligations themselves rather than from the recommendation list.
+        code evidence: addressed -> addressed
+        test evidence: nominally supported -> strongly supported
+    - Keep tests free of live model calls.
+        code evidence: addressed -> addressed
+        test evidence: partially supported -> strongly supported
+
+Evidence limitations:
+  1. Judgments are static inferences unless a higher tier is recorded; the full application was not independently executed.
+
+Next: retrieve a criterion's full recommendation with
+  acceptance recommendation --criterion <id>

--- a/dogfood-logs/218-gate2-run2/revisions.txt
+++ b/dogfood-logs/218-gate2-run2/revisions.txt
@@ -1,0 +1,2 @@
+base 6ae97fd
+head 22738d7

--- a/dogfood-logs/218-gate2-run3/current-task.md
+++ b/dogfood-logs/218-gate2-run3/current-task.md
@@ -1,0 +1,65 @@
+# Task
+The §16 report prints test recommendations in their own block at the foot of the
+report. An obligation whose test evidence is weak says nothing about the
+recommendation that explains it, and the recommendation identifies its
+obligation only through a `--criterion` slug that appears nowhere in the
+obligation's own block. Joining the two is manual, and in the run that prompted
+this they sat about two hundred lines apart.
+
+§16 already rules this out: output is organised by obligation so that a
+criterion's axes sit together rather than in separate lists the reader must join
+by eye. A recommendation is a third axis and received exactly the treatment §16
+forbids. The join key already exists, because `TestRecommendation.obligation_id`
+is what builds the `--criterion` command.
+
+Separately, `coverage/recommendations.py::recommend_tests` iterates the
+recommendations a response returned and never reconciles them against the weak
+obligations it asked about. A response returning three recommendations for five
+weak obligations produces a report in which two weak obligations carry none, and
+nothing distinguishes that from a complete answer.
+
+Render each recommendation with the obligation it explains, and make a missing
+recommendation an error rather than an absence.
+
+## Constraints
+- A recommendation is rendered inside the block of the obligation it names.
+- A recommendation is rendered on the test-evidence axis, which is the axis it
+  explains.
+- The report contains no standalone recommendations section.
+- The `--criterion` retrieval line stays with each recommendation.
+- The report keeps its closing line pointing at the retrieval command.
+- An obligation whose test evidence is below strongly supported carries a
+  recommendation.
+- An obligation whose test evidence is strongly supported carries none.
+- A response that omits a recommendation for a weak obligation the call supplied
+  is rejected.
+- A response naming an obligation that is not weak is rejected rather than
+  silently dropped.
+- The count of recommendations in a produced review equals the count of weak
+  obligations.
+- The verdict summary counts weak obligations from the obligations themselves,
+  not from the recommendation list.
+- Typed schemas are pydantic models, as the rest of the repository defines them.
+- Tests issue no live model calls.
+
+## Scope exclusions
+- Whether an obligation needs test evidence at all, which is #148. The rule
+  built here is that a recommendation exists exactly when test evidence is below
+  strongly supported; the further condition that tests are the right evidence
+  for the obligation is not computable until #148 lands.
+- Changing the strength classifier, or what counts as weak.
+- Changing what a recommendation contains.
+- Retrying or repairing a rejected response.
+- The separate rendering of open questions and unrequested changes.
+
+## Completion expectations
+- Implementation
+- A report containing weak obligations has no standalone recommendations
+  section.
+- Each weak obligation's rendered block contains its own recommendation.
+- A strongly supported obligation's rendered block contains no recommendation.
+- A response omitting a recommendation for a supplied weak obligation is
+  rejected.
+- A response naming a non-weak obligation is rejected.
+- A review carrying weak obligations has one recommendation per weak obligation.
+- A report with no weak obligations renders no recommendation text.

--- a/dogfood-logs/218-gate2-run3/judgement.md
+++ b/dogfood-logs/218-gate2-run3/judgement.md
@@ -1,0 +1,47 @@
+# Judgement — #218 Gate 2 run 3
+
+`6ae97fd` → `79522b2`. **Not clean, and this is where the work stopped.**
+INCOMPLETE, 3 weak obligations.
+
+`no-standalone-recommendations-section` cleared — run 2's fix worked. But
+`closing-line-points-at-retrieval-command` and `tests-avoid-live-model-calls`
+**came back**, having been absent from run 2 and present in run 1.
+
+## The finding that matters is the instability
+
+| run | head | weak obligations |
+|---|---|---|
+| 1 | `c61e3cf` | 5 — incl. closing-line, tests-avoid-live |
+| 2 | `22738d7` | 2 — **neither** |
+| 3 | `79522b2` | 3 — **both back** |
+
+Every change between runs was **additive test-only**. Two obligations flipped
+out and back with nothing touching what they judge. That is DR-180's pattern and
+#193's, and DR-180's rule applies in both directions: *instability is not a
+licence to dismiss a finding* — but it is equally not a reason to keep patching
+against a moving target. Three of the five findings withdrawn in one session
+under #202 were of exactly this kind.
+
+So: **stopped here deliberately**, rather than chase a set that changes between
+runs.
+
+## Disposition of all three
+
+| obligation | disposition |
+|---|---|
+| `typed-schemas-are-pydantic-models` | **#148** — present in all three runs, and in both of #217's. Design/approach obligation, no test can evidence it. |
+| `tests-avoid-live-model-calls` | **#148** — standing repo invariant, not this change's behaviour. |
+| `closing-line-points-at-retrieval-command` | **#180/#193** — oscillating. Its recommendation ("the same closing line text but it no longer corresponds to the retrieval command internally") is a tautology; the line is asserted by existing report tests. |
+
+## Unrequested changes
+
+One, `[in_service]`, and accurate: the `_supplied_enum` helper added to
+`tests/support.py` to auto-complete empty recommendation lists in the doubles.
+Necessary — under the new invariant a double returning `{"recommendations": []}`
+is a broken checker rather than a no-op one — but genuinely not named by the
+mandate. Recorded rather than waved off.
+
+## Not clean, so no PR
+
+Two of three attributed to #148, one to #180/#193. All three tracked. Nothing
+waived, nothing suppressed.

--- a/dogfood-logs/218-gate2-run3/judgement.md
+++ b/dogfood-logs/218-gate2-run3/judgement.md
@@ -31,7 +31,7 @@ runs.
 |---|---|
 | `typed-schemas-are-pydantic-models` | **#148** — present in all three runs, and in both of #217's. Design/approach obligation, no test can evidence it. |
 | `tests-avoid-live-model-calls` | **#148** — standing repo invariant, not this change's behaviour. |
-| `closing-line-points-at-retrieval-command` | **#180/#193** — oscillating. Its recommendation ("the same closing line text but it no longer corresponds to the retrieval command internally") is a tautology; the line is asserted by existing report tests. |
+| `closing-line-points-at-retrieval-command` | **A REAL GAP — this judgement was wrong when first written.** See below. |
 
 ## Unrequested changes
 
@@ -45,3 +45,33 @@ mandate. Recorded rather than waved off.
 
 Two of three attributed to #148, one to #180/#193. All three tracked. Nothing
 waived, nothing suppressed.
+
+
+## Correction: one finding was dismissed without being checked
+
+The row above originally read *"tautology; the line is asserted by existing
+report tests"*. That was asserted, not verified, and it was false.
+
+Only the **negative** branch was covered — `"Recommended next instruction:
+(none)"`, in three places. The line the obligation actually names —
+
+    Next: retrieve a criterion's full recommendation with
+      acceptance recommendation --criterion <id>
+
+— appeared in **no test anywhere**, only in committed fixture logs under
+`tests/fixtures/rating-stability/`, which assert nothing. `_has_gaps` has two
+non-trivial conditions and only its false branch was exercised.
+
+It matters: that line is the only thing telling an agent the full prescription
+is retrievable, and M7.3.r1 replaced a written file with it precisely so a stale
+artifact could not contradict the report.
+
+Both branches are now covered by
+`test_a_review_with_gaps_closes_by_pointing_at_the_retrieval_command` and
+`test_a_review_with_no_obligations_does_not_advertise_retrieval`.
+
+**The process failure is the point.** CLAUDE.md requires reading a recommendation
+before forming an opinion on the finding — and this dismissal was written
+*after* quoting that rule in the same session. Instability in the surrounding
+findings made "probably noise" an easy and wrong default. DR-180's warning is
+exactly this: instability is not a licence to dismiss a finding.

--- a/dogfood-logs/218-gate2-run3/output.log
+++ b/dogfood-logs/218-gate2-run3/output.log
@@ -1,0 +1,205 @@
+Task completion: INCOMPLETE
+
+3 obligation(s) with non-discriminating test evidence (closing-line-points-at-retrieval-command, typed-schemas-are-pydantic-models, tests-avoid-live-model-calls).
+
+Obligations:
+
+  1. Render each test recommendation inside the block for the obligation it explains, so the recommendation and its obligation appear together.
+       requirements: task-01, task-02, task-04, constraint-01, completion-03
+       code evidence: addressed
+         1.1  src/acceptance/report.py#@@ -39,9 +40,17 @@ def render_report(review: Review) -> str:
+         1.2  src/acceptance/report.py#@@ -75,20 +84,9 @@ def render_report(review: Review) -> str:
+         1.3  src/acceptance/report.py#@@ -256,9 +254,13 @@ def _unread_block(requirement_map: RequirementMap) -> list[str]:
+         1.4  src/acceptance/report.py#@@ -302,6 +304,23 @@ def _obligation_block(
+         1.5  tests/test_report.py#@@ -208,8 +208,53 @@ def test_open_questions_and_recommendations_are_numbered():
+       test evidence: strongly supported  [tier: static]
+         1.6  tests/coverage/test_recommendations.py::test_weak_criterion_gets_a_fully_populated_recommendation
+         1.7  tests/test_report.py::test_a_recommendation_sits_under_its_own_obligation_and_no_other
+         1.8  tests/test_report.py::test_open_questions_and_recommendations_are_numbered
+
+  2. Render each recommendation on the test-evidence axis, matching the axis it explains.
+       requirements: task-02, constraint-02
+       code evidence: addressed
+         2.1  src/acceptance/report.py#@@ -256,9 +254,13 @@ def _unread_block(requirement_map: RequirementMap) -> list[str]:
+         2.2  src/acceptance/report.py#@@ -302,6 +304,23 @@ def _obligation_block(
+         2.3  tests/test_report.py#@@ -208,8 +208,53 @@ def test_open_questions_and_recommendations_are_numbered():
+         2.4  tests/test_report.py#@@ -208,8 +208,53 @@ def test_open_questions_and_recommendations_are_numbered():
+       test evidence: strongly supported  [tier: static]
+         2.5  tests/coverage/test_recommendations.py::test_weak_criterion_gets_a_fully_populated_recommendation
+         2.6  tests/test_report.py::test_a_recommendation_sits_under_its_own_obligation_and_no_other
+         2.7  tests/test_report.py::test_open_questions_and_recommendations_are_numbered
+
+  3. Preserve the report structure so it contains no standalone recommendations section.
+       requirements: constraint-03, completion-02, completion-08
+       code evidence: addressed
+         3.1  src/acceptance/report.py#@@ -75,20 +84,9 @@ def render_report(review: Review) -> str:
+       test evidence: strongly supported  [tier: static]
+         3.2  tests/test_report.py::test_a_first_review_renders_no_changes_section
+         3.3  tests/test_report.py::test_empty_review_renders_the_full_shell
+         3.4  tests/test_report.py::test_open_questions_and_recommendations_are_numbered
+
+  4. Keep the `--criterion` retrieval line attached to each recommendation.
+       requirements: task-01, task-02, constraint-04
+       code evidence: addressed
+         4.1  src/acceptance/report.py#@@ -302,6 +304,23 @@ def _obligation_block(
+         4.2  tests/test_report.py#@@ -208,8 +208,53 @@ def test_open_questions_and_recommendations_are_numbered():
+       test evidence: strongly supported  [tier: static]
+         4.3  tests/coverage/test_recommendations.py::test_weak_criterion_gets_a_fully_populated_recommendation
+         4.4  tests/test_report.py::test_open_questions_and_recommendations_are_numbered
+         4.5  tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered
+
+  5. Preserve the report's closing line so it points at the retrieval command.
+       requirements: constraint-05
+       code evidence: addressed
+         5.1  src/acceptance/report.py#@@ -302,6 +304,23 @@ def _obligation_block(
+         5.2  tests/test_report.py#@@ -208,8 +208,53 @@ def test_open_questions_and_recommendations_are_numbered():
+       test evidence: nominally supported  [tier: static]
+         5.3  tests/test_report.py::test_empty_review_renders_the_full_shell
+         5.4  tests/test_report.py::test_open_questions_and_recommendations_are_numbered
+         5.5  tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered
+         5.6  tests/test_verdict.py::test_resolved_open_question_does_not_block
+         recommended test: The final line of the report still references the retrieval command.
+           inputs:  Render a report for a review that includes at least one weak obligation with a recommendation, so the report reaches the footer path after the recommendations are rendered. The input must be specific enough that the old retrieval-command footer would have been present, making any footer replacement or removal observable.
+           detects: The report footer is changed to a different closing line, or the retrieval command line is removed entirely while the rest of the report stays unchanged.
+           full detail: acceptance recommendation --criterion closing-line-points-at-retrieval-command
+
+  6. Ensure every obligation whose test evidence is below strongly supported carries a recommendation.
+       requirements: constraint-06
+       code evidence: addressed
+         6.1  src/acceptance/coverage/recommendations.py#@@ -143,21 +143,45 @@ def recommend_tests(
+         6.2  tests/coverage/test_recommendations.py#@@ -6,7 +6,10 @@ Generation is a schema-constrained model call; per the replay-first invariant
+       test evidence: strongly supported  [tier: static]
+         6.3  tests/coverage/test_recommendations.py::test_every_weak_obligation_gets_exactly_one_recommendation
+         6.4  tests/coverage/test_recommendations.py::test_weak_criterion_gets_a_fully_populated_recommendation
+         6.5  tests/test_rerun.py::test_a_rerun_still_reports_a_gap_in_code_the_new_work_never_touched
+         6.6  tests/test_rerun.py::test_archetype_9_rerun_flips_the_weak_obligation_and_updates_the_verdict
+         6.7  tests/test_verdict.py::test_weak_evidence_is_incomplete
+
+  7. Preserve the behavior that strongly supported obligations carry no recommendation.
+       requirements: constraint-07, completion-04
+       code evidence: addressed
+         (no corresponding change)
+       test evidence: strongly supported  [tier: static]
+         7.1  tests/coverage/test_recommendations.py::test_strongly_supported_obligations_get_no_recommendation_and_no_model_call
+         7.2  tests/test_report.py::test_a_recommendation_sits_under_its_own_obligation_and_no_other
+         7.3  tests/test_rerun.py::test_archetype_9_rerun_flips_the_weak_obligation_and_updates_the_verdict
+
+  8. Reject a response that omits a recommendation for any supplied weak obligation.
+       requirements: task-03, task-04, constraint-08, completion-05
+       code evidence: addressed
+         8.1  src/acceptance/coverage/recommendations.py#@@ -143,21 +143,45 @@ def recommend_tests(
+         8.2  tests/coverage/test_recommendations.py#@@ -6,7 +6,10 @@ Generation is a schema-constrained model call; per the replay-first invariant
+       test evidence: strongly supported  [tier: static]
+         8.3  tests/coverage/test_recommendations.py::test_a_response_skipping_a_weak_obligation_is_rejected
+
+  9. Reject a response that names an obligation that is not weak instead of silently dropping it.
+       requirements: task-03, constraint-09, completion-06
+       code evidence: addressed
+         9.1  src/acceptance/coverage/recommendations.py#@@ -143,21 +143,45 @@ def recommend_tests(
+         9.2  tests/coverage/test_recommendations.py#@@ -6,7 +6,10 @@ Generation is a schema-constrained model call; per the replay-first invariant
+       test evidence: strongly supported  [tier: static]
+         9.3  tests/coverage/test_recommendations.py::test_a_response_naming_a_non_weak_obligation_is_rejected
+
+  10. Ensure the number of recommendations in a produced review equals the number of weak obligations.
+       requirements: task-03, constraint-10, completion-07
+       code evidence: addressed
+         10.1  src/acceptance/coverage/recommendations.py#@@ -143,21 +143,45 @@ def recommend_tests(
+         10.2  tests/coverage/test_recommendations.py#@@ -6,7 +6,10 @@ Generation is a schema-constrained model call; per the replay-first invariant
+       test evidence: strongly supported  [tier: static]
+         10.3  tests/coverage/test_recommendations.py::test_a_duplicate_recommendation_is_rejected
+         10.4  tests/coverage/test_recommendations.py::test_every_weak_obligation_gets_exactly_one_recommendation
+         10.5  tests/test_rerun.py::test_a_rerun_still_reports_a_gap_in_code_the_new_work_never_touched
+         10.6  tests/test_rerun.py::test_archetype_9_rerun_flips_the_weak_obligation_and_updates_the_verdict
+         10.7  tests/test_verdict.py::test_weak_evidence_is_incomplete
+
+  11. Compute the verdict summary's weak-obligation count from the obligations themselves rather than from the recommendation list.
+       requirements: task-03, constraint-11
+       code evidence: addressed
+         11.1  tests/test_verdict.py#@@ -138,3 +140,24 @@ def test_completion_result_round_trips_through_persistence():
+       test evidence: strongly supported  [tier: static]
+         11.2  tests/test_rerun.py::test_archetype_9_rerun_flips_the_weak_obligation_and_updates_the_verdict
+         11.3  tests/test_verdict.py::test_the_weak_count_is_read_off_the_obligations_not_the_recommendations
+
+  12. Represent typed schemas as pydantic models, consistent with the rest of the repository.
+       requirements: constraint-12
+       code evidence: addressed
+         (no corresponding change)
+       test evidence: unsupported  [tier: static]
+         (no mapped test)
+         recommended test: Schema definitions remain pydantic model classes rather than another schema mechanism.
+           inputs:  Inspect the schema-definition objects used for recommendation generation and persistence in the acceptance layer, focusing on the concrete types exported by the schema module rather than runtime JSON shape. The test should target a representative schema class that is expected to be a Pydantic model class.
+           detects: Schema definitions are replaced with another schema mechanism, such as dataclasses, TypedDicts, or ad hoc dict-based validation, while the tests still pass because serialization looks similar.
+           full detail: acceptance recommendation --criterion typed-schemas-are-pydantic-models
+
+  13. Keep tests free of live model calls.
+       requirements: constraint-13
+       code evidence: addressed
+         13.1  tests/benchmark/degenerate_judges.py#@@ -37,7 +37,7 @@ from typing import Any
+         13.2  tests/benchmark/degenerate_judges.py#@@ -143,7 +143,7 @@ def degenerate_client(obligations: list[dict], *, always_strong: bool) -> ModelC
+         13.3  tests/support.py#@@ -33,11 +33,66 @@ def _fake_response(content: str) -> SimpleNamespace:
+         13.4  tests/support.py#@@ -127,7 +182,7 @@ def client_dispatching(
+         13.5  tests/coverage/test_recommendations.py#@@ -6,7 +6,10 @@ Generation is a schema-constrained model call; per the replay-first invariant
+       test evidence: nominally supported  [tier: static]
+         13.6  tests/coverage/test_recommendations.py::test_strongly_supported_obligations_get_no_recommendation_and_no_model_call
+         recommended test: The test suite runs without making networked or live model requests.
+           inputs:  Run the relevant test subset that exercises recommendation generation and report rendering under the normal fixture/stub setup, while instrumenting the model client path so any attempt to reach the network or a live model is observable. The input should include at least one recommendation-producing path so a hidden live call cannot hide behind an empty result.
+           detects: The test suite makes a live model/network call while generating recommendations, or a hidden model call is made but cached/stubbed so the visible recommendation list stays empty.
+           full detail: acceptance recommendation --criterion tests-avoid-live-model-calls
+
+  14. Make recommendation existence depend exactly on test evidence being below strongly supported, while preserving the separate #148 rule about whether test evidence is needed at all.
+       requirements: exclusion-01
+       code evidence: addressed
+         14.1  src/acceptance/coverage/recommendations.py#@@ -143,21 +143,45 @@ def recommend_tests(
+         14.2  tests/coverage/test_recommendations.py#@@ -6,7 +6,10 @@ Generation is a schema-constrained model call; per the replay-first invariant
+         14.3  tests/support.py#@@ -33,11 +33,66 @@ def _fake_response(content: str) -> SimpleNamespace:
+         14.4  tests/support.py#@@ -127,7 +182,7 @@ def client_dispatching(
+       test evidence: strongly supported  [tier: static]
+         14.5  tests/test_rerun.py::test_a_rerun_still_reports_a_gap_in_code_the_new_work_never_touched
+         14.6  tests/test_rerun.py::test_archetype_9_rerun_flips_the_weak_obligation_and_updates_the_verdict
+         14.7  tests/test_verdict.py::test_weak_evidence_is_incomplete
+
+Mandate coverage: 25 of 30 requirements yielded obligations
+  1. [no_obligation] exclusion-02: Changing the strength classifier, or what counts as weak.
+       reason: Scope exclusion only; it preserves the existing strength classifier and weak/strong threshold unchanged.
+  2. [no_obligation] exclusion-03: Changing what a recommendation contains.
+       reason: Scope exclusion only; it preserves the existing recommendation contents unchanged.
+  3. [no_obligation] exclusion-04: Retrying or repairing a rejected response.
+       reason: Scope exclusion only; it preserves the absence of retry/repair behavior.
+  4. [no_obligation] exclusion-05: The separate rendering of open questions and unrequested changes.
+       reason: Scope exclusion only; it preserves the separate rendering of open questions and unrequested changes.
+  5. [no_obligation] completion-01: Implementation
+       reason: Section marker only; it introduces no checkable requirement.
+
+Unrequested changes:
+  1. [in_service] Added a new helper to recursively extract enum values from the outgoing schema and used it to auto-complete empty recommendation lists in test doubles. This is an internal test-support refactor not required by the listed obligations.
+       tests/support.py#@@ -33,11 +33,66 @@ def _fake_response(content: str) -> SimpleNamespace:
+       tests/support.py#@@ -127,7 +182,7 @@ def client_dispatching(
+       tests/benchmark/degenerate_judges.py#@@ -37,7 +37,7 @@ from typing import Any
+       tests/benchmark/degenerate_judges.py#@@ -143,7 +143,7 @@ def degenerate_client(obligations: list[dict], *, always_strong: bool) -> ModelC
+  2. [in_service] The new tests assert specific rejection behavior for duplicate recommendations and for recommendations naming non-weak obligations. The obligations require rejecting missing recommendations and rejecting non-weak obligations instead of silently dropping them, but they do not call for duplicate-detection behavior or its test coverage.
+       tests/coverage/test_recommendations.py#@@ -6,7 +6,10 @@ Generation is a schema-constrained model call; per the replay-first invariant
+       tests/coverage/test_recommendations.py#@@ -120,3 +123,115 @@ def test_recommendation_round_trips_through_persistence():
+  3. [in_service] The report test was expanded to assert exact placement and count of recommendation text, including a new test for a weak recommendation under one obligation and absent from another. The obligations require co-locating recommendations with obligations and preserving the retrieval line, but not these extra count-based assertions or the additional bespoke test case.
+       tests/test_report.py#@@ -208,8 +208,53 @@ def test_open_questions_and_recommendations_are_numbered():
+  4. [in_service] The rerun test was changed to expect an additional recommendation (`alpha`) and to explain the prior behavior in comments. The obligations require weak obligations to carry recommendations, but this specific scenario adjustment and commentary are not directly called for by the listed obligations.
+       tests/test_rerun.py#@@ -687,7 +687,16 @@ def test_a_rerun_still_reports_a_gap_in_code_the_new_work_never_touched(tmp_path
+  5. [in_service] The verdict test adds an import of `inspect` and a new assertion about `derive_verdict`'s signature not accepting recommendations. The obligations require computing the weak-obligation count from obligations themselves, but not this signature-level assertion or the extra import.
+       tests/test_verdict.py#@@ -7,6 +7,8 @@ question blocks a positive verdict (#113).
+       tests/test_verdict.py#@@ -138,3 +140,24 @@ def test_completion_result_round_trips_through_persistence():
+
+Changes since 22738d75:
+  closed:
+    - Preserve the report structure so it contains no standalone recommendations section.
+        code evidence: addressed -> addressed
+        test evidence: partially supported -> strongly supported
+  moved:
+    - Preserve the report's closing line so it points at the retrieval command.
+        test evidence: strongly supported -> nominally supported
+    - Keep tests free of live model calls.
+        test evidence: strongly supported -> nominally supported
+
+Evidence limitations:
+  1. Judgments are static inferences unless a higher tier is recorded; the full application was not independently executed.
+
+Next: retrieve a criterion's full recommendation with
+  acceptance recommendation --criterion <id>

--- a/dogfood-logs/218-gate2-run3/revisions.txt
+++ b/dogfood-logs/218-gate2-run3/revisions.txt
@@ -1,0 +1,2 @@
+base 6ae97fd
+head 79522b2

--- a/dogfood-logs/218-gate2-run4/current-task.md
+++ b/dogfood-logs/218-gate2-run4/current-task.md
@@ -1,0 +1,65 @@
+# Task
+The §16 report prints test recommendations in their own block at the foot of the
+report. An obligation whose test evidence is weak says nothing about the
+recommendation that explains it, and the recommendation identifies its
+obligation only through a `--criterion` slug that appears nowhere in the
+obligation's own block. Joining the two is manual, and in the run that prompted
+this they sat about two hundred lines apart.
+
+§16 already rules this out: output is organised by obligation so that a
+criterion's axes sit together rather than in separate lists the reader must join
+by eye. A recommendation is a third axis and received exactly the treatment §16
+forbids. The join key already exists, because `TestRecommendation.obligation_id`
+is what builds the `--criterion` command.
+
+Separately, `coverage/recommendations.py::recommend_tests` iterates the
+recommendations a response returned and never reconciles them against the weak
+obligations it asked about. A response returning three recommendations for five
+weak obligations produces a report in which two weak obligations carry none, and
+nothing distinguishes that from a complete answer.
+
+Render each recommendation with the obligation it explains, and make a missing
+recommendation an error rather than an absence.
+
+## Constraints
+- A recommendation is rendered inside the block of the obligation it names.
+- A recommendation is rendered on the test-evidence axis, which is the axis it
+  explains.
+- The report contains no standalone recommendations section.
+- The `--criterion` retrieval line stays with each recommendation.
+- The report keeps its closing line pointing at the retrieval command.
+- An obligation whose test evidence is below strongly supported carries a
+  recommendation.
+- An obligation whose test evidence is strongly supported carries none.
+- A response that omits a recommendation for a weak obligation the call supplied
+  is rejected.
+- A response naming an obligation that is not weak is rejected rather than
+  silently dropped.
+- The count of recommendations in a produced review equals the count of weak
+  obligations.
+- The verdict summary counts weak obligations from the obligations themselves,
+  not from the recommendation list.
+- Typed schemas are pydantic models, as the rest of the repository defines them.
+- Tests issue no live model calls.
+
+## Scope exclusions
+- Whether an obligation needs test evidence at all, which is #148. The rule
+  built here is that a recommendation exists exactly when test evidence is below
+  strongly supported; the further condition that tests are the right evidence
+  for the obligation is not computable until #148 lands.
+- Changing the strength classifier, or what counts as weak.
+- Changing what a recommendation contains.
+- Retrying or repairing a rejected response.
+- The separate rendering of open questions and unrequested changes.
+
+## Completion expectations
+- Implementation
+- A report containing weak obligations has no standalone recommendations
+  section.
+- Each weak obligation's rendered block contains its own recommendation.
+- A strongly supported obligation's rendered block contains no recommendation.
+- A response omitting a recommendation for a supplied weak obligation is
+  rejected.
+- A response naming a non-weak obligation is rejected.
+- A review carrying weak obligations has one recommendation per weak obligation.
+- A report with no weak obligations renders no recommendation text.

--- a/dogfood-logs/218-gate2-run4/judgement.md
+++ b/dogfood-logs/218-gate2-run4/judgement.md
@@ -1,0 +1,74 @@
+# Judgement — #218 Gate 2 run 4
+
+`1c71535` → `e52a57c`, the first run after rebasing onto #217.
+
+**The tool reports NO-MATERIAL-GAPS. Do not read that as a clean gate.**
+
+## What the report says
+
+- 14 obligations, all `addressed`, all `strongly supported`
+- 0 open questions, 0 recommended tests
+- 5 unrequested changes, all `[in_service]`
+- mandate coverage 25 of 30, the 5 declines being 4 scope exclusions (#219) and
+  the `Implementation` marker
+
+Mapping is not half-blind (DR-164): **14 of 14** obligations carry mapped tests,
+33 links total, measured from the persisted review rather than the cache.
+
+## Why it is not comparable to run 3
+
+The task file is **byte-identical** between runs 3 and 4, and **12 of the 14
+obligations were reworded**. Only 2 survive verbatim.
+
+The cause is legitimate and identifiable: #217 changed `_Decomposition`'s
+response schema, `request_key` hashes the response schema, so the decompose
+transcript was invalidated and the obligation set was re-derived by a fresh call.
+In #220's terms this is case 2 — changed, and its inputs moved.
+
+But it means the 3-weak → 0-weak movement is **not** evidence that the added
+tests closed anything. Different obligations were judged. A stable count
+concealed a re-split, which is the failure mode the session notes already warn
+about.
+
+## The false positive
+
+```
+12. Represent typed schemas as pydantic models.
+       code evidence: addressed
+         (no corresponding change)
+       test evidence: strongly supported  [tier: static]
+         12.1  tests/coverage/test_recommendations.py::test_recommendation_round_trips_through_persistence
+         12.2  tests/test_verdict.py::test_completion_result_round_trips_through_persistence
+```
+
+Both cited tests round-trip a model through persistence. **They would pass if
+the schemas were dataclasses with the same serialisation.** They do not
+discriminate the obligation. And `code evidence: addressed` is asserted with
+`(no corresponding change)` — a claim with no citation behind it.
+
+This is the same #148 obligation that read `unsupported / (no mapped test)` in
+runs 1-3. Nothing in the code changed that could make it testable.
+
+**This is worse than the blocking behaviour #148 has produced so far.** Until
+now #148 caused honest `unsupported` readings that *blocked* a gate. Here it
+manufactured `strongly supported` from non-discriminating evidence and
+*unblocked* one. A defect that can turn a gate green is a different severity of
+problem from one that turns it red.
+
+Obligation 7 has the same `(no corresponding change)` shape and is **fine** — a
+preservation obligation, correctly `addressed` with no diff refs per #133, with
+two genuinely discriminating tests behind it. The shape alone is not the tell.
+
+## Disposition
+
+**Attributed to #148**, with this run attached as evidence of the escalation.
+Not addressed here: no test can evidence obligation 12, which is the whole point
+of #148.
+
+**The work itself is complete.** Every obligation #218 actually set out to
+deliver is implemented and genuinely tested. The unreliability is in the tool's
+judgement of one obligation, not in the change.
+
+**Recommendation: do not treat this as a clean Gate 2 in the PR.** Record it as a
+pass with a known false positive, so the next reader is not told the tool
+verified something it cannot verify.

--- a/dogfood-logs/218-gate2-run4/output.log
+++ b/dogfood-logs/218-gate2-run4/output.log
@@ -1,0 +1,173 @@
+Task completion: NO-MATERIAL-GAPS
+
+Every obligation is addressed and strongly supported by discriminating tests.
+
+Obligations:
+
+  1. Render each test recommendation inside the block of the obligation it explains, on the test-evidence axis.
+       requirements: task-01, task-02, task-04, constraint-01, constraint-02, completion-03
+       code evidence: addressed
+         1.1  src/acceptance/report.py#@@ -39,9 +40,17 @@ def render_report(review: Review) -> str:
+         1.2  src/acceptance/report.py#@@ -75,20 +84,9 @@ def render_report(review: Review) -> str:
+         1.3  src/acceptance/report.py#@@ -260,9 +258,13 @@ def _unread_block(requirement_map: RequirementMap) -> list[str]:
+         1.4  tests/test_report.py#@@ -208,8 +208,53 @@ def test_open_questions_and_recommendations_are_numbered():
+       test evidence: strongly supported  [tier: static]
+         1.5  tests/test_report.py::test_a_recommendation_sits_under_its_own_obligation_and_no_other
+         1.6  tests/test_report.py::test_open_questions_and_recommendations_are_numbered
+
+  2. Treat a missing recommendation for a supplied weak obligation as a rejected response.
+       requirements: task-04
+       code evidence: addressed
+         2.1  src/acceptance/coverage/recommendations.py#@@ -143,21 +143,45 @@ def recommend_tests(
+         2.2  tests/coverage/test_recommendations.py#@@ -6,7 +6,10 @@ Generation is a schema-constrained model call; per the replay-first invariant
+         2.3  tests/coverage/test_recommendations.py#@@ -120,3 +123,115 @@ def test_recommendation_round_trips_through_persistence():
+       test evidence: strongly supported  [tier: static]
+         2.4  tests/coverage/test_recommendations.py::test_a_response_skipping_a_weak_obligation_is_rejected
+
+  3. Keep recommendations out of a standalone report section.
+       requirements: task-01, constraint-03, completion-02
+       code evidence: addressed
+         3.1  src/acceptance/report.py#@@ -75,20 +84,9 @@ def render_report(review: Review) -> str:
+         3.2  tests/test_report.py#@@ -208,8 +208,53 @@ def test_open_questions_and_recommendations_are_numbered():
+       test evidence: strongly supported  [tier: static]
+         3.3  tests/test_report.py::test_a_recommendation_sits_under_its_own_obligation_and_no_other
+         3.4  tests/test_report.py::test_open_questions_and_recommendations_are_numbered
+
+  4. Keep the `--criterion` retrieval line adjacent to each recommendation.
+       requirements: task-02, constraint-04
+       code evidence: addressed
+         4.1  src/acceptance/report.py#@@ -260,9 +258,13 @@ def _unread_block(requirement_map: RequirementMap) -> list[str]:
+         4.2  tests/test_report.py#@@ -208,8 +208,53 @@ def test_open_questions_and_recommendations_are_numbered():
+       test evidence: strongly supported  [tier: static]
+         4.3  tests/coverage/test_recommendations.py::test_weak_criterion_gets_a_fully_populated_recommendation
+         4.4  tests/test_report.py::test_a_review_with_gaps_closes_by_pointing_at_the_retrieval_command
+         4.5  tests/test_report.py::test_open_questions_and_recommendations_are_numbered
+         4.6  tests/test_report.py::test_report_renders_each_obligation_with_both_axes_numbered
+
+  5. Preserve the report's closing line pointing at the retrieval command.
+       requirements: constraint-05
+       code evidence: addressed
+         5.1  tests/test_report.py#@@ -359,3 +404,51 @@ def test_a_first_review_renders_no_changes_section():
+       test evidence: strongly supported  [tier: static]
+         5.2  tests/test_report.py::test_a_review_with_gaps_closes_by_pointing_at_the_retrieval_command
+
+  6. Render a recommendation for every obligation whose test evidence is below strongly supported.
+       requirements: constraint-06
+       code evidence: addressed
+         6.1  src/acceptance/coverage/recommendations.py#@@ -143,21 +143,45 @@ def recommend_tests(
+         6.2  src/acceptance/report.py#@@ -39,9 +40,17 @@ def render_report(review: Review) -> str:
+       test evidence: strongly supported  [tier: static]
+         6.3  tests/coverage/test_recommendations.py::test_every_weak_obligation_gets_exactly_one_recommendation
+         6.4  tests/coverage/test_recommendations.py::test_weak_criterion_gets_a_fully_populated_recommendation
+         6.5  tests/test_report.py::test_a_recommendation_sits_under_its_own_obligation_and_no_other
+         6.6  tests/test_report.py::test_open_questions_and_recommendations_are_numbered
+         6.7  tests/test_rerun.py::test_a_rerun_still_reports_a_gap_in_code_the_new_work_never_touched
+
+  7. Render no recommendation for obligations whose test evidence is strongly supported.
+       requirements: constraint-07, completion-04, completion-08
+       code evidence: addressed
+         (no corresponding change)
+       test evidence: strongly supported  [tier: static]
+         7.1  tests/coverage/test_recommendations.py::test_strongly_supported_obligations_get_no_recommendation_and_no_model_call
+         7.2  tests/test_report.py::test_a_recommendation_sits_under_its_own_obligation_and_no_other
+
+  8. Reject a response that omits a recommendation for a weak obligation supplied in the call.
+       requirements: task-03, constraint-08, completion-05
+       code evidence: addressed
+         8.1  src/acceptance/coverage/recommendations.py#@@ -143,21 +143,45 @@ def recommend_tests(
+         8.2  tests/coverage/test_recommendations.py#@@ -6,7 +6,10 @@ Generation is a schema-constrained model call; per the replay-first invariant
+       test evidence: strongly supported  [tier: static]
+         8.3  tests/coverage/test_recommendations.py::test_a_response_skipping_a_weak_obligation_is_rejected
+
+  9. Reject a response that names an obligation that is not weak.
+       requirements: task-03, constraint-09, completion-06
+       code evidence: addressed
+         9.1  src/acceptance/coverage/recommendations.py#@@ -143,21 +143,45 @@ def recommend_tests(
+         9.2  tests/coverage/test_recommendations.py#@@ -6,7 +6,10 @@ Generation is a schema-constrained model call; per the replay-first invariant
+       test evidence: strongly supported  [tier: static]
+         9.3  tests/coverage/test_recommendations.py::test_a_duplicate_recommendation_is_rejected
+         9.4  tests/coverage/test_recommendations.py::test_a_response_naming_a_non_weak_obligation_is_rejected
+
+  10. Produce exactly one recommendation per weak obligation in a review.
+       requirements: task-03, constraint-10, completion-07
+       code evidence: addressed
+         10.1  src/acceptance/coverage/recommendations.py#@@ -143,21 +143,45 @@ def recommend_tests(
+         10.2  tests/coverage/test_recommendations.py#@@ -120,3 +123,115 @@ def test_recommendation_round_trips_through_persistence():
+       test evidence: strongly supported  [tier: static]
+         10.3  tests/coverage/test_recommendations.py::test_every_weak_obligation_gets_exactly_one_recommendation
+         10.4  tests/test_report.py::test_open_questions_and_recommendations_are_numbered
+         10.5  tests/test_rerun.py::test_a_rerun_still_reports_a_gap_in_code_the_new_work_never_touched
+
+  11. Compute the verdict summary's weak-obligation count from the obligations themselves rather than from the recommendation list.
+       requirements: task-03, constraint-11
+       code evidence: addressed
+         11.1  tests/test_verdict.py#@@ -138,3 +140,24 @@ def test_completion_result_round_trips_through_persistence():
+       test evidence: strongly supported  [tier: static]
+         11.2  tests/test_verdict.py::test_the_weak_count_is_read_off_the_obligations_not_the_recommendations
+
+  12. Represent typed schemas as pydantic models.
+       requirements: constraint-12
+       code evidence: addressed
+         (no corresponding change)
+       test evidence: strongly supported  [tier: static]
+         12.1  tests/coverage/test_recommendations.py::test_recommendation_round_trips_through_persistence
+         12.2  tests/test_verdict.py::test_completion_result_round_trips_through_persistence
+
+  13. Keep tests free of live model calls.
+       requirements: constraint-13
+       code evidence: addressed
+         13.1  tests/support.py#@@ -33,6 +33,82 @@ def _fake_response(content: str) -> SimpleNamespace:
+         13.2  tests/benchmark/degenerate_judges.py#@@ -37,7 +37,7 @@ from typing import Any
+         13.3  tests/coverage/test_recommendations.py#@@ -6,7 +6,10 @@ Generation is a schema-constrained model call; per the replay-first invariant
+       test evidence: strongly supported  [tier: static]
+         13.4  tests/coverage/test_recommendations.py::test_strongly_supported_obligations_get_no_recommendation_and_no_model_call
+
+  14. Make recommendation presence correspond exactly to obligations whose test evidence is below strongly supported.
+       requirements: exclusion-01
+       code evidence: addressed
+         14.1  src/acceptance/coverage/recommendations.py#@@ -143,21 +143,45 @@ def recommend_tests(
+         14.2  tests/coverage/test_recommendations.py#@@ -6,7 +6,10 @@ Generation is a schema-constrained model call; per the replay-first invariant
+         14.3  tests/coverage/test_recommendations.py#@@ -120,3 +123,115 @@ def test_recommendation_round_trips_through_persistence():
+       test evidence: strongly supported  [tier: static]
+         14.4  tests/coverage/test_recommendations.py::test_every_weak_obligation_gets_exactly_one_recommendation
+         14.5  tests/coverage/test_recommendations.py::test_strongly_supported_obligations_get_no_recommendation_and_no_model_call
+         14.6  tests/coverage/test_recommendations.py::test_weak_criterion_gets_a_fully_populated_recommendation
+         14.7  tests/test_report.py::test_a_recommendation_sits_under_its_own_obligation_and_no_other
+         14.8  tests/test_report.py::test_open_questions_and_recommendations_are_numbered
+         14.9  tests/test_rerun.py::test_a_rerun_still_reports_a_gap_in_code_the_new_work_never_touched
+
+Mandate coverage: 25 of 30 requirements yielded obligations
+  1. [no_obligation] exclusion-02: Changing the strength classifier, or what counts as weak.
+       reason: This is a scope exclusion preserving the existing strength classifier and weak/strong threshold unchanged; it does not add a new checkable behavior beyond that preservation.
+  2. [no_obligation] exclusion-03: Changing what a recommendation contains.
+       reason: This is a scope exclusion preserving the contents of a recommendation; it does not specify a new behavior to implement.
+  3. [no_obligation] exclusion-04: Retrying or repairing a rejected response.
+       reason: This is a scope exclusion about recovery behavior that is not part of the requested change and adds no new checkable requirement here.
+  4. [no_obligation] exclusion-05: The separate rendering of open questions and unrequested changes.
+       reason: This is a scope exclusion preserving separate rendering of other sections; it does not impose a distinct new behavior for this change.
+  5. [no_obligation] completion-01: Implementation
+       reason: Section marker only; it contains no requirement content.
+
+Unrequested changes:
+  1. [in_service] Added a new schema-walking helper in test support and refactored the existing empty-response completion logic to use it. This is an internal test-support refactor not required by the obligations themselves.
+       tests/support.py#@@ -33,6 +33,82 @@ def _fake_response(content: str) -> SimpleNamespace:
+       tests/support.py#@@ -148,57 +224,6 @@ def client_dispatching(
+       tests/benchmark/degenerate_judges.py#@@ -37,7 +37,7 @@ from typing import Any
+       tests/benchmark/degenerate_judges.py#@@ -154,7 +154,7 @@ def degenerate_client(obligations: list[dict], *, always_strong: bool) -> ModelC
+  2. [in_service] The new coverage tests assert duplicate-recommendation rejection and exact ordering/count behavior for recommendations. The obligations require rejecting missing recommendations and non-weak obligations, but do not ask for duplicate-detection behavior or these extra ordering/count assertions.
+       tests/coverage/test_recommendations.py#@@ -6,7 +6,10 @@ Generation is a schema-constrained model call; per the replay-first invariant
+       tests/coverage/test_recommendations.py#@@ -120,3 +123,115 @@ def test_recommendation_round_trips_through_persistence():
+  3. [in_service] The report test was expanded beyond the requested placement/adjacency checks to assert exact count-based behavior and a bespoke two-obligation scenario. Those extra assertions are not explicitly required by the obligations.
+       tests/test_report.py#@@ -208,8 +208,53 @@ def test_open_questions_and_recommendations_are_numbered():
+       src/acceptance/report.py#@@ -39,9 +40,17 @@ def render_report(review: Review) -> str:
+       src/acceptance/report.py#@@ -75,20 +84,9 @@ def render_report(review: Review) -> str:
+  4. [in_service] The rerun test was changed to expect an additional recommendation (`alpha`) and includes explanatory commentary about the prior defect. The obligations require weak obligations to carry recommendations, but not this specific scenario adjustment or commentary.
+       tests/test_rerun.py#@@ -687,7 +687,16 @@ def test_a_rerun_still_reports_a_gap_in_code_the_new_work_never_touched(tmp_path
+  5. [in_service] The verdict test adds an `inspect` import and a new assertion about `derive_verdict`'s signature not accepting recommendations. The obligations require computing the weak-obligation count from obligations themselves, but not this signature-level assertion or extra import.
+       tests/test_verdict.py#@@ -7,6 +7,8 @@ question blocks a positive verdict (#113).
+       tests/test_verdict.py#@@ -138,3 +140,24 @@ def test_completion_result_round_trips_through_persistence():
+
+Evidence limitations:
+  1. No material gaps found at the achievable evidence tier — not proof of correctness. The full application was not independently executed (§3.7).
+
+Recommended next instruction: (none)

--- a/dogfood-logs/218-gate2-run4/revisions.txt
+++ b/dogfood-logs/218-gate2-run4/revisions.txt
@@ -1,0 +1,2 @@
+base 1c71535
+head e52a57c

--- a/session-state.md
+++ b/session-state.md
@@ -53,16 +53,27 @@ single-field version of `_supplied_enum`.
 
 ## Where #218 stands
 
-Gate 1 passed. **Gate 2 is not clean** — 3 weak obligations at `79522b2`,
-pre-rebase. The run needs repeating post-rebase, since the diff changed.
+Gate 1 passed. Gate 2 run 4 (`1c71535` → `e52a57c`) reports **NO-MATERIAL-GAPS**
+— and it should not be read as a clean gate. Judgement in
+`dogfood-logs/218-gate2-run4/judgement.md`.
 
-The weak set went 5 → 2 → 3 across three runs whose only changes were additive
-tests. Remaining attributed to #148 and #180/#193; judgements in
-`dogfood-logs/218-gate2-run{1,2,3}/`.
+- **Not comparable to run 3.** The task file is byte-identical, yet 12 of 14
+  obligations were reworded, because #217 changed `_Decomposition`'s schema and
+  `request_key` hashes it, so the decomposition was re-derived. The 3-weak → 0
+  movement is not evidence the added tests closed anything.
+- **One false positive.** Obligation 12, *"Represent typed schemas as pydantic
+  models"* — the #148 obligation that read `unsupported` in runs 1-3 — is now
+  `strongly supported`, citing two `*_round_trips_through_persistence` tests
+  that pass whether or not the schemas are pydantic. `addressed` is claimed with
+  `(no corresponding change)`.
+- Mapping is sound (DR-164 check): 14 of 14 obligations carry mapped tests, 33
+  links, measured from the persisted review.
 
-**Before a PR:** re-run Gate 2 against the new base, and re-check each
-recommendation against the actual tests rather than judging it from its
-`detects:` line — see below.
+**The work itself is complete and genuinely tested.** The unreliability is in the
+tool's judgement of one obligation, not in the change.
+
+**#148 escalated.** Until now it produced honest `unsupported` readings that
+blocked gates. Here it manufactured a green one. Evidence attached to #148.
 
 ## A correction worth not repeating
 

--- a/session-state.md
+++ b/session-state.md
@@ -14,103 +14,113 @@ Clear it out when the task lands rather than letting it accrete.
 
 ## Task in flight
 
-**#217 — M1.2.r2**, branch `issue-217-disposition-unrepresentable`, three commits
-(`76b847b`, `007966f`, `6c06517`). Not pushed, no PR.
+**#218**, branch `issue-218-recommendations-by-obligation`, rebased onto main
+after #217 landed. Not pushed, no PR.
 
-**Gate 2 is NOT clean.** Do not open a PR. See *Where it stands* below.
+**#217 (M1.2.r2) is merged** — `1c71535`, PR #221, CI green.
 
-## How #217 came to exist
+## What #218 does
 
-#216 was the intended task. Its **Gate 1 never passed**: 8 of 31 requirements
-came back `yielded` with an empty id list. The transcript showed the model had
-supplied a substantive `no_obligation` reason for every one, and
-`_requirement_map` discarded it because the label disagreed with the payload,
-recording the requirement as unaccounted-for instead.
+A test recommendation exists exactly when an obligation's test evidence is below
+strongly-supported. Two halves:
 
-So the fourth disposition `M1.2.r1` added, `UNDISPOSED`, was turning malformed
-responses into soft findings that still reached a verdict. #202 is correctly
-closed — its acceptance genuinely passed — and #217 supersedes it.
+- **Placement.** Each recommendation renders inside the obligation it explains,
+  on the test-evidence axis. §16 organises output by obligation "so a criterion's
+  two axes sit together rather than in separate lists the reader must join by
+  eye", and its example report has no recommendations block at all. In #217's
+  Gate 2 the obligation and its recommendation sat ~200 lines apart, joined only
+  by a `--criterion` slug appearing nowhere in the obligation's block.
+- **Completeness.** `recommend_tests` kept whatever the response returned, so a
+  response answering 3 of 5 weak obligations produced a report where two carried
+  none — M1.2.r1's missing disposition, one stage downstream. Missing, duplicate
+  and non-weak recommendations now raise.
 
-**#216 is still open and still unstarted.** Its Gate 1 must be re-run after #217
-lands; the run that exposed all this is in `dogfood-logs/216-gate1-run1/`.
+Not in scope: whether an obligation needs test evidence at all, which is #148.
 
-## What #217 delivered
+## The rebase had a silent hazard — look for it again next time
 
-- three disposition shapes, each carrying only its own payload; `UNDISPOSED` and
-  every path assigning it deleted
-- reconciliation raises `SchemaValidationError` on a missing requirement, a
-  duplicate, an unknown id, or a claim naming only outputs never produced
-- a supplied reason is preserved, never replaced by a diagnostic
-- `constrain()` walks unions — **without this the `requirement_id` constraint
-  would have vanished silently** under the new shape, with every test still green
-- DR-202 decision 3 amended in place
+`tests/support.py` **auto-merged cleanly and was semantically wrong**. Both
+branches added a `_completed` helper in different regions, so git reported no
+conflict and left two definitions; the second shadowed the first, which would
+have disabled #218's recommendation completion with nothing failing at merge
+time.
 
-772 tests pass, ruff clean.
+Folded into one: `_supplied_enum(field, **kwargs)` walks the outgoing schema for
+any id field's enum, `declining_dispositions` is built on it, and one
+`_completed` handles both `requirement_dispositions` (#217) and
+`recommendations` (#218). `supplied_requirement_ids` is gone — it was the
+single-field version of `_supplied_enum`.
 
-## Two things not to rediscover
+## Where #218 stands
+
+Gate 1 passed. **Gate 2 is not clean** — 3 weak obligations at `79522b2`,
+pre-rebase. The run needs repeating post-rebase, since the diff changed.
+
+The weak set went 5 → 2 → 3 across three runs whose only changes were additive
+tests. Remaining attributed to #148 and #180/#193; judgements in
+`dogfood-logs/218-gate2-run{1,2,3}/`.
+
+**Before a PR:** re-run Gate 2 against the new base, and re-check each
+recommendation against the actual tests rather than judging it from its
+`detects:` line — see below.
+
+## A correction worth not repeating
+
+Two recommendations across the two branches were dismissed wrongly, both toward
+"already covered":
+
+- #218's `closing-line-points-at-retrieval-command` was called a tautology
+  "asserted by existing report tests". Only the *negative* branch was; the line
+  the obligation names appeared in no test at all. Real gap, now covered.
+- #217's `pydantic-typed-schemas` was reported as a mapping miss (#182) because
+  a test matched the recommendation's prescription. That test would pass whether
+  or not the production schemas are pydantic, so it cannot discriminate the
+  obligation. It is #148.
+
+**The shape**: naming a test that resembles the recommendation without checking
+it would fail if the obligation were violated. Recorded in both judgement files.
+
+## Filed this session, not built
+
+- **#219** — scope exclusions declined as `no_obligation` against the prompt's
+  own instruction at `obligations.py:150`, with the reason stating the
+  obligation. Fired in two consecutive Gate 1 runs. Belongs in the
+  #204/#205/#206 prompt batch, where the re-record is paid once.
+- **#220** (`decision`) — every carried rating change classified into three
+  exhaustive cases: unchanged / changed with inputs moved / changed with inputs
+  unmoved. The third is the reportable event. Classification is **computed**
+  from `rerun.py::stale_obligation_ids`, so no model call and no re-examination.
+  `restated` deferred behind measurement.
+- **#148** — this session's evidence attached. It now blocks Gate 2 on
+  consecutive PRs and is the strongest candidate for the next capability task.
+
+## Do not rediscover
 
 - **A pydantic tagged union cannot go on the wire.** `Field(discriminator=...)`
-  renders `oneOf` + `discriminator`; OpenAI strict mode accepts neither, and
+  renders `oneOf` + `discriminator`; strict mode accepts neither, and
   `inline_schema_refs` leaves the mapping pointing at `$defs` it just inlined.
-  Plain `Union` renders `anyOf`, which works; `Literal` tags still disambiguate.
-- **"At least one" cannot be `min_length` either** — strict mode rejects
-  `minItems`. It is a required scalar field beside a list (`obligation_id` +
-  `more_obligation_ids`), so the guarantee is carried by the shape.
-
-## Where it stands — the 5 open findings
-
-Gate 2 run 3 (`6ae97fd` → `6c06517`): INCOMPLETE, 5 obligations with
-non-discriminating test evidence. Down from 11 → 7 → 5. Nothing unaddressed, no
-`separable` change, mandate coverage correct.
-
-Judgement in `dogfood-logs/217-gate2-run3/judgement.md`. In short:
-
-- **2 are meta-obligations** — the task file asks that *a test exist*, so the
-  evidence stage is hunting for a test proving a test exists. Probably a
-  task-file authoring fix: state the behaviour, not the artifact.
-- **3 have direct, on-point tests** and still read non-discriminating. Whether
-  that is #183 (judgement) or #182 (mapping) is **not established** — check the
-  mapping transcript before assuming (DR-164).
-
-Each of the five needs a fix or a filed defect before a PR. None may be waived.
-
-Run 3's recommendation 2 is worth writing regardless: union members carrying
-*misleading* fields, which `extra="forbid"` turns into the strongest proof that
-dispatch is by literal tag alone.
-
-## Still open from the same root
-
-**The decomposer declines scope exclusions outright** — 7 of 8 in #216's Gate 1,
-against the instruction already at `obligations.py:150`. #217 makes those
-declines visible and reasoned; it does not make them right. **Not yet filed.**
-Belongs in the #204/#205/#206 prompt batch, where the re-record is paid once.
-
-## The re-record cost was paid
-
-`request_key` hashes the response schema (`llm.py:81-87`), so changing
-`_RequirementDisposition` invalidated **every** recorded decompose transcript.
-Decomposition-accuracy figures are non-comparable across this change.
-
-## Known open, not this task's problem
-
-- **#210** — false links; fired again in #217's own Gate 1 (five exclusions
-  linked to an obligation that does not state them).
-- **#216** — nested bullets dropped silently; unstarted.
-- **#153**, **#191**, **#196**, **#178**, **#193**, **#214**, **#129**.
+  Plain `Union` renders `anyOf`; `Literal` tags still disambiguate.
+- **"At least one" cannot be `min_length`** — strict mode rejects `minItems`.
+  Use a required scalar beside a list.
+- **`request_key` hashes the response schema** (`llm.py:81-87`). #217 paid this
+  for the whole decompose corpus; accuracy figures are non-comparable across it.
+- **A text search for a removed symbol flags its own explanation.** Use an AST
+  walk so the docstrings recording *why* survive.
 
 ## Traps
 
 - **`decompose|check --mode record` writes nothing to stdout when redirected.**
-  Record once, then re-run in replay to capture. Cost real time this session.
-- **A text search for a removed symbol flags its own explanation.** Use an AST
-  walk for "no code references X" so the docstrings recording *why* survive.
-- **Test doubles returning `requirement_dispositions: []` no longer parse.**
-  `tests/support.py::declining_dispositions` completes them from the ids the
-  call supplied, read off the outgoing schema's enum.
+  Record once, then re-run in replay to capture.
 - **Python here is 3.10** — no `enum.StrEnum`. Use `(str, Enum)`.
 - **The repo is `alipeles/acceptance-review`**, not the local dir name.
 - **`gh api ... -f` sends strings**; sub-issue ids need `-F` for integers.
 - **Adding a sub-issue returns the PARENT**, so `-q .number` echoes the umbrella.
+
+## Known open, not this task's problem
+
+**#148** (blocks Gate 2), **#216** (unstarted — its Gate 1 started this whole
+session), **#219**, **#220**, **#210**, **#180**, **#193**, **#153**, **#191**,
+**#196**, **#178**, **#214**, **#129**.
 
 ## What to ignore
 

--- a/src/acceptance/coverage/recommendations.py
+++ b/src/acceptance/coverage/recommendations.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 from acceptance.coverage.prompt import render_diff_section
 from acceptance.evidence.discrimination import ObligationDiscrimination
-from acceptance.llm import ModelClient, StrictResponseModel
+from acceptance.llm import ModelClient, SchemaValidationError, StrictResponseModel
 from acceptance.supplied_ids import UnusableAnswerLog, constrain, scan
 from acceptance.review_state import ChangeSet, Obligation, TestRecommendation
 
@@ -143,21 +143,45 @@ def recommend_tests(
         obligation.id: (obligation.observable_behavior or obligation.description)
         for obligation in weak
     }
-    recommendations = []
+
+    # A recommendation exists for a weak obligation, and only for a weak one.
+    # The "only" half was already enforced — `weak` is what the call supplies,
+    # and a foreign id is unrepresentable under constrained decoding. The
+    # "always" half was not: this loop used to iterate the response and skip
+    # what it could not place, so a response answering 3 of 5 weak obligations
+    # produced a report where two carried no recommendation and nothing
+    # distinguished it from a complete answer. That is M1.2.r1's missing
+    # disposition, one stage downstream, and it is rejected the same way.
+    returned: dict[str, _Recommendation] = {}
     for rec in result.recommendations:
-        criterion = criterion_by_id.get(rec.obligation_id)
-        if criterion is None:
-            continue  # model named an obligation that isn't weak / doesn't exist
-        recommendations.append(
-            TestRecommendation(
-                obligation_id=rec.obligation_id,
-                criterion=criterion,
-                required_inputs=rec.required_inputs,
-                boundary_conditions=rec.boundary_conditions,
-                expected_output=rec.expected_output,
-                required_assertions=rec.required_assertions,
-                plausible_defect=rec.plausible_defect,
-                repo_conventions=rec.repo_conventions,
+        if rec.obligation_id in returned:
+            raise SchemaValidationError(
+                f"obligation '{rec.obligation_id}' was recommended for more than once"
             )
+        if rec.obligation_id not in criterion_by_id:
+            raise SchemaValidationError(
+                f"recommendation named obligation '{rec.obligation_id}', which the call "
+                "did not supply as weak"
+            )
+        returned[rec.obligation_id] = rec
+
+    missing = [obligation.id for obligation in weak if obligation.id not in returned]
+    if missing:
+        raise SchemaValidationError(
+            f"no recommendation for {len(missing)} of {len(weak)} weak "
+            f"obligation(s): {', '.join(missing)}"
         )
-    return recommendations
+
+    return [
+        TestRecommendation(
+            obligation_id=obligation.id,
+            criterion=criterion_by_id[obligation.id],
+            required_inputs=returned[obligation.id].required_inputs,
+            boundary_conditions=returned[obligation.id].boundary_conditions,
+            expected_output=returned[obligation.id].expected_output,
+            required_assertions=returned[obligation.id].required_assertions,
+            plausible_defect=returned[obligation.id].plausible_defect,
+            repo_conventions=returned[obligation.id].repo_conventions,
+        )
+        for obligation in weak
+    ]

--- a/src/acceptance/report.py
+++ b/src/acceptance/report.py
@@ -22,6 +22,7 @@ from acceptance.review_state import (
     Obligation,
     RequirementMap,
     Review,
+    TestRecommendation,
 )
 
 _EMPTY = "  (none)"
@@ -39,9 +40,17 @@ def render_report(review: Review) -> str:
 
     lines.append("Obligations:")
     if review.obligation_map:
+        by_obligation = {rec.obligation_id: rec for rec in review.recommendations}
         for index, obligation in enumerate(review.obligation_map, start=1):
             lines.append("")
-            lines.extend(_obligation_block(index, obligation, review.requirement_map))
+            lines.extend(
+                _obligation_block(
+                    index,
+                    obligation,
+                    review.requirement_map,
+                    by_obligation.get(obligation.id),
+                )
+            )
     else:
         lines.append(_EMPTY)
     lines.append("")
@@ -75,20 +84,9 @@ def render_report(review: Review) -> str:
                 lines.append(f"       {question.resolution_rationale}")
         lines.append("")
 
-    if review.recommendations:
-        lines.append("Recommended tests:")
-        for index, rec in enumerate(review.recommendations, start=1):
-            lines.append(f"  {index}. {rec.criterion}")
-            lines.append(f"       inputs:  {rec.required_inputs}")
-            lines.append(f"       detects: {rec.plausible_defect}")
-            # §9.5's single-iteration goal depends on the agent KNOWING the full
-            # prescription exists. Naming the command per recommendation — rather
-            # than once at the foot of the report — is what makes the pull happen
-            # at the moment the reader decides to act on this criterion.
-            lines.append(
-                f"       full detail: acceptance recommendation --criterion {rec.obligation_id}"
-            )
-        lines.append("")
+    # No recommendations block. Each one renders inside the obligation it
+    # explains (`_obligation_block`), per §16's rule that a criterion's axes sit
+    # together rather than in separate lists joined by eye.
 
     if completion is not None and completion.limitations:
         lines.append("Evidence limitations:")
@@ -260,9 +258,13 @@ def _unread_block(requirement_map: RequirementMap) -> list[str]:
 
 
 def _obligation_block(
-    index: int, obligation: Obligation, requirement_map: RequirementMap | None = None
+    index: int,
+    obligation: Obligation,
+    requirement_map: RequirementMap | None = None,
+    recommendation: TestRecommendation | None = None,
 ) -> list[str]:
-    """One numbered obligation with both evidence axes nested beneath it.
+    """One numbered obligation with both evidence axes nested beneath it, and
+    the test recommendation that explains a weak one.
 
     Evidence items are numbered `<obligation>.<item>` continuously across both
     axes, so every citation in the report has a unique handle."""
@@ -305,6 +307,23 @@ def _obligation_block(
             lines.append(f"         {index}.{item}  {test_id}")
     else:
         lines.append(f"         {_NO_TESTS}")
+
+    # The recommendation belongs to the axis it explains. It used to render in a
+    # separate block at the foot of the report, identified only by a
+    # `--criterion` slug that appeared nowhere in this block — the "separate
+    # lists the reader must join by eye" §16 exists to prevent, and a real cost:
+    # CLAUDE.md requires reading the recommendation BEFORE judging a weak
+    # obligation, which the old layout made a manual cross-reference.
+    if recommendation is not None:
+        lines.append(f"         recommended test: {recommendation.criterion}")
+        lines.append(f"           inputs:  {recommendation.required_inputs}")
+        lines.append(f"           detects: {recommendation.plausible_defect}")
+        # §9.5's single-iteration goal depends on the agent KNOWING the full
+        # prescription exists, at the moment it decides to act on this criterion.
+        lines.append(
+            "           full detail: acceptance recommendation "
+            f"--criterion {recommendation.obligation_id}"
+        )
 
     return lines
 

--- a/tests/benchmark/degenerate_judges.py
+++ b/tests/benchmark/degenerate_judges.py
@@ -37,7 +37,7 @@ from typing import Any
 
 from acceptance.config import DEFAULT_MODEL
 from acceptance.llm import Mode, ModelClient, TranscriptStore
-from tests.support import _EMPTY_BY_SCHEMA, _fake_response, declining_dispositions
+from tests.support import _EMPTY_BY_SCHEMA, _completed, _fake_response, declining_dispositions
 
 import tempfile
 
@@ -154,7 +154,7 @@ def degenerate_client(obligations: list[dict], *, always_strong: bool) -> ModelC
                 ]
             }))
 
-        return _fake_response(json.dumps(_EMPTY_BY_SCHEMA[name]))
+        return _fake_response(json.dumps(_completed(_EMPTY_BY_SCHEMA[name], **kwargs)))
 
     return ModelClient(
         model=DEFAULT_MODEL,

--- a/tests/coverage/test_recommendations.py
+++ b/tests/coverage/test_recommendations.py
@@ -6,7 +6,10 @@ Generation is a schema-constrained model call; per the replay-first invariant
 these tests inject the recorded response via completion_fn — no live calls.
 Recommendation *quality* against the real model is shown by the PR's record run."""
 
+import pytest
+
 from acceptance.coverage.recommendations import recommend_tests
+from acceptance.llm import SchemaValidationError
 from acceptance.evidence.discrimination import ObligationDiscrimination, PlausibleDefect
 from acceptance.review_state import ChangeSet, DiffHunk, FileChange, Obligation, ObligationType
 from tests.support import client_returning as _client_returning
@@ -120,3 +123,115 @@ def test_recommendation_round_trips_through_persistence():
 
     rec = recommend_tests(obligations, [], _change_set(), _client_returning(response))[0]
     assert TestRecommendation.from_dict(rec.to_dict()) == rec
+
+
+def _two_weak() -> tuple[list[Obligation], list[ObligationDiscrimination]]:
+    obligations = [
+        _obligation("daily-rate", "Daily rate uses days_in_month", "nominally_supported"),
+        _obligation("proration", "Proration handles partial months", "unsupported"),
+    ]
+    discriminations = [
+        ObligationDiscrimination(
+            obligation_id=obligation.id,
+            defects=[
+                PlausibleDefect(
+                    description="the behaviour is wrong",
+                    would_be_caught=False,
+                    reason="no discriminating input",
+                )
+            ],
+            discriminating=False,
+        )
+        for obligation in obligations
+    ]
+    return obligations, discriminations
+
+
+def _recommendation(obligation_id: str) -> dict:
+    return {
+        "obligation_id": obligation_id,
+        "required_inputs": "a month whose length is not 30",
+        "boundary_conditions": "0 days and a full month",
+        "expected_output": "price/28*days",
+        "required_assertions": ["assert prorate(280, 14, 28) == 140.0"],
+        "plausible_defect": "hard-codes /30",
+        "repo_conventions": "test_billing.py",
+    }
+
+
+def test_a_response_skipping_a_weak_obligation_is_rejected():
+    """The "always" half of the invariant, and the defect #218 removes.
+
+    This stage used to iterate the response and keep what it could place, so a
+    response answering one of two weak obligations produced a report where the
+    other silently carried no recommendation — indistinguishable from a complete
+    answer. That is M1.2.r1's missing disposition, one stage downstream.
+    """
+    obligations, discriminations = _two_weak()
+    response = {"recommendations": [_recommendation("daily-rate")]}
+
+    with pytest.raises(SchemaValidationError) as raised:
+        recommend_tests(
+            obligations, discriminations, _change_set(), _client_returning(response)
+        )
+
+    message = str(raised.value)
+    assert "proration" in message
+    assert "1 of 2" in message
+
+
+def test_a_response_naming_a_non_weak_obligation_is_rejected():
+    """The "only" half. It was enforced by dropping the entry, which is the same
+    silence in the other direction: a recommendation the call never asked for
+    means the model answered about something else, and that is worth knowing."""
+    obligations, discriminations = _two_weak()
+    response = {
+        "recommendations": [
+            _recommendation("daily-rate"),
+            _recommendation("proration"),
+            _recommendation("some-other-obligation"),
+        ]
+    }
+
+    with pytest.raises(SchemaValidationError) as raised:
+        recommend_tests(
+            obligations, discriminations, _change_set(), _client_returning(response)
+        )
+
+    assert "some-other-obligation" in str(raised.value)
+
+
+def test_a_duplicate_recommendation_is_rejected():
+    obligations, discriminations = _two_weak()
+    response = {
+        "recommendations": [
+            _recommendation("daily-rate"),
+            _recommendation("daily-rate"),
+            _recommendation("proration"),
+        ]
+    }
+
+    with pytest.raises(SchemaValidationError) as raised:
+        recommend_tests(
+            obligations, discriminations, _change_set(), _client_returning(response)
+        )
+
+    assert "more than once" in str(raised.value)
+
+
+def test_every_weak_obligation_gets_exactly_one_recommendation():
+    """The invariant stated positively, and in weak-obligation order rather than
+    response order — two recorded runs over one input must be byte-identical."""
+    obligations, discriminations = _two_weak()
+    response = {
+        "recommendations": [
+            _recommendation("proration"),
+            _recommendation("daily-rate"),
+        ]
+    }
+
+    recommendations = recommend_tests(
+        obligations, discriminations, _change_set(), _client_returning(response)
+    )
+
+    assert [r.obligation_id for r in recommendations] == ["daily-rate", "proration"]

--- a/tests/support.py
+++ b/tests/support.py
@@ -33,6 +33,82 @@ def _fake_response(content: str) -> SimpleNamespace:
     )
 
 
+def _supplied_enum(field: str, **kwargs) -> list[str]:
+    """The ids a call supplied for `field`, read back off the schema it sent.
+
+    `constrain` restricts each id field to a `Literal` of the ids that call
+    actually offered, so the enum in the outgoing schema is the work list. That
+    lets a double answer a call completely without being told the fixture's ids
+    separately, and keeps it honest when they change.
+    """
+    schema = kwargs["response_format"]["json_schema"]["schema"]
+    found: list[str] = []
+
+    def walk(node, key=None):
+        if isinstance(node, dict):
+            if key == field and isinstance(node.get("enum"), list):
+                found.extend(v for v in node["enum"] if v not in found)
+            for name, value in node.items():
+                walk(value, name if name not in ("properties", "$defs", "items") else key)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item, key)
+
+    walk(schema)
+    return found
+
+
+def declining_dispositions(reason: str = "not exercised by this fixture", **kwargs) -> list[dict]:
+    """One `no_obligation` disposition per supplied requirement.
+
+    The honest "found nothing" for decomposition since M1.2.r2. A response
+    disposing nothing is malformed and raises, so a double that returns an
+    empty list is not a no-op checker — it is a broken one.
+    """
+    return [
+        {"requirement_id": requirement_id, "disposition": "no_obligation", "reason": reason}
+        for requirement_id in _supplied_enum("requirement_id", **kwargs)
+    ]
+
+
+def _completed(response: dict, **kwargs) -> dict:
+    """Fill an empty response list from the ids the call supplied.
+
+    Two stages reject an under-filled answer rather than absorbing it, so `[]`
+    is not the neutral stand-in it used to be — a double returning one is not a
+    no-op checker but a broken one:
+
+    - decomposition (M1.2.r2, #217) — a response disposing nothing does not parse;
+    - recommendations (#218) — a weak obligation with no recommendation is an
+      error, not an absence.
+
+    Rather than make every fixture restate ids it never cared about, the doubles
+    complete both. A test that IS about either names them explicitly, and a
+    non-empty list is left alone.
+    """
+    if not isinstance(response, dict):
+        return response
+    if response.get("requirement_dispositions") == []:
+        return {**response, "requirement_dispositions": declining_dispositions(**kwargs)}
+    if response.get("recommendations") == []:
+        return {
+            **response,
+            "recommendations": [
+                {
+                    "obligation_id": obligation_id,
+                    "required_inputs": "inputs where the defect changes the outcome",
+                    "boundary_conditions": "none",
+                    "expected_output": "the criterion holds",
+                    "required_assertions": ["asserts the criterion"],
+                    "plausible_defect": "the criterion is not met",
+                    "repo_conventions": "follow the existing test module",
+                }
+                for obligation_id in _supplied_enum("obligation_id", **kwargs)
+            ],
+        }
+    return response
+
+
 def client_returning(response: dict, model: str = _DEFAULT_MODEL) -> ModelClient:
     """A client whose every call returns the same fixed response.
 
@@ -146,57 +222,6 @@ def client_dispatching(
         seed=seed,
         completion_fn=completion_fn,
     )
-
-
-def supplied_requirement_ids(**kwargs) -> list[str]:
-    """The requirement ids a decomposition call supplied, read back off the
-    schema it sent.
-
-    `constrain` restricts `requirement_id` to a `Literal` of the registry ids,
-    so the enum in the outgoing schema is the work list — which lets a double
-    answer a call completely without being told the fixture's requirements
-    separately, and keeps it honest if they change.
-    """
-    schema = kwargs["response_format"]["json_schema"]["schema"]
-    items = schema["properties"]["requirement_dispositions"]["items"]
-    ids: list[str] = []
-    for member in items.get("anyOf", [items]):
-        enum = member.get("properties", {}).get("requirement_id", {}).get("enum") or []
-        for value in enum:
-            if value not in ids:
-                ids.append(value)
-    return ids
-
-
-def declining_dispositions(reason: str = "not exercised by this fixture", **kwargs) -> list[dict]:
-    """One `no_obligation` disposition per supplied requirement.
-
-    The honest "found nothing" for decomposition since M1.2.r2. A response
-    disposing nothing is malformed and raises, so a double that returns an
-    empty list is not a no-op checker — it is a broken one.
-    """
-    return [
-        {"requirement_id": requirement_id, "disposition": "no_obligation", "reason": reason}
-        for requirement_id in supplied_requirement_ids(**kwargs)
-    ]
-
-
-def _completed(response: dict, **kwargs) -> dict:
-    """Fill in an empty `requirement_dispositions` from the requirements the
-    call supplied.
-
-    Since M1.2.r2 a decomposition response that disposes nothing does not
-    parse, so `[]` is not the neutral stand-in it used to be. Rather than make
-    every fixture restate its task file's whole requirement list, the doubles
-    complete it as a full set of declines — which keeps them well-formed while
-    leaving the obligations and questions they are actually about untouched. A
-    test that IS about dispositions names them, and this leaves it alone.
-    """
-    if not isinstance(response, dict) or response.get("requirement_dispositions") != []:
-        return response
-    if "requirement_dispositions" not in response:
-        return response
-    return {**response, "requirement_dispositions": declining_dispositions(**kwargs)}
 
 
 # An empty result per pipeline response schema (schemas are strict, so each

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -404,3 +404,51 @@ def test_a_first_review_renders_no_changes_section():
     )
 
     assert "Changes since" not in render_report(review)
+
+
+def test_a_review_with_gaps_closes_by_pointing_at_the_retrieval_command():
+    """The positive branch of `_has_gaps`, which nothing covered.
+
+    Only `"Recommended next instruction: (none)"` was asserted anywhere — the
+    no-gaps branch. The line this exists to produce appeared in no test at all,
+    just in committed fixture logs that assert nothing. Found by the tool's own
+    Gate 2 on #218, and dismissed as tautological before being checked.
+
+    It matters because the line is the only thing telling an agent the full
+    prescription is retrievable; M7.3.r1 replaced a written file with it
+    precisely so a stale artifact could not contradict the report.
+    """
+    review = Review(
+        mode="local",
+        reviewed_revision="abc",
+        obligation_map=[_obligation("A", "addressed", "nominally_supported")],
+        completion=CompletionResult(
+            verdict=CompletionVerdict.INCOMPLETE,
+            rationale="1 obligation(s) with non-discriminating test evidence.",
+        ),
+    )
+
+    report = render_report(review)
+
+    assert report.endswith(
+        "Next: retrieve a criterion's full recommendation with\n"
+        "  acceptance recommendation --criterion <id>"
+    )
+    assert "Recommended next instruction: (none)" not in report
+
+
+def test_a_review_with_no_obligations_does_not_advertise_retrieval():
+    """The second condition of `_has_gaps`, and the reason it is not simply
+    "the verdict is not positive". A review with no obligations is
+    `unable_to_determine` because there was nothing to assess — pointing it at
+    the retrieval command would advertise detail that does not exist."""
+    review = Review(
+        mode="local",
+        reviewed_revision="abc",
+        completion=CompletionResult(
+            verdict=CompletionVerdict.UNABLE_TO_DETERMINE,
+            rationale="No obligations were derived.",
+        ),
+    )
+
+    assert render_report(review).endswith("Recommended next instruction: (none)")

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -215,7 +215,13 @@ def test_open_questions_and_recommendations_are_numbered():
     assert "recommended test: Daily rate uses days_in_month" in obligation_block
     assert "detects: hard-codes /30" in obligation_block
     assert "full detail: acceptance recommendation --criterion a" in obligation_block
-    assert "Recommended tests:" not in report
+
+    # Asserted by COUNT, not by the absence of a header string. A standalone
+    # block restates the criterion, so "appears exactly once" catches one under
+    # any heading — or none — where `"Recommended tests:" not in report` only
+    # catches the old spelling.
+    assert report.count("Daily rate uses days_in_month") == 1
+    assert report.count("detects: hard-codes /30") == 1
 
 
 def test_a_recommendation_sits_under_its_own_obligation_and_no_other():

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -208,8 +208,47 @@ def test_open_questions_and_recommendations_are_numbered():
 
     assert "  1. [open] Minus sign or parentheses?" in report
     assert "  2. [resolved] Tax inclusive?" in report
-    assert "  1. Daily rate uses days_in_month" in report
-    assert "detects: hard-codes /30" in report
+
+    # The recommendation renders inside its obligation's block, on the test
+    # evidence axis it explains — not in a separate numbered list (#218, §16).
+    obligation_block = report.split("Obligations:")[1].split("Unrequested changes:")[0]
+    assert "recommended test: Daily rate uses days_in_month" in obligation_block
+    assert "detects: hard-codes /30" in obligation_block
+    assert "full detail: acceptance recommendation --criterion a" in obligation_block
+    assert "Recommended tests:" not in report
+
+
+def test_a_recommendation_sits_under_its_own_obligation_and_no_other():
+    """The join key is `obligation_id`, and using it for placement is the whole
+    point: §16 organises by obligation so a criterion's axes sit together rather
+    than in separate lists the reader must join by eye."""
+    review = Review(
+        mode="local",
+        reviewed_revision="abc",
+        obligation_map=[
+            _obligation("Weak one", "addressed", "nominally_supported"),
+            _obligation("Strong one", "addressed", "strongly_supported"),
+        ],
+        recommendations=[
+            TestRecommendation(
+                obligation_id="weak-one",
+                criterion="Weak one",
+                required_inputs="A non-30-day month",
+                boundary_conditions="0 days",
+                expected_output="price/28*days",
+                required_assertions=["assert prorate(280, 14, 28) == 140.0"],
+                plausible_defect="hard-codes /30",
+                repo_conventions="test_billing.py",
+            )
+        ],
+    )
+
+    report = render_report(review)
+    blocks = report.split("Obligations:")[1].split("Unrequested changes:")[0]
+    weak_block, strong_block = blocks.split("  2. Strong one")
+
+    assert "recommended test:" in weak_block
+    assert "recommended test:" not in strong_block
 
 
 def test_tier_label_comes_from_the_recorded_tier_not_a_hardcoded_string():

--- a/tests/test_rerun.py
+++ b/tests/test_rerun.py
@@ -687,7 +687,16 @@ def test_a_rerun_still_reports_a_gap_in_code_the_new_work_never_touched(tmp_path
     # And its gap is still reported, so the verdict still reflects it —
     # along with the instruction for closing it, which the agent still needs.
     assert any(f.related_obligation == "Beta behaves" for f in review.findings)
-    assert [r.obligation_id for r in review.recommendations] == ["beta"]
+
+    # Both weak obligations carry a recommendation: `beta` carried forward from
+    # the prior review, `alpha` derived fresh this run.
+    #
+    # This assertion previously read `== ["beta"]`, which encoded the defect
+    # #218 removed. `alpha` is weak — it is supplied to `recommend_tests` as
+    # such — and simply went without a recommendation because the stage kept
+    # whatever the response returned and never reconciled it against the weak
+    # set. A weak obligation with no recommendation is now an error.
+    assert sorted(r.obligation_id for r in review.recommendations) == ["alpha", "beta"]
     assert review.completion is not None
     assert review.completion.verdict.value != "no_material_gaps"
 

--- a/tests/test_verdict.py
+++ b/tests/test_verdict.py
@@ -7,6 +7,8 @@ question blocks a positive verdict (#113).
 derive_verdict is a pure function, so these assert its output directly — no
 model call is involved in the headline result at all."""
 
+import inspect
+
 from acceptance.review_state import (
     CompletionVerdict,
     Finding,
@@ -138,3 +140,24 @@ def test_completion_result_round_trips_through_persistence():
 
     result = derive_verdict([_obligation("a", "strongly_supported")], [], [])
     assert CompletionResult.from_dict(result.to_dict()) == result
+
+def test_the_weak_count_is_read_off_the_obligations_not_the_recommendations():
+    """The summary's weak count must not be derivable from the recommendation
+    list (#218).
+
+    If it were, a response that skipped a recommendation would *lower* the
+    reported weak count — a decomposer-style blindness where answering less
+    scores better (#214). `derive_verdict` is not given the recommendations at
+    all, which is the strongest form of that guarantee; this pins it, since a
+    later refactor threading them in would look harmless.
+    """
+    obligations = [
+        _obligation("a", "nominally_supported"),
+        _obligation("b", "unsupported"),
+        _obligation("c", "strongly_supported"),
+    ]
+
+    result = derive_verdict(obligations, [], [])
+
+    assert "2 obligation(s) with non-discriminating test evidence" in result.rationale
+    assert "recommendation" not in inspect.signature(derive_verdict).parameters


### PR DESCRIPTION
Closes #218.

One invariant, two halves: **a test recommendation exists exactly when an obligation's test evidence is below strongly-supported.**

## Placement

§16 states the rule this broke:

> Output is organized **by obligation**, so a criterion's two axes — code evidence (§9.2) and test evidence (§9.3) — sit together **rather than in separate lists the reader must join by eye**.

Recommendations are a third axis and got exactly the treatment §16 rules out. §16's own example report has no recommendations block at all. In #217's Gate 2 an obligation and its recommendation sat ~200 lines apart, joined only by a `--criterion` slug that appears nowhere in the obligation's block.

The join key already existed — `TestRecommendation.obligation_id` is what builds that command. Each recommendation now renders on the test-evidence axis it explains.

This has a cost beyond tidiness: CLAUDE.md requires reading a recommendation *before* forming an opinion on a weak obligation, which the old layout made a manual cross-reference. It was got wrong twice while building this, both times toward "already covered" — see *Dogfooding*.

## Completeness — the M1.2.r1 shape, one stage downstream

`recommend_tests` iterated the response and kept what it could place, so a response answering 3 of 5 weak obligations produced a report where two carried none — **indistinguishable from a complete answer**. The "only" half was already enforced; the "always" half was not.

Missing, duplicate and non-weak recommendations now raise. Output is ordered by weak obligation rather than response order, so reruns stay byte-identical.

`test_a_rerun_still_reports_a_gap...` asserted `== ["beta"]`, which **encoded the defect**: `alpha` is supplied to the stage as weak and simply went without.

## Not in scope

Whether an obligation needs test evidence at all — **#148**. Until that lands, design/approach and artifact-existence obligations keep drawing the tautological recommendations #148 predicts.

## Dogfooding

Gate 1 passed. `dogfood-logs/218-gate1-run1/`, `218-gate2-run{1,2,3,4}/`.

**Gate 2 run 4 reports NO-MATERIAL-GAPS, and should not be read as a clean gate.** Two reasons, both recorded in `dogfood-logs/218-gate2-run4/judgement.md`:

**It is not comparable to run 3.** The task file is byte-identical, yet **12 of 14 obligations were reworded** — #217 changed `_Decomposition`'s response schema, `request_key` hashes it, so the obligation set was re-derived by a fresh call. The 3-weak → 0-weak movement is therefore not evidence the added tests closed anything. A stable count of 14 concealed a near-total re-split.

**One obligation is a false positive:**

```
12. Represent typed schemas as pydantic models.
       code evidence: addressed
         (no corresponding change)
       test evidence: strongly supported  [tier: static]
         12.1  ...::test_recommendation_round_trips_through_persistence
         12.2  ...::test_completion_result_round_trips_through_persistence
```

Both cited tests round-trip a model through persistence; they pass whether or not the schemas are pydantic. The evidence is **inverted** — code evidence, where the answer lives, cites nothing; test evidence, which cannot hold it, carries citations. This is the same #148 obligation that read `unsupported / (no mapped test)` in runs 1-3.

That escalates #148: until now it produced honest `unsupported` readings that *blocked* gates; here it manufactured a green one. Evidence and analysis attached to #148, including that `requires_other_evidence` already exists as an `evidence_class` and is already honoured by the verdict — it is simply never produced.

Obligation 7 has the same `(no corresponding change)` shape and is correct — a preservation obligation per #133 with two discriminating tests. The shape alone is not the tell.

Mapping is sound on the DR-164 check: **14 of 14** obligations carry mapped tests, 33 links, measured from the persisted review rather than the cache.

Merging with the false positive named rather than buried, on the basis that #148 and #180/#193 track the causes and the change itself is complete and genuinely tested.

## Rebase note

`tests/support.py` **auto-merged cleanly and was semantically wrong** — both branches added a `_completed` helper in different regions, so git reported no conflict and left two definitions, the second shadowing the first. That would have disabled this PR's recommendation completion with nothing failing at merge time. Folded into one helper handling both stages.

781 tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
