### PR TITLE
Prefilter obligation pairs by cosine distance before the linking call (#259)

### DIFF
--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -24,6 +24,8 @@ from pathlib import Path
 from acceptance.change.diff import extract_change_set, extract_working_tree_change_set
 from acceptance.config import (
     DEFAULT_DECOMPOSE_BATCH_SIZE,
+    DEFAULT_EMBEDDING_MODEL,
+    DEFAULT_LINK_DISTANCE_THRESHOLD,
     DEFAULT_MAPPING_BATCH_SIZE,
     DEFAULT_MODEL,
     DEFAULT_SEED,
@@ -31,7 +33,10 @@ from acceptance.config import (
 )
 from acceptance.coverage.classify import ImplementationCoverage, classify_coverage
 from acceptance.coverage.disposition import DispositionedChange, classify_dispositions
-from acceptance.coverage.open_questions import apply_open_question_resolutions, resolve_open_questions
+from acceptance.coverage.open_questions import (
+    apply_open_question_resolutions,
+    resolve_open_questions,
+)
 from acceptance.coverage.unrequested import detect_unrequested_changes
 from acceptance.llm import LLMError, Mode, ModelClient
 from acceptance.pipeline import run_review
@@ -177,6 +182,7 @@ def run_check(
         mapping_batch_size=config.mapping_batch_size,
         decompose_batch_size=config.decompose_batch_size,
         link_pair_batch_size=config.link_pair_batch_size,
+        link_distance_threshold=config.link_distance_threshold,
         task_identifier=task,
         prior=prior,
     )
@@ -230,7 +236,11 @@ def run_decompose(task: str, config: RunConfig) -> tuple[Decomposition, Unusable
     # obligation set from the one `check` reviews, so the Gate 1 breakdown a
     # reader confirms would not be the set every later stage judges.
     linked = link_duplicate_obligations(
-        derived, client, unusable, pair_batch_size=config.link_pair_batch_size
+        derived,
+        client,
+        unusable,
+        pair_batch_size=config.link_pair_batch_size,
+        distance_threshold=config.link_distance_threshold,
     )
     return linked, unusable
 
@@ -384,8 +394,7 @@ def _orphan_obligations(result: Decomposition, requirement_map) -> list[str]:
     this command was restructured to remove.
     """
     orphans = [
-        o for o in result.obligations
-        if not requirement_map.requirements_for_obligation(o.id)
+        o for o in result.obligations if not requirement_map.requirements_for_obligation(o.id)
     ]
     if not orphans:
         return []
@@ -399,11 +408,7 @@ def _orphan_obligations(result: Decomposition, requirement_map) -> list[str]:
 
 def _unraised_questions(result: Decomposition, requirement_map) -> list[str]:
     """Open questions no requirement's disposition accounts for."""
-    claimed = {
-        qid
-        for entry in requirement_map.dispositions
-        for qid in entry.open_question_ids
-    }
+    claimed = {qid for entry in requirement_map.dispositions for qid in entry.open_question_ids}
     loose = [q for q in result.open_questions if q.id not in claimed]
     if not loose:
         return []
@@ -503,6 +508,7 @@ def run_classify(
         decompose(parsed, client, batch_size=config.decompose_batch_size),
         client,
         pair_batch_size=config.link_pair_batch_size,
+        distance_threshold=config.link_distance_threshold,
     )
     obligations = decomposition.obligations
 
@@ -523,8 +529,12 @@ def run_classify(
     coverages = classify_coverage(obligations, change_set, config.build_client())
     unrequested = detect_unrequested_changes(obligations, change_set, config.build_client())
     dispositioned = classify_dispositions(
-        unrequested, obligations, coverages, change_set,
-        config.scope_expansion_policy, config.build_client(),
+        unrequested,
+        obligations,
+        coverages,
+        change_set,
+        config.scope_expansion_policy,
+        config.build_client(),
     )
     resolutions = resolve_open_questions(
         decomposition.open_questions, change_set, config.build_client()
@@ -561,7 +571,9 @@ def render_classify(
         lines.append("  (none)")
     for cov in coverages:
         refs = ", ".join(f"{r.file}" for r in cov.diff_refs) or "no corresponding change"
-        lines.append(f"  [{cov.status.value}] {cov.obligation_id}: {descriptions.get(cov.obligation_id, '')}")
+        lines.append(
+            f"  [{cov.status.value}] {cov.obligation_id}: {descriptions.get(cov.obligation_id, '')}"
+        )
         lines.append(f"      -> {refs}")
     lines.append("")
     lines.append("Unrequested changes (no obligation calls for these — your call):")
@@ -626,6 +638,28 @@ def _add_model_flags(parser: argparse.ArgumentParser, default_mode: str) -> None
             "Requirements per obligation-derivation call (determinism; default: "
             f"{DEFAULT_DECOMPOSE_BATCH_SIZE}). Changing it invalidates recorded "
             "decompose transcripts."
+        ),
+    )
+    parser.add_argument(
+        "--embedding-model",
+        default=DEFAULT_EMBEDDING_MODEL,
+        help=(
+            "Model used to embed obligations for the linking prefilter "
+            f"(determinism; default: {DEFAULT_EMBEDDING_MODEL}). Changing it "
+            "invalidates recorded linking transcripts, and the distance "
+            "threshold is calibrated to it — a different model needs "
+            "recalibration, not the same number."
+        ),
+    )
+    parser.add_argument(
+        "--link-distance-threshold",
+        type=float,
+        default=DEFAULT_LINK_DISTANCE_THRESHOLD,
+        help=(
+            "Cosine distance above which an obligation pair is not asked about "
+            f"(determinism; default: {DEFAULT_LINK_DISTANCE_THRESHOLD}). "
+            "Changing it invalidates recorded linking transcripts. Use 2.0 to "
+            "ask about every pair."
         ),
     )
 
@@ -743,11 +777,18 @@ def main(argv: list[str] | None = None) -> int:
             temperature=args.temperature,
             mapping_batch_size=args.mapping_batch_size,
             decompose_batch_size=args.decompose_batch_size,
+            embedding_model=args.embedding_model,
+            link_distance_threshold=args.link_distance_threshold,
         )
         try:
             review = run_check(
-                args.task, args.base, args.head, config, ReviewStore(),
-                declaration=args.declaration, since=args.since,
+                args.task,
+                args.base,
+                args.head,
+                config,
+                ReviewStore(),
+                declaration=args.declaration,
+                since=args.since,
             )
         except CliError as exc:
             print(f"acceptance: error: {exc}", file=sys.stderr)
@@ -795,6 +836,8 @@ def main(argv: list[str] | None = None) -> int:
             temperature=args.temperature,
             mapping_batch_size=args.mapping_batch_size,
             decompose_batch_size=args.decompose_batch_size,
+            embedding_model=args.embedding_model,
+            link_distance_threshold=args.link_distance_threshold,
         )
         try:
             result, unusable = run_decompose(args.task, config)
@@ -833,6 +876,8 @@ def main(argv: list[str] | None = None) -> int:
             temperature=args.temperature,
             mapping_batch_size=args.mapping_batch_size,
             decompose_batch_size=args.decompose_batch_size,
+            embedding_model=args.embedding_model,
+            link_distance_threshold=args.link_distance_threshold,
         )
         try:
             obligations, open_questions, coverages, dispositioned = run_classify(

--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -33,10 +33,7 @@ from acceptance.config import (
 )
 from acceptance.coverage.classify import ImplementationCoverage, classify_coverage
 from acceptance.coverage.disposition import DispositionedChange, classify_dispositions
-from acceptance.coverage.open_questions import (
-    apply_open_question_resolutions,
-    resolve_open_questions,
-)
+from acceptance.coverage.open_questions import apply_open_question_resolutions, resolve_open_questions
 from acceptance.coverage.unrequested import detect_unrequested_changes
 from acceptance.llm import LLMError, Mode, ModelClient
 from acceptance.pipeline import run_review
@@ -394,7 +391,8 @@ def _orphan_obligations(result: Decomposition, requirement_map) -> list[str]:
     this command was restructured to remove.
     """
     orphans = [
-        o for o in result.obligations if not requirement_map.requirements_for_obligation(o.id)
+        o for o in result.obligations
+        if not requirement_map.requirements_for_obligation(o.id)
     ]
     if not orphans:
         return []
@@ -408,7 +406,11 @@ def _orphan_obligations(result: Decomposition, requirement_map) -> list[str]:
 
 def _unraised_questions(result: Decomposition, requirement_map) -> list[str]:
     """Open questions no requirement's disposition accounts for."""
-    claimed = {qid for entry in requirement_map.dispositions for qid in entry.open_question_ids}
+    claimed = {
+        qid
+        for entry in requirement_map.dispositions
+        for qid in entry.open_question_ids
+    }
     loose = [q for q in result.open_questions if q.id not in claimed]
     if not loose:
         return []
@@ -529,12 +531,8 @@ def run_classify(
     coverages = classify_coverage(obligations, change_set, config.build_client())
     unrequested = detect_unrequested_changes(obligations, change_set, config.build_client())
     dispositioned = classify_dispositions(
-        unrequested,
-        obligations,
-        coverages,
-        change_set,
-        config.scope_expansion_policy,
-        config.build_client(),
+        unrequested, obligations, coverages, change_set,
+        config.scope_expansion_policy, config.build_client(),
     )
     resolutions = resolve_open_questions(
         decomposition.open_questions, change_set, config.build_client()
@@ -571,9 +569,7 @@ def render_classify(
         lines.append("  (none)")
     for cov in coverages:
         refs = ", ".join(f"{r.file}" for r in cov.diff_refs) or "no corresponding change"
-        lines.append(
-            f"  [{cov.status.value}] {cov.obligation_id}: {descriptions.get(cov.obligation_id, '')}"
-        )
+        lines.append(f"  [{cov.status.value}] {cov.obligation_id}: {descriptions.get(cov.obligation_id, '')}")
         lines.append(f"      -> {refs}")
     lines.append("")
     lines.append("Unrequested changes (no obligation calls for these — your call):")
@@ -647,8 +643,7 @@ def _add_model_flags(parser: argparse.ArgumentParser, default_mode: str) -> None
             "Model used to embed obligations for the linking prefilter "
             f"(determinism; default: {DEFAULT_EMBEDDING_MODEL}). Changing it "
             "invalidates recorded linking transcripts, and the distance "
-            "threshold is calibrated to it — a different model needs "
-            "recalibration, not the same number."
+            "threshold is calibrated to it."
         ),
     )
     parser.add_argument(
@@ -656,8 +651,8 @@ def _add_model_flags(parser: argparse.ArgumentParser, default_mode: str) -> None
         type=float,
         default=DEFAULT_LINK_DISTANCE_THRESHOLD,
         help=(
-            "Cosine distance above which an obligation pair is not asked about "
-            f"(determinism; default: {DEFAULT_LINK_DISTANCE_THRESHOLD}). "
+            "Cosine distance above which an obligation pair is not asked "
+            f"about (determinism; default: {DEFAULT_LINK_DISTANCE_THRESHOLD}). "
             "Changing it invalidates recorded linking transcripts. Use 2.0 to "
             "ask about every pair."
         ),
@@ -782,13 +777,8 @@ def main(argv: list[str] | None = None) -> int:
         )
         try:
             review = run_check(
-                args.task,
-                args.base,
-                args.head,
-                config,
-                ReviewStore(),
-                declaration=args.declaration,
-                since=args.since,
+                args.task, args.base, args.head, config, ReviewStore(),
+                declaration=args.declaration, since=args.since,
             )
         except CliError as exc:
             print(f"acceptance: error: {exc}", file=sys.stderr)

--- a/src/acceptance/config.py
+++ b/src/acceptance/config.py
@@ -22,7 +22,7 @@ from typing import Any, Callable
 from pydantic import BaseModel, ConfigDict, Field
 
 from acceptance.llm import DEFAULT_TRANSCRIPT_ROOT, Mode, ModelClient, TranscriptStore
-from acceptance.review_state import DeterminismControls, ReviewProvenance
+from acceptance.review_state import DeterminismControls, LinkPrefilter, ReviewProvenance
 
 # LiteLLM model string. Provider-agnostic: swap freely via --model / RunConfig.
 DEFAULT_MODEL = "openai/gpt-5.4-mini"
@@ -82,6 +82,30 @@ DEFAULT_DECOMPOSE_BATCH_SIZE = 8
 # obligation, and a derivation item enumerates, types and quotes.
 DEFAULT_LINK_PAIR_BATCH_SIZE = 25
 
+# The model that embeds obligations for #259's linking prefilter. Separate from
+# DEFAULT_MODEL: nothing is judged on an embedding, so the two are chosen on
+# different grounds and swapped independently.
+DEFAULT_EMBEDDING_MODEL = "voyage/voyage-3.5-lite"
+
+# Cosine distance above which an obligation pair is not asked about (#259,
+# DR-259). A determinism control in the seed's sense — it decides which
+# questions reach the model — so changing it, or the embedding model, invalidates
+# recorded linking transcripts.
+#
+# **Scale-specific to the embedding model above.** A different one needs
+# recalibration, not this number.
+#
+# 0.10 is the under-merging side of a real trade, not a clean separator. On
+# DR-259's calibration sample it kept 20/20 genuine merges and dropped 10/10
+# spurious ones; on a held-out task file it kept 11 of 12, missing a genuine
+# merge at 0.2257 where the two obligations paraphrased each other across levels
+# of abstraction. No threshold does both — the nearest spurious merge sits at
+# 0.116, below that — so this errs the way `linking.py` already errs: a missed
+# merge leaves a redundant obligation the reader can see, while a spurious merge
+# destroys a requirement silently. #211's link-precision measure is how the
+# number gets settled properly.
+DEFAULT_LINK_DISTANCE_THRESHOLD = 0.10
+
 
 class ScopeExpansionPolicy(str, Enum):
     """How tolerant the review is of changes beyond the mandate (DR-081
@@ -118,6 +142,14 @@ class RunConfig(BaseModel):
     # And for obligation linking (#144), whose unit is a PAIR of obligations
     # rather than an obligation — see the constant's note.
     link_pair_batch_size: int = Field(default=DEFAULT_LINK_PAIR_BATCH_SIZE, ge=1)
+    # #259's prefilter. Both are determinism controls that reach the linking
+    # stage through the pipeline, like the batch sizes above, and both are
+    # hashed into the linking request so a change invalidates its transcripts.
+    embedding_model: str = DEFAULT_EMBEDDING_MODEL
+    # Bounded by the range of cosine distance itself. 0 asks nothing; 2 asks
+    # every pair and is the honest way to turn the prefilter off, which is why
+    # it is not a separate boolean.
+    link_distance_threshold: float = Field(default=DEFAULT_LINK_DISTANCE_THRESHOLD, ge=0.0, le=2.0)
     # A review-interpretation knob (consumed by the M3.5.3 separability
     # classifier), not a determinism control — so it deliberately does not
     # feed build_client() or provenance_for(). If we later want it recorded for
@@ -132,6 +164,7 @@ class RunConfig(BaseModel):
             temperature=self.temperature,
             seed=self.seed,
             completion_fn=completion_fn,
+            embedding_model=self.embedding_model,
         )
 
 
@@ -148,10 +181,12 @@ def provenance_for(client: ModelClient) -> ReviewProvenance:
     it recorded or replayed, so a replay run stays free of the provider stack.
     """
     in_force = client.controls_in_force
+    prefilter = client.prefilter_in_force
     return ReviewProvenance(
         determinism_mode=client.mode.value,
         model=client.model,
         controls_requested=DeterminismControls(temperature=client.temperature, seed=client.seed),
         controls_in_force=(None if in_force is None else DeterminismControls(**in_force)),
         request_partition_sizes=client.partition_sizes_in_force,
+        link_prefilter=(None if prefilter is None else LinkPrefilter(**prefilter)),
     )

--- a/src/acceptance/llm.py
+++ b/src/acceptance/llm.py
@@ -29,7 +29,7 @@ import json
 import sys
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, Sequence, TypeVar
 
 from pydantic import BaseModel, ConfigDict, ValidationError
 
@@ -122,6 +122,43 @@ def _default_completion_fn(**kwargs: Any) -> Any:
     return litellm.completion(drop_params=True, **kwargs)
 
 
+def _default_embedding_fn(**kwargs: Any) -> Any:
+    """Live embedding call. Imported lazily, exactly like the completion path,
+    so REPLAY still needs neither LiteLLM nor a key.
+
+    No `drop_params`: an embedding request carries no sampling controls for a
+    provider to reject, so there is nothing to drop and nothing to reconcile
+    afterwards.
+    """
+    import litellm
+
+    return litellm.embedding(**kwargs)
+
+
+def _extract_embeddings(response: Any) -> list[list[float]]:
+    """The vectors from a provider reply, in the order their inputs were sent.
+
+    Order is the only thing tying a vector back to its text — an embedding reply
+    carries no ids — so a provider that reordered `data` would silently mislabel
+    every vector. LiteLLM normalises this across providers and preserves input
+    order; `embed` additionally checks the count, which is the one part of that
+    contract a wrong reply could break observably.
+    """
+    try:
+        data = response["data"]
+    except (TypeError, KeyError, IndexError) as exc:
+        raise SchemaValidationError(f"embedding response had no data array: {exc}") from exc
+    vectors: list[list[float]] = []
+    for index, item in enumerate(data):
+        try:
+            vectors.append([float(value) for value in item["embedding"]])
+        except (TypeError, KeyError, ValueError) as exc:
+            raise SchemaValidationError(
+                f"embedding response item {index} had no numeric embedding: {exc}"
+            ) from exc
+    return vectors
+
+
 def _const_to_enum(node: Any) -> Any:
     """Rewrite `{"const": x}` as `{"enum": [x]}`.
 
@@ -133,9 +170,7 @@ def _const_to_enum(node: Any) -> Any:
     case where the constraint quietly stopped binding.
     """
     if isinstance(node, dict):
-        rewritten = {
-            key: _const_to_enum(value) for key, value in node.items() if key != "const"
-        }
+        rewritten = {key: _const_to_enum(value) for key, value in node.items() if key != "const"}
         if "const" in node:
             rewritten["enum"] = [node["const"]]
         return rewritten
@@ -247,6 +282,8 @@ class ModelClient:
         temperature: float = 0.0,
         seed: int | None = None,
         completion_fn: Callable[..., Any] | None = None,
+        embedding_model: str | None = None,
+        embedding_fn: Callable[..., Any] | None = None,
     ) -> None:
         self.model = model
         self.mode = mode
@@ -254,6 +291,13 @@ class ModelClient:
         self.temperature = temperature
         self.seed = seed
         self._completion_fn = completion_fn or _default_completion_fn
+        # A second model, on the same store and the same mode. It is not a
+        # fallback for `model` and never answers a judgment: nothing decides
+        # anything on an embedding, which only narrows which questions get
+        # asked. `None` means this client cannot embed, and `embed` says so
+        # rather than quietly skipping the work.
+        self.embedding_model = embedding_model
+        self._embedding_fn = embedding_fn or _default_embedding_fn
         # One entry per completed call: the controls that call ran under, or
         # None if nothing is known about them. Accumulated so a review's
         # provenance can report the controls actually in force rather than the
@@ -271,12 +315,20 @@ class ModelClient:
         # partitioned twice report `None` — indistinguishable from a run that
         # never partitioned at all.
         self._observed_partitions: list[tuple[str, dict]] = []
+        # One entry per stage that prefiltered its work before asking (#259).
+        # Observed, like the two above, so provenance describes the run that
+        # happened. Recorded even when nothing was excluded: "the filter ran and
+        # dropped none" and "no filter ran" are different claims, and a merge
+        # missing from a filtered run is only attributable if the reader can
+        # tell which of those they are looking at.
+        self._observed_prefilters: list[tuple[str, dict]] = []
 
     def build_request(
         self,
         messages: list[dict],
         response_model: type[BaseModel],
         partition: dict[str, Any] | None = None,
+        stage_controls: dict[str, Any] | None = None,
     ) -> dict:
         """The recorded, hashed description of a call."""
         request: dict[str, Any] = {
@@ -298,6 +350,14 @@ class ModelClient:
             # the model, so recordings made under the old partitioning must be
             # re-verified rather than silently replayed (DR-164).
             request["partition"] = partition
+        if stage_controls is not None:
+            # Same reasoning one step further out. A control that decides which
+            # work reaches the model at all — #259's distance threshold and the
+            # embedding model behind it — changes the answer as surely as the
+            # seed does, but leaves no trace in `messages` when the surviving
+            # batch happens to come out the same. Hashing it keeps a moved
+            # control from replaying as though nothing moved.
+            request["stage_controls"] = stage_controls
         return request
 
     def complete(
@@ -307,6 +367,7 @@ class ModelClient:
         partition: dict[str, Any] | None = None,
         parse_as: type[BaseModel] | None = None,
         stage: str | None = None,
+        stage_controls: dict[str, Any] | None = None,
     ) -> ResponseModelT:
         """Return a validated response, from a live call or a transcript.
 
@@ -321,7 +382,7 @@ class ModelClient:
         `SchemaValidationError` that discards every judgment in the batch. The
         stage then checks the ids itself — see `supplied_ids`.
         """
-        request = self.build_request(messages, response_model, partition)
+        request = self.build_request(messages, response_model, partition, stage_controls)
         key = request_key(request)
         record = self.store.read(key)
 
@@ -354,6 +415,163 @@ class ModelClient:
             # mapping transcript for a label that cannot change an answer.
             self._observed_partitions.append((stage or "unknown", partition))
         return self._validate(record["response"], parse_as or response_model)  # type: ignore[arg-type]
+
+    def embed(self, texts: Sequence[str]) -> list[list[float]]:
+        """Vectors for `texts`, in order, from a live call or a transcript.
+
+        Recorded and replayed exactly like `complete`, and for the same reason:
+        an embedding is a model call, so leaving it live would put a provider and
+        an API key back into `pytest` and CI, which the replay-first invariant
+        forbids. It shares the store and the mode; only the model differs.
+
+        Deliberately NOT folded into `complete`. That path is built around a
+        response schema — it hashes one, sends one, and validates against one —
+        and an embedding reply has no schema to constrain. Threading a `None`
+        schema through it would make the schema optional everywhere to serve one
+        caller that never wants it.
+
+        The result feeds no judgment (see `embedding_model`), so no determinism
+        control applies here and none is recorded: there is no temperature or
+        seed on an embedding request to honour or drop. What makes a *run*
+        reproducible is the transcript, which is keyed on the model and the exact
+        input list.
+        """
+        if self.embedding_model is None:
+            raise LLMError(
+                "this client has no embedding model configured, so it cannot embed; "
+                "pass embedding_model to ModelClient (RunConfig.embedding_model "
+                "supplies it for a normal run)"
+            )
+        # No call at all for nothing to embed — an empty request is not a
+        # transcript worth keeping, and providers reject it anyway.
+        if not texts:
+            return []
+
+        request = self.build_embedding_request(texts)
+        key = request_key(request)
+        record = self.store.read(key)
+
+        if record is None:
+            if self.mode is Mode.REPLAY:
+                raise TranscriptNotFoundError(
+                    f"no recorded transcript for embedding request {key} "
+                    f"(embedding_model={self.embedding_model}, {len(texts)} inputs); "
+                    "REPLAY mode does not fall back to a live call.\n"
+                    "\n"
+                    "The key hashes the exact input list, so this is expected "
+                    "whenever the text being embedded changes — including when an "
+                    "upstream stage rewords the obligations feeding it. Re-record "
+                    "with --mode record."
+                )
+            record = self._persist_live_embedding(key, request)
+
+        return self._validate_embeddings(record["response"], len(texts))
+
+    def build_embedding_request(self, texts: Sequence[str]) -> dict:
+        """The recorded, hashed description of an embedding call.
+
+        `kind` is explicit so an embedding request can never collide with a
+        completion one in the content-addressed store, and so a transcript says
+        what it is without the reader inferring it from which fields are absent.
+        """
+        return {
+            "kind": "embedding",
+            "model": self.embedding_model,
+            "input": list(texts),
+        }
+
+    def observe_prefilter(self, stage: str, record: dict[str, Any]) -> None:
+        """Record that a stage narrowed its own work before asking (#259).
+
+        Reported by the stage rather than derived here, because the harness
+        cannot see it: the questions the filter removed were never asked, so from
+        the client's side a filtered run and an unfiltered one are the same run
+        with fewer calls. Provenance would otherwise have no way to say that a
+        merge was never considered — see `prefilter_in_force`.
+        """
+        self._observed_prefilters.append((stage, dict(record)))
+
+    @property
+    def prefilter_in_force(self) -> dict[str, Any] | None:
+        """The prefilter a stage applied, or `None` if none did.
+
+        `None` is the positive claim that every candidate was asked about. A
+        stage that filtered and excluded nothing still reports a record, so the
+        two stay distinguishable — the whole point is that a missing merge is
+        attributable to the filter rather than invisible.
+
+        Only one stage prefilters today. Two stages reporting different records
+        would need a per-stage mapping, as `partition_sizes_in_force` already
+        has; until then a second reporter is an error rather than a silent
+        last-one-wins.
+        """
+        if not self._observed_prefilters:
+            return None
+        stages = {stage for stage, _ in self._observed_prefilters}
+        if len(stages) > 1:
+            raise LLMError(
+                f"more than one stage reported a prefilter ({sorted(stages)}); "
+                "prefilter_in_force reports a single stage and needs to become "
+                "per-stage before a second one is added"
+            )
+        merged: dict[str, Any] = {}
+        for _, record in self._observed_prefilters:
+            for name, value in record.items():
+                # Counts accumulate across calls; the controls behind them must
+                # agree, exactly as `controls_in_force` requires.
+                if isinstance(value, int) and not isinstance(value, bool):
+                    merged[name] = merged.get(name, 0) + value
+                else:
+                    merged[name] = value
+        return merged
+
+    def _persist_live_embedding(self, key: str, request: dict) -> dict:
+        """Call, validate, and only then keep — same order as `_persist_live_call`,
+        and for the same reason: a reply the harness rejects is not evidence, and
+        persisting first would let replay serve it forever (#160)."""
+        response = self._embedding_fn(
+            model=request["model"],
+            input=request["input"],
+        )
+        record = {
+            "request": request,
+            "response": _extract_embeddings(response),
+            "usage": _extract_usage(response),
+        }
+        self._validate_embeddings(record["response"], len(request["input"]))
+        self.store.write(key, record)
+        return record
+
+    @staticmethod
+    def _validate_embeddings(vectors: Any, expected: int) -> list[list[float]]:
+        """One vector per input, all the same width, all numeric.
+
+        Checked on the replay path too, not only when recording. A transcript is
+        a file on disk that a person can edit and that an older version of this
+        code may have written, so trusting its shape because it was validated
+        once is trusting the wrong thing.
+        """
+        if not isinstance(vectors, list) or len(vectors) != expected:
+            raise SchemaValidationError(
+                f"embedding response held {len(vectors) if isinstance(vectors, list) else '?'} "
+                f"vectors for {expected} inputs; a vector is matched to its text by "
+                "position, so a count mismatch makes every pairing unsafe"
+            )
+        widths = set()
+        for index, vector in enumerate(vectors):
+            if not isinstance(vector, list) or not vector:
+                raise SchemaValidationError(f"embedding {index} is not a non-empty vector")
+            if not all(
+                isinstance(value, (int, float)) and not isinstance(value, bool) for value in vector
+            ):
+                raise SchemaValidationError(f"embedding {index} holds a non-numeric component")
+            widths.add(len(vector))
+        if len(widths) > 1:
+            raise SchemaValidationError(
+                f"embedding response mixes vector widths {sorted(widths)}; "
+                "distances between them would be meaningless"
+            )
+        return vectors
 
     @property
     def controls_in_force(self) -> dict[str, Any] | None:
@@ -398,9 +616,7 @@ class ModelClient:
             if len(sizes) == 1 and isinstance(next(iter(sizes)), int)
         }
 
-    def _persist_live_call(
-        self, key: str, request: dict, response_model: type[BaseModel]
-    ) -> dict:
+    def _persist_live_call(self, key: str, request: dict, response_model: type[BaseModel]) -> dict:
         """Make the call, validate the reply, and only then keep the transcript.
 
         Validating first matters because structured output is best-effort on some

--- a/src/acceptance/pipeline.py
+++ b/src/acceptance/pipeline.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 from acceptance.config import (
     DEFAULT_DECOMPOSE_BATCH_SIZE,
+    DEFAULT_LINK_DISTANCE_THRESHOLD,
     DEFAULT_LINK_PAIR_BATCH_SIZE,
     DEFAULT_MAPPING_BATCH_SIZE,
     ScopeExpansionPolicy,
@@ -219,6 +220,7 @@ def run_review(
     mapping_batch_size: int = DEFAULT_MAPPING_BATCH_SIZE,
     decompose_batch_size: int = DEFAULT_DECOMPOSE_BATCH_SIZE,
     link_pair_batch_size: int = DEFAULT_LINK_PAIR_BATCH_SIZE,
+    link_distance_threshold: float | None = DEFAULT_LINK_DISTANCE_THRESHOLD,
     task_identifier: str = "<inline>",
     prior: Review | None = None,
 ) -> Review:
@@ -245,7 +247,9 @@ def run_review(
     # both requirements. `derived` is kept, not discarded — it is persisted as
     # provenance so a movement in the final set can be attributed to the stage
     # that caused it.
-    decomposition = link_duplicate_obligations(derived, client, unusable, link_pair_batch_size)
+    decomposition = link_duplicate_obligations(
+        derived, client, unusable, link_pair_batch_size, link_distance_threshold
+    )
 
     # Open-question resolution runs HERE, ahead of every judging stage, because
     # a question the diff resolves yields an obligation (#214) and that

--- a/src/acceptance/requirement/linking.py
+++ b/src/acceptance/requirement/linking.py
@@ -27,9 +27,25 @@ requests (DR-164), and this one must not. The judgement is inherently pairwise
 over the whole set, so a batch boundary decides which obligations *can* be
 compared at all: a duplicate pair split across two batches is invisible to both
 calls and silently under-merged. That failure looks exactly like the bias working
-as intended, so it would never surface. If the obligation count later forces
-partitioning, #211's link-precision measure needs to exist first, so the loss is
-measured rather than assumed small.
+as intended, so it would never surface.
+
+**But the sweep is no longer complete, and that is a real cost (#259, DR-259).**
+Pairs whose obligations are too far apart in embedding space are dropped before
+any call, so a duplicate can now be missed the way a partitioned one would be.
+This paragraph used to say that #211's link-precision measure had to exist first
+so the loss would be measured rather than assumed small; it does not exist, and
+the trade was made anyway on DR-259's evidence. Two things keep that honest:
+
+- The threshold errs *low*, toward asking too few — the same under-merging bias
+  stated above, for the same reason. On a held-out task file the default missed
+  one genuine merge in twelve. It is not a clean separator and the DR no longer
+  claims it is.
+- **Every dropped pair is counted and the count reaches review state**
+  (`LinkPrefilter`), because a question never asked leaves no other trace. A
+  missed merge has to be attributable to the filter rather than invisible.
+
+#211 remains how the number gets settled; it is now load-bearing rather than
+nice-to-have.
 
 The canonical obligation of a cluster is chosen **here, by derivation order**,
 not taken from the model's answer. Two runs that agree on which obligations are
@@ -39,6 +55,7 @@ model's judgement rather than of how it happened to order a response.
 
 from __future__ import annotations
 
+import math
 from typing import Sequence
 
 from acceptance.config import DEFAULT_LINK_PAIR_BATCH_SIZE
@@ -154,17 +171,60 @@ def _can_state_one_requirement(left: Obligation, right: Obligation) -> bool:
     return (left.type is ObligationType.TEST_DEMAND) == (right.type is ObligationType.TEST_DEMAND)
 
 
+def embedding_text(obligation: Obligation) -> str:
+    """What gets embedded for an obligation, for #259's distance prefilter.
+
+    `description` and `observable_behavior` joined by a single space, because
+    that is exactly what DR-259 measured. **The threshold is calibrated against
+    this string**, so changing what goes into it — adding the type, dropping the
+    behavior — moves every distance and silently invalidates the default without
+    changing it. Change this and recalibrate, or do not change it.
+    """
+    return f"{obligation.description} {obligation.observable_behavior}".strip()
+
+
+def cosine_distance(left: Sequence[float], right: Sequence[float]) -> float:
+    """1 - cosine similarity, in [0, 2].
+
+    Raw, with no normalisation against either endpoint's neighbourhood. DR-259
+    measured z-score, CSLS and mutual-rank corrections for hub effects and all
+    three performed worse, because the obligations that attract spurious merges
+    are not the ones that are geometrically central — so normalising by
+    centrality adds noise and removes almost no bias.
+    """
+    dot = sum(x * y for x, y in zip(left, right))
+    left_norm = math.sqrt(sum(x * x for x in left))
+    right_norm = math.sqrt(sum(y * y for y in right))
+    if left_norm == 0.0 or right_norm == 0.0:
+        # A zero vector has no direction, so it has no distance to anything.
+        # Treat it as maximally far rather than dividing by zero: the pair is
+        # dropped, which is the under-merging direction this module errs in.
+        return 2.0
+    return 1.0 - dot / (left_norm * right_norm)
+
+
 def _pairs(
-    ordered_ids: list[str], by_id: dict[str, Obligation] | None = None
+    ordered_ids: list[str],
+    by_id: dict[str, Obligation] | None = None,
+    vectors: dict[str, Sequence[float]] | None = None,
+    distance_threshold: float | None = None,
 ) -> list[tuple[str, str, str]]:
     """Every unordered pair that could state one requirement, with a stable id,
     in derivation order.
 
-    Quadratic and deliberately so. Every pair is asked, which is what makes the
-    sweep complete — no duplicate can be invisible the way it would be if the
-    obligations themselves were partitioned — and what makes an inconsistent
-    answer detectable. Inferring a pair from two others would assume the model's
-    judgments are consistent, and destroy the evidence that they are not.
+    Quadratic in the pairs it *considers* — the enumeration is complete, so a
+    pair id names the same pair however the gates below fall — but the pairs it
+    returns are filtered by two independent, composable rules. A pair excluded by
+    either is not asked:
+
+    - `by_id` enables the **type gate**: one obligation demanding a test and the
+      other demanding a behavior can never be the same requirement (#232).
+    - `vectors` and `distance_threshold` enable the **distance prefilter**: pairs
+      farther apart than the threshold are not asked (#259).
+
+    Both are optional and default off, so a caller that wants the complete sweep
+    gets it. `link_duplicate_obligations` is where the product's defaults are
+    applied.
     """
     # Ordered by the DISTANCE between the two obligations, not by the first of
     # them: (0,1),(1,2),(2,3)… then (0,2),(1,3)… and so on.
@@ -185,15 +245,45 @@ def _pairs(
     ordered = [
         (left, left + distance) for distance in range(1, count) for left in range(count - distance)
     ]
+
+    def admissible(left: int, right: int) -> bool:
+        left_id, right_id = ordered_ids[left], ordered_ids[right]
+        if by_id is not None and not _can_state_one_requirement(by_id[left_id], by_id[right_id]):
+            return False
+        if vectors is None or distance_threshold is None:
+            return True
+        # A pair missing a vector is asked rather than dropped. Silently
+        # excluding it would let an embedding failure quietly shrink the sweep,
+        # which is the one outcome this filter's accounting exists to prevent.
+        if left_id not in vectors or right_id not in vectors:
+            return True
+        return cosine_distance(vectors[left_id], vectors[right_id]) <= distance_threshold
+
     # Numbered before filtering, so a pair id names the same pair whether or not
     # its neighbours were skipped. Ids that are stable under an unrelated
     # obligation's type changing is worth more than ids without gaps.
     return [
         (f"pair-{index:04d}", ordered_ids[left], ordered_ids[right])
         for index, (left, right) in enumerate(ordered)
-        if by_id is None
-        or _can_state_one_requirement(by_id[ordered_ids[left]], by_id[ordered_ids[right]])
+        if admissible(left, right)
     ]
+
+
+def _embed(obligations: Sequence[Obligation], client: ModelClient) -> dict[str, Sequence[float]]:
+    """One embedding call for the whole obligation set, keyed back by id.
+
+    A single call rather than one per obligation: the vectors are only ever
+    compared with each other, and batching keeps that comparison inside one
+    recorded request instead of scattering it across N transcripts that would
+    each have to be present for a replay to work.
+
+    Order is the contract — the provider returns vectors positionally — so the
+    inputs are built from `obligations` once and zipped straight back onto the
+    same sequence.
+    """
+    texts = [embedding_text(obligation) for obligation in obligations]
+    vectors = client.embed(texts)
+    return {obligation.id: vector for obligation, vector in zip(obligations, vectors)}
 
 
 def _user_prompt(decomposition: Decomposition, batch: Sequence[tuple[str, str, str]]) -> str:
@@ -341,12 +431,18 @@ def link_duplicate_obligations(
     client: ModelClient,
     unusable_answers: UnusableAnswerLog | None = None,
     pair_batch_size: int = DEFAULT_LINK_PAIR_BATCH_SIZE,
+    distance_threshold: float | None = None,
 ) -> Decomposition:
     """Link the obligations that state the same requirement.
 
-    Sweeps every pair, in batches, and merges only cliques the model confirmed
-    outright. Returns the input unchanged when there is nothing to compare —
-    fewer than two obligations means no call is made at all.
+    Sweeps the admissible pairs, in batches, and merges only cliques the model
+    confirmed outright. Returns the input unchanged when there is nothing to
+    compare — fewer than two obligations means no call is made at all.
+
+    `distance_threshold` turns on #259's prefilter and defaults to **off**, so
+    calling this directly gives the complete sweep. The product default lives in
+    `RunConfig.link_distance_threshold` and reaches here through the pipeline,
+    the same way the batch sizes do.
     """
     obligations = decomposition.obligations
     if len(obligations) < 2:
@@ -356,7 +452,31 @@ def link_duplicate_obligations(
     by_id = {obligation.id: obligation for obligation in obligations}
     confirmed: set[frozenset[str]] = set()
 
-    askable = _pairs(ordered_ids, by_id)
+    # The type gate alone, which is what the threshold then acts on. Computed
+    # even when not prefiltering, because it is the denominator that makes
+    # `pairs_excluded` mean "excluded by DISTANCE" rather than "excluded by
+    # either rule" — two different numbers that would otherwise be conflated.
+    admissible = _pairs(ordered_ids, by_id)
+    askable = admissible
+    stage_controls: dict[str, object] | None = None
+
+    if distance_threshold is not None and admissible:
+        vectors = _embed(obligations, client)
+        askable = _pairs(ordered_ids, by_id, vectors, distance_threshold)
+        stage_controls = {
+            "distance_threshold": distance_threshold,
+            "embedding_model": client.embedding_model,
+        }
+        client.observe_prefilter(
+            _STAGE,
+            {
+                "distance_threshold": distance_threshold,
+                "embedding_model": client.embedding_model,
+                "pairs_considered": len(admissible),
+                "pairs_excluded": len(admissible) - len(askable),
+            },
+        )
+
     if not askable:
         return decomposition
 
@@ -372,6 +492,7 @@ def link_duplicate_obligations(
             batch.request_partition(),
             parse_as=_Verdicts,
             stage=_STAGE,
+            stage_controls=stage_controls,
         )
         if unusable_answers is not None:
             unusable_answers.record(scan(result, allowed, _STAGE))

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -704,6 +704,33 @@ class DeterminismControls(_Model):
     seed: int | None = None
 
 
+class LinkPrefilter(_Model):
+    """What a stage excluded from its own work before asking the model (#259).
+
+    Stored because the exclusion is otherwise undetectable. A question that was
+    never asked leaves no verdict, no unusable answer and no unreconciled
+    cluster — so a duplicate the prefilter dropped is indistinguishable from a
+    duplicate that does not exist, unless the run says how many it dropped and
+    under what threshold. That is the difference between a missed merge being
+    *attributable* and being invisible, and it is the reason DR-259 made
+    recording part of the deliverable rather than a nicety.
+
+    `pairs_excluded == 0` is a real and useful value: it says the filter ran and
+    removed nothing, which is a different claim from the filter not running —
+    the latter is `ReviewProvenance.link_prefilter is None`.
+    """
+
+    # The controls that produced the exclusion, carried alongside the count so a
+    # reader can reproduce it without consulting configuration that may since
+    # have changed.
+    distance_threshold: float
+    embedding_model: str
+    # Candidates the stage would have asked about had it not prefiltered — after
+    # any other admissibility rule, so this is what the threshold alone acted on.
+    pairs_considered: int
+    pairs_excluded: int
+
+
 class ReviewProvenance(_Model):
     """How a review was produced (§13.6 trustworthiness). Stored so a reader
     can tell what determinism controls were in force — a fixed-seed replay is
@@ -738,6 +765,10 @@ class ReviewProvenance(_Model):
     # EMPTY mapping is that claim, and a stage is absent when its own calls
     # disagreed.
     request_partition_sizes: dict[str, int] = Field(default_factory=dict)
+    # What obligation linking declined to ask about, and why (#259). `None` is
+    # the positive claim that every admissible pair was asked — see
+    # `LinkPrefilter` for why the zero case is not the same thing.
+    link_prefilter: LinkPrefilter | None = None
 
     def determinism(self) -> Literal["pinned", "unpinned", "indeterminate"]:
         """Whether this run is reproducible, derived rather than stored.

--- a/tests/benchmark/degenerate_decomposers.py
+++ b/tests/benchmark/degenerate_decomposers.py
@@ -82,7 +82,9 @@ def _faithful(labels: GroundTruthLabels) -> dict[str, Any]:
     return {
         "obligations": obligations,
         "open_questions": [
-            _question(q.id, q.description) for q in labels.open_questions if q.should_be_raised
+            _question(q.id, q.description)
+            for q in labels.open_questions
+            if q.should_be_raised
         ],
         # Filled in by `decomposer`'s completion_fn, which can see the
         # requirement ids the call supplied; a label-seeded builder cannot.
@@ -208,8 +210,9 @@ def decomposer(labels: GroundTruthLabels, *, behaviour: str) -> ModelClient:
         store=TranscriptStore(tempfile.mkdtemp()),
         temperature=0.0,
         completion_fn=completion_fn,
-        # As in `degenerate_judges`: the pipeline embeds before linking (#259),
-        # and neutral vectors keep the degenerate DECOMPOSER the only variable.
+        # As in `degenerate_judges`: the pipeline embeds before linking
+        # (#259), and neutral vectors keep the degenerate DECOMPOSER the
+        # only variable.
         embedding_model=DEFAULT_EMBEDDING_MODEL,
         embedding_fn=constant_embedding_fn,
     )

--- a/tests/benchmark/degenerate_decomposers.py
+++ b/tests/benchmark/degenerate_decomposers.py
@@ -33,13 +33,14 @@ import tempfile
 from typing import Any
 
 from acceptance.benchmark.case import GroundTruthLabels
-from acceptance.config import DEFAULT_MODEL
+from acceptance.config import DEFAULT_EMBEDDING_MODEL, DEFAULT_MODEL
 from acceptance.llm import Mode, ModelClient, TranscriptStore
 from tests.support import (
     _EMPTY_BY_SCHEMA,
     _fake_response,
     _nest_obligations,
     _supplied_enum,
+    constant_embedding_fn,
 )
 
 # Obligations the permissive decomposer adds on top of a faithful set, standing
@@ -81,9 +82,7 @@ def _faithful(labels: GroundTruthLabels) -> dict[str, Any]:
     return {
         "obligations": obligations,
         "open_questions": [
-            _question(q.id, q.description)
-            for q in labels.open_questions
-            if q.should_be_raised
+            _question(q.id, q.description) for q in labels.open_questions if q.should_be_raised
         ],
         # Filled in by `decomposer`'s completion_fn, which can see the
         # requirement ids the call supplied; a label-seeded builder cannot.
@@ -209,4 +208,8 @@ def decomposer(labels: GroundTruthLabels, *, behaviour: str) -> ModelClient:
         store=TranscriptStore(tempfile.mkdtemp()),
         temperature=0.0,
         completion_fn=completion_fn,
+        # As in `degenerate_judges`: the pipeline embeds before linking (#259),
+        # and neutral vectors keep the degenerate DECOMPOSER the only variable.
+        embedding_model=DEFAULT_EMBEDDING_MODEL,
+        embedding_fn=constant_embedding_fn,
     )

--- a/tests/benchmark/degenerate_judges.py
+++ b/tests/benchmark/degenerate_judges.py
@@ -35,9 +35,14 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from acceptance.config import DEFAULT_MODEL
+from acceptance.config import DEFAULT_EMBEDDING_MODEL, DEFAULT_MODEL
 from acceptance.llm import Mode, ModelClient, TranscriptStore
-from tests.support import _EMPTY_BY_SCHEMA, _completed, _fake_response
+from tests.support import (
+    _EMPTY_BY_SCHEMA,
+    _completed,
+    _fake_response,
+    constant_embedding_fn,
+)
 
 import tempfile
 
@@ -113,42 +118,56 @@ def degenerate_client(obligations: list[dict], *, always_strong: bool) -> ModelC
             # the difference between them to be the verdict and nothing else.
             tests = _enums(schema, "test_id")
             allowed = _enums(schema, "obligation_ids") or [o["id"] for o in obligations]
-            return _fake_response(json.dumps({
-                "mappings": [
-                    {"test_id": t, "obligation_ids": allowed, "rationale": "."}
-                    for t in tests
-                ]
-            }))
+            return _fake_response(
+                json.dumps(
+                    {
+                        "mappings": [
+                            {"test_id": t, "obligation_ids": allowed, "rationale": "."}
+                            for t in tests
+                        ]
+                    }
+                )
+            )
 
         if name == "_Discrimination":
             ids = _enums(schema, "obligation_id") or [o["id"] for o in obligations]
-            return _fake_response(json.dumps({
-                "obligations": [
+            return _fake_response(
+                json.dumps(
                     {
-                        "obligation_id": oid,
-                        "defects": [{
-                            "description": "the behaviour under review is wrong",
-                            "would_be_caught": always_strong,
-                            "reason": "fixed verdict from a degenerate judge",
-                        }],
+                        "obligations": [
+                            {
+                                "obligation_id": oid,
+                                "defects": [
+                                    {
+                                        "description": "the behaviour under review is wrong",
+                                        "would_be_caught": always_strong,
+                                        "reason": "fixed verdict from a degenerate judge",
+                                    }
+                                ],
+                            }
+                            for oid in ids
+                        ]
                     }
-                    for oid in ids
-                ]
-            }))
+                )
+            )
 
         if name == "_Coverage":
             ids = _enums(schema, "obligation_id") or [o["id"] for o in obligations]
-            return _fake_response(json.dumps({
-                "classifications": [
+            return _fake_response(
+                json.dumps(
                     {
-                        "obligation_id": oid,
-                        "status": "addressed" if always_strong else "not_addressed",
-                        "rationale": "fixed verdict from a degenerate judge",
-                        "diff_refs": [],
+                        "classifications": [
+                            {
+                                "obligation_id": oid,
+                                "status": "addressed" if always_strong else "not_addressed",
+                                "rationale": "fixed verdict from a degenerate judge",
+                                "diff_refs": [],
+                            }
+                            for oid in ids
+                        ]
                     }
-                    for oid in ids
-                ]
-            }))
+                )
+            )
 
         return _fake_response(json.dumps(_completed(_EMPTY_BY_SCHEMA[name], **kwargs)))
 
@@ -161,4 +180,10 @@ def degenerate_client(obligations: list[dict], *, always_strong: bool) -> ModelC
         store=TranscriptStore(tempfile.mkdtemp()),
         temperature=0.0,
         completion_fn=completion_fn,
+        # Linking prefilters before it asks (#259), so a client driving the full
+        # pipeline has to be able to embed. Neutral vectors, for the reason
+        # `constant_embedding_fn` gives: a degenerate JUDGE is the variable under
+        # test here, and the prefilter must not quietly become a second one.
+        embedding_model=DEFAULT_EMBEDDING_MODEL,
+        embedding_fn=constant_embedding_fn,
     )

--- a/tests/benchmark/degenerate_judges.py
+++ b/tests/benchmark/degenerate_judges.py
@@ -118,56 +118,42 @@ def degenerate_client(obligations: list[dict], *, always_strong: bool) -> ModelC
             # the difference between them to be the verdict and nothing else.
             tests = _enums(schema, "test_id")
             allowed = _enums(schema, "obligation_ids") or [o["id"] for o in obligations]
-            return _fake_response(
-                json.dumps(
-                    {
-                        "mappings": [
-                            {"test_id": t, "obligation_ids": allowed, "rationale": "."}
-                            for t in tests
-                        ]
-                    }
-                )
-            )
+            return _fake_response(json.dumps({
+                "mappings": [
+                    {"test_id": t, "obligation_ids": allowed, "rationale": "."}
+                    for t in tests
+                ]
+            }))
 
         if name == "_Discrimination":
             ids = _enums(schema, "obligation_id") or [o["id"] for o in obligations]
-            return _fake_response(
-                json.dumps(
+            return _fake_response(json.dumps({
+                "obligations": [
                     {
-                        "obligations": [
-                            {
-                                "obligation_id": oid,
-                                "defects": [
-                                    {
-                                        "description": "the behaviour under review is wrong",
-                                        "would_be_caught": always_strong,
-                                        "reason": "fixed verdict from a degenerate judge",
-                                    }
-                                ],
-                            }
-                            for oid in ids
-                        ]
+                        "obligation_id": oid,
+                        "defects": [{
+                            "description": "the behaviour under review is wrong",
+                            "would_be_caught": always_strong,
+                            "reason": "fixed verdict from a degenerate judge",
+                        }],
                     }
-                )
-            )
+                    for oid in ids
+                ]
+            }))
 
         if name == "_Coverage":
             ids = _enums(schema, "obligation_id") or [o["id"] for o in obligations]
-            return _fake_response(
-                json.dumps(
+            return _fake_response(json.dumps({
+                "classifications": [
                     {
-                        "classifications": [
-                            {
-                                "obligation_id": oid,
-                                "status": "addressed" if always_strong else "not_addressed",
-                                "rationale": "fixed verdict from a degenerate judge",
-                                "diff_refs": [],
-                            }
-                            for oid in ids
-                        ]
+                        "obligation_id": oid,
+                        "status": "addressed" if always_strong else "not_addressed",
+                        "rationale": "fixed verdict from a degenerate judge",
+                        "diff_refs": [],
                     }
-                )
-            )
+                    for oid in ids
+                ]
+            }))
 
         return _fake_response(json.dumps(_completed(_EMPTY_BY_SCHEMA[name], **kwargs)))
 
@@ -180,10 +166,10 @@ def degenerate_client(obligations: list[dict], *, always_strong: bool) -> ModelC
         store=TranscriptStore(tempfile.mkdtemp()),
         temperature=0.0,
         completion_fn=completion_fn,
-        # Linking prefilters before it asks (#259), so a client driving the full
-        # pipeline has to be able to embed. Neutral vectors, for the reason
-        # `constant_embedding_fn` gives: a degenerate JUDGE is the variable under
-        # test here, and the prefilter must not quietly become a second one.
+        # Linking prefilters before it asks (#259), so a client driving the
+        # full pipeline has to be able to embed. Neutral vectors, for the
+        # reason `constant_embedding_fn` gives: a degenerate JUDGE is the
+        # variable here, and the prefilter must not become a second one.
         embedding_model=DEFAULT_EMBEDDING_MODEL,
         embedding_fn=constant_embedding_fn,
     )

--- a/tests/requirement/test_link_prefilter.py
+++ b/tests/requirement/test_link_prefilter.py
@@ -476,6 +476,52 @@ def test_a_pair_missing_a_vector_is_asked_rather_than_dropped():
     assert len(_pairs(ordered, None, vectors, 0.10)) == 1
 
 
+def test_a_pair_exactly_at_the_threshold_is_asked_about():
+    """The boundary is inclusive: `<=`, not `<`.
+
+    Verified by mutation — flipping the comparison to `<` passed the entire
+    suite before this test existed, so nothing pinned which side of the boundary
+    the threshold falls on. The threshold is taken as the pair's own computed
+    distance rather than a literal, so the equality is exact rather than
+    approximate and the test cannot pass by floating-point luck.
+    """
+    origin = _obligation("origin", "the origin obligation")
+    edge = _obligation("edge", "an obligation exactly at the boundary")
+    vectors = {
+        embedding_text(origin): _at(0.0),
+        embedding_text(edge): _vector_for_distance(0.10),
+    }
+    exact = cosine_distance(vectors[embedding_text(origin)], vectors[embedding_text(edge)])
+
+    asked: list[str] = []
+    client = _client_recording_pairs(vectors, asked)
+    link_duplicate_obligations(_decomposition(origin, edge), client, distance_threshold=exact)
+
+    assert asked, "a pair exactly at the threshold was dropped; the comparison is < not <="
+    assert provenance_for(client).link_prefilter.pairs_excluded == 0
+
+
+def test_a_pair_just_beyond_the_threshold_is_not_asked_about():
+    """The other side of the same boundary, so the pair of tests pins `<=`
+    rather than merely tolerating anything permissive."""
+    origin = _obligation("origin", "the origin obligation")
+    edge = _obligation("edge", "an obligation just past the boundary")
+    vectors = {
+        embedding_text(origin): _at(0.0),
+        embedding_text(edge): _vector_for_distance(0.10),
+    }
+    exact = cosine_distance(vectors[embedding_text(origin)], vectors[embedding_text(edge)])
+
+    asked: list[str] = []
+    client = _client_recording_pairs(vectors, asked)
+    link_duplicate_obligations(
+        _decomposition(origin, edge), client, distance_threshold=math.nextafter(exact, 0.0)
+    )
+
+    assert asked == []
+    assert provenance_for(client).link_prefilter.pairs_excluded == 1
+
+
 def test_the_linking_path_embeds_every_obligation_exactly_once():
     """Not `embed()` in isolation — the path linking actually takes.
 

--- a/tests/requirement/test_link_prefilter.py
+++ b/tests/requirement/test_link_prefilter.py
@@ -97,7 +97,7 @@ def _decomposition(*obligations: Obligation) -> Decomposition:
     )
 
 
-def _client_recording_pairs(vectors_by_text, asked: list[str]):
+def _client_recording_pairs(vectors_by_text, asked: list[str], embedding_fn=None):
     """A client that answers `false` to everything and records the pair ids asked."""
 
     def completion_fn(**kwargs):
@@ -136,14 +136,13 @@ def _client_recording_pairs(vectors_by_text, asked: list[str]):
             usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
         )
 
-
     return ModelClient(
         model="openai/gpt-5.4-mini",
         mode=Mode.RECORD,
         store=TranscriptStore(tempfile.mkdtemp()),
         completion_fn=completion_fn,
         embedding_model=DEFAULT_EMBEDDING_MODEL,
-        embedding_fn=embedding_fn_for(vectors_by_text),
+        embedding_fn=embedding_fn or embedding_fn_for(vectors_by_text),
     )
 
 
@@ -370,7 +369,6 @@ def test_an_embedding_request_is_replayed_from_its_recording_rather_than_issued_
         calls.append(list(kwargs["input"]))
         return constant_embedding_fn(**kwargs)
 
-
     store = TranscriptStore(tempfile.mkdtemp())
     texts = ["alpha text", "beta text"]
 
@@ -429,7 +427,6 @@ def test_embedding_nothing_makes_no_call():
     def exploding(**kwargs):
         raise AssertionError("embedded an empty input list")
 
-
     client = ModelClient(
         model="openai/gpt-5.4-mini",
         mode=Mode.RECORD,
@@ -477,3 +474,84 @@ def test_a_pair_missing_a_vector_is_asked_rather_than_dropped():
     vectors = {"alpha": _at(0.0)}  # beta has none
 
     assert len(_pairs(ordered, None, vectors, 0.10)) == 1
+
+
+def test_the_linking_path_embeds_every_obligation_exactly_once():
+    """Not `embed()` in isolation — the path linking actually takes.
+
+    Catches embedding a subset, embedding one obligation twice, or collapsing
+    two obligations into a single vector: all of which leave the filter running
+    on vectors that do not correspond to the obligations being compared.
+    """
+    decomposition, vectors = _near_and_far()
+    embedded: list[list[str]] = []
+    answer = embedding_fn_for(vectors)
+
+    def recording_embedding_fn(**kwargs):
+        embedded.append(list(kwargs["input"]))
+        return answer(**kwargs)
+
+    client = _client_recording_pairs(vectors, [], embedding_fn=recording_embedding_fn)
+
+    link_duplicate_obligations(decomposition, client, distance_threshold=0.10)
+
+    assert len(embedded) == 1, "one call for the whole set, not one per obligation"
+    assert embedded[0] == [embedding_text(o) for o in decomposition.obligations]
+
+
+def test_changing_the_threshold_changes_which_pairs_are_sent():
+    """The configurable-threshold obligation, asserted on behaviour rather than
+    on the field existing: same obligations, same everything, one threshold that
+    admits a pair and one that does not."""
+    decomposition, vectors = _near_and_far()
+
+    def asked_at(threshold):
+        asked: list[str] = []
+        link_duplicate_obligations(
+            decomposition, _client_recording_pairs(vectors, asked), distance_threshold=threshold
+        )
+        return set(asked)
+
+    # `near` sits at 0.05 and `far` at 0.5, so 0.10 admits one pair and 0.60 all three.
+    narrow, wide = asked_at(0.10), asked_at(0.60)
+    assert narrow < wide
+    assert len(narrow) == 1
+    assert len(wide) == 3
+
+
+def test_the_default_run_filters_at_the_documented_default():
+    """The default path, with no threshold named anywhere — what a real run does."""
+    decomposition, vectors = _near_and_far()
+    asked: list[str] = []
+    client = _client_recording_pairs(vectors, asked)
+
+    link_duplicate_obligations(
+        decomposition, client, distance_threshold=RunConfig().link_distance_threshold
+    )
+
+    assert DEFAULT_LINK_DISTANCE_THRESHOLD == 0.10
+    assert provenance_for(client).link_prefilter.distance_threshold == 0.10
+    # 0.10 admits only origin+near; the two pairs involving `far` are dropped.
+    assert len(asked) == 1
+
+
+def test_both_records_survive_a_round_trip_through_the_persisted_review():
+    """The obligation says *persisted* review state, and every other test here
+    asserts the in-memory object. A field that serialises but does not read back
+    would pass all of those and fail the requirement."""
+    from acceptance.review_state import LinkPrefilter, Review
+    from acceptance.review_store import ReviewStore
+
+    decomposition, vectors = _near_and_far()
+    client = _client_recording_pairs(vectors, [])
+    link_duplicate_obligations(decomposition, client, distance_threshold=0.10)
+
+    review = Review(mode="local", reviewed_revision="deadbeef", provenance=provenance_for(client))
+    store = ReviewStore(tempfile.mkdtemp())
+    store.write(review)
+
+    reloaded = store.read("deadbeef").provenance.link_prefilter
+    assert isinstance(reloaded, LinkPrefilter)
+    assert reloaded.pairs_excluded == 2
+    assert reloaded.distance_threshold == 0.10
+    assert reloaded.embedding_model == DEFAULT_EMBEDDING_MODEL

--- a/tests/requirement/test_link_prefilter.py
+++ b/tests/requirement/test_link_prefilter.py
@@ -1,0 +1,479 @@
+"""#259 — obligation pairs too far apart in embedding space are never asked about.
+
+The prefilter's whole risk is that it removes questions silently, so these tests
+are mostly about what is *not* sent and what the run says it dropped. Distances
+come from hand-placed vectors rather than a real embedding model: the threshold
+is calibrated to `voyage-3.5-lite` and this suite is about the mechanism, not
+about that calibration, which #211 is the way to settle.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import tempfile
+
+import pytest
+
+from acceptance.config import (
+    DEFAULT_EMBEDDING_MODEL,
+    DEFAULT_LINK_DISTANCE_THRESHOLD,
+    RunConfig,
+    provenance_for,
+)
+from acceptance.llm import (
+    LLMError,
+    Mode,
+    ModelClient,
+    TranscriptNotFoundError,
+    TranscriptStore,
+    request_key,
+)
+from acceptance.requirement.linking import (
+    _pairs,
+    _Verdicts,
+    cosine_distance,
+    embedding_text,
+    link_duplicate_obligations,
+)
+from acceptance.requirement.obligations import Decomposition
+from acceptance.review_state import (
+    Disposition,
+    Obligation,
+    ObligationType,
+    RequirementDisposition,
+    RequirementMap,
+    RequirementRef,
+    RequirementSection,
+)
+from acceptance.source_ref import TextSpan
+from tests.support import constant_embedding_fn, embedding_fn_for
+
+
+# Unit vectors at chosen angles, so a test states the distance it wants.
+# cosine_distance(_at(0), _at(theta)) == 1 - cos(theta).
+def _at(radians: float) -> list[float]:
+    return [math.cos(radians), math.sin(radians)]
+
+
+def _vector_for_distance(distance: float) -> list[float]:
+    """A vector whose cosine distance from `_at(0)` is exactly `distance`."""
+    return _at(math.acos(1.0 - distance))
+
+
+def _obligation(obligation_id: str, description: str, typ=ObligationType.FUNCTIONAL) -> Obligation:
+    return Obligation(
+        id=obligation_id,
+        description=description,
+        type=typ,
+        importance="critical",
+        explicit=True,
+        observable_behavior=f"{obligation_id}() holds",
+        source_spans=[TextSpan(text=description, start=0, end=len(description))],
+    )
+
+
+def _decomposition(*obligations: Obligation) -> Decomposition:
+    requirements = [
+        RequirementRef(
+            id=f"constraint-{index:02d}",
+            section=RequirementSection.CONSTRAINT,
+            ordinal=index,
+            span=TextSpan(text=obligation.description, start=0, end=len(obligation.description)),
+        )
+        for index, obligation in enumerate(obligations)
+    ]
+    dispositions = [
+        RequirementDisposition(
+            requirement_id=f"constraint-{index:02d}",
+            disposition=Disposition.YIELDED,
+            obligation_ids=[obligation.id],
+        )
+        for index, obligation in enumerate(obligations)
+    ]
+    return Decomposition(
+        obligations=list(obligations),
+        requirement_map=RequirementMap(requirements=requirements, dispositions=dispositions),
+    )
+
+
+def _client_recording_pairs(vectors_by_text, asked: list[str]):
+    """A client that answers `false` to everything and records the pair ids asked."""
+
+    def completion_fn(**kwargs):
+        from types import SimpleNamespace
+
+        schema = kwargs["response_format"]["json_schema"]["schema"]
+        found: list[str] = []
+
+        def walk(node, key=None):
+            if isinstance(node, dict):
+                if key == "pair_id" and isinstance(node.get("enum"), list):
+                    found.extend(v for v in node["enum"] if v not in found)
+                for name, value in node.items():
+                    walk(value, name if name not in ("properties", "$defs", "items") else key)
+            elif isinstance(node, list):
+                for item in node:
+                    walk(item, key)
+
+        walk(schema)
+        asked.extend(found)
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content=json.dumps(
+                            {
+                                "verdicts": [
+                                    {"pair_id": p, "same_requirement": False, "reason": "no"}
+                                    for p in found
+                                ]
+                            }
+                        )
+                    )
+                )
+            ],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+
+
+    return ModelClient(
+        model="openai/gpt-5.4-mini",
+        mode=Mode.RECORD,
+        store=TranscriptStore(tempfile.mkdtemp()),
+        completion_fn=completion_fn,
+        embedding_model=DEFAULT_EMBEDDING_MODEL,
+        embedding_fn=embedding_fn_for(vectors_by_text),
+    )
+
+
+def _near_and_far():
+    """Three obligations: `near` sits 0.05 from `origin`, `far` sits 0.5."""
+    origin = _obligation("origin", "the origin obligation")
+    near = _obligation("near", "a near obligation")
+    far = _obligation("far", "a distant obligation")
+    vectors = {
+        embedding_text(origin): _at(0.0),
+        embedding_text(near): _vector_for_distance(0.05),
+        embedding_text(far): _vector_for_distance(0.5),
+    }
+    return _decomposition(origin, near, far), vectors
+
+
+# --- the two headline behaviours -------------------------------------------
+
+
+def test_a_pair_beyond_the_threshold_is_never_sent_to_the_model():
+    decomposition, vectors = _near_and_far()
+    asked: list[str] = []
+    client = _client_recording_pairs(vectors, asked)
+
+    link_duplicate_obligations(decomposition, client, distance_threshold=0.10)
+
+    pair_ids = {p: (a, b) for p, a, b in _pairs(["origin", "near", "far"])}
+    asked_pairs = {frozenset(pair_ids[p]) for p in asked}
+    assert frozenset(("origin", "far")) not in asked_pairs
+    assert frozenset(("near", "far")) not in asked_pairs
+
+
+def test_a_pair_within_the_threshold_is_sent_to_the_model():
+    decomposition, vectors = _near_and_far()
+    asked: list[str] = []
+    client = _client_recording_pairs(vectors, asked)
+
+    link_duplicate_obligations(decomposition, client, distance_threshold=0.10)
+
+    pair_ids = {p: (a, b) for p, a, b in _pairs(["origin", "near", "far"])}
+    asked_pairs = {frozenset(pair_ids[p]) for p in asked}
+    assert frozenset(("origin", "near")) in asked_pairs
+
+
+# --- what the run says it dropped ------------------------------------------
+
+
+def test_the_number_of_pairs_excluded_by_distance_reaches_review_state():
+
+    decomposition, vectors = _near_and_far()
+    client = _client_recording_pairs(vectors, [])
+
+    link_duplicate_obligations(decomposition, client, distance_threshold=0.10)
+
+    prefilter = provenance_for(client).link_prefilter
+    assert prefilter is not None
+    # Three obligations, three pairs, of which two involve `far`.
+    assert prefilter.pairs_considered == 3
+    assert prefilter.pairs_excluded == 2
+
+
+def test_the_threshold_in_force_reaches_review_state():
+
+    decomposition, vectors = _near_and_far()
+    client = _client_recording_pairs(vectors, [])
+
+    link_duplicate_obligations(decomposition, client, distance_threshold=0.17)
+
+    prefilter = provenance_for(client).link_prefilter
+    assert prefilter is not None
+    assert prefilter.distance_threshold == 0.17
+    assert prefilter.embedding_model == DEFAULT_EMBEDDING_MODEL
+
+
+def test_a_filter_that_excluded_nothing_still_reports_a_record():
+    """`pairs_excluded == 0` and "no filter ran" are different claims, and only
+    the second is `None`. Without this the reader cannot tell a complete sweep
+    from one that happened to drop nothing."""
+
+    decomposition, vectors = _near_and_far()
+    client = _client_recording_pairs(vectors, [])
+
+    link_duplicate_obligations(decomposition, client, distance_threshold=2.0)
+
+    prefilter = provenance_for(client).link_prefilter
+    assert prefilter is not None
+    assert prefilter.pairs_excluded == 0
+
+
+def test_no_prefilter_reports_none_rather_than_a_zero_record():
+
+    decomposition, vectors = _near_and_far()
+    client = _client_recording_pairs(vectors, [])
+
+    link_duplicate_obligations(decomposition, client, distance_threshold=None)
+
+    assert provenance_for(client).link_prefilter is None
+
+
+# --- composition with the type gate ----------------------------------------
+
+
+def test_a_pair_excluded_for_stating_a_different_kind_of_demand_stays_excluded():
+    """The two rules compose; neither can readmit what the other excluded.
+
+    Placed at distance 0 so the prefilter would admit it on distance alone —
+    the exclusion here can only come from the type gate."""
+    behaviour = _obligation("behaviour", "the thing happens", ObligationType.FUNCTIONAL)
+    demand = _obligation("demand", "a test asserts the thing happens", ObligationType.TEST_DEMAND)
+    vectors = {embedding_text(behaviour): _at(0.0), embedding_text(demand): _at(0.0)}
+    decomposition = _decomposition(behaviour, demand)
+
+    assert cosine_distance(vectors[embedding_text(behaviour)], vectors[embedding_text(demand)]) == 0
+
+    asked: list[str] = []
+    client = _client_recording_pairs(vectors, asked)
+    link_duplicate_obligations(decomposition, client, distance_threshold=0.10)
+
+    assert asked == []
+
+
+def test_pairs_excluded_counts_only_the_distance_exclusions():
+    """The denominator is the type-gated set, so `pairs_excluded` means
+    "excluded by DISTANCE" rather than "excluded by either rule" — two numbers
+    that would otherwise be silently conflated."""
+
+    behaviour = _obligation("behaviour", "the thing happens", ObligationType.FUNCTIONAL)
+    demand = _obligation("demand", "a test asserts it", ObligationType.TEST_DEMAND)
+    far = _obligation("far", "something else entirely", ObligationType.FUNCTIONAL)
+    vectors = {
+        embedding_text(behaviour): _at(0.0),
+        embedding_text(demand): _at(0.0),
+        embedding_text(far): _vector_for_distance(0.5),
+    }
+    client = _client_recording_pairs(vectors, [])
+
+    link_duplicate_obligations(
+        _decomposition(behaviour, demand, far), client, distance_threshold=0.10
+    )
+
+    prefilter = provenance_for(client).link_prefilter
+    # Of three pairs, behaviour+demand is type-gated out before distance is
+    # consulted, leaving two considered; behaviour+far is the one dropped on
+    # distance. demand+far is type-gated too.
+    assert prefilter.pairs_considered == 1
+    assert prefilter.pairs_excluded == 1
+
+
+# --- determinism ------------------------------------------------------------
+
+
+def _key_under(client, controls) -> str:
+    """The request key one linking call would get under `controls`, holding the
+    prompt fixed so only the control can move it."""
+    return request_key(
+        client.build_request(
+            [{"role": "user", "content": "identical prompt"}], _Verdicts, None, controls
+        )
+    )
+
+
+def test_changing_the_threshold_invalidates_the_recorded_linking_requests():
+    """The threshold reaches the hashed request, so a moved control cannot
+    replay as though nothing moved — even when the surviving pair set is
+    identical, which is exactly when the prompt alone would not show it."""
+    _, vectors = _near_and_far()
+    client = _client_recording_pairs(vectors, [])
+    base = {"distance_threshold": 0.10, "embedding_model": DEFAULT_EMBEDDING_MODEL}
+
+    assert _key_under(client, base) != _key_under(client, {**base, "distance_threshold": 0.12})
+
+
+def test_changing_the_embedding_model_invalidates_the_recorded_linking_requests():
+    _, vectors = _near_and_far()
+    client = _client_recording_pairs(vectors, [])
+    base = {"distance_threshold": 0.10, "embedding_model": "voyage/voyage-3.5-lite"}
+
+    assert _key_under(client, base) != _key_under(
+        client, {**base, "embedding_model": "openai/text-embedding-3-small"}
+    )
+
+
+def test_the_linking_call_actually_carries_the_prefilter_controls():
+    """The two tests above prove the harness hashes `stage_controls`; this one
+    proves the linking stage supplies them. Without it they would pass over a
+    mechanism nothing uses."""
+    decomposition, vectors = _near_and_far()
+    client = _client_recording_pairs(vectors, [])
+
+    link_duplicate_obligations(decomposition, client, distance_threshold=0.10)
+
+    recorded = [
+        json.loads(path.read_text())["request"] for path in client.store.root.glob("*.json")
+    ]
+    linking = [r for r in recorded if r.get("kind") != "embedding"]
+    assert linking, "no linking request was recorded"
+    for request in linking:
+        assert request["stage_controls"] == {
+            "distance_threshold": 0.10,
+            "embedding_model": DEFAULT_EMBEDDING_MODEL,
+        }
+
+
+def test_two_runs_over_the_same_obligation_set_choose_the_same_pairs():
+    decomposition, vectors = _near_and_far()
+
+    def chosen():
+        asked: list[str] = []
+        link_duplicate_obligations(
+            decomposition, _client_recording_pairs(vectors, asked), distance_threshold=0.10
+        )
+        return asked
+
+    assert chosen() == chosen()
+
+
+# --- the embedding call itself ---------------------------------------------
+
+
+def test_an_embedding_request_is_replayed_from_its_recording_rather_than_issued_again():
+    calls: list[list[str]] = []
+
+    def counting_embedding_fn(**kwargs):
+        calls.append(list(kwargs["input"]))
+        return constant_embedding_fn(**kwargs)
+
+
+    store = TranscriptStore(tempfile.mkdtemp())
+    texts = ["alpha text", "beta text"]
+
+    def fresh(mode):
+        return ModelClient(
+            model="openai/gpt-5.4-mini",
+            mode=mode,
+            store=store,
+            completion_fn=lambda **kw: None,
+            embedding_model=DEFAULT_EMBEDDING_MODEL,
+            embedding_fn=counting_embedding_fn,
+        )
+
+    recorded = fresh(Mode.RECORD).embed(texts)
+    assert len(calls) == 1
+
+    # A second client, sharing only the store, in REPLAY — so nothing but the
+    # transcript can answer it.
+    replayed = fresh(Mode.REPLAY).embed(texts)
+
+    assert replayed == recorded
+    assert len(calls) == 1, "replay issued a second live embedding call"
+
+
+def test_replay_without_a_recording_raises_rather_than_calling_a_provider():
+
+    client = ModelClient(
+        model="openai/gpt-5.4-mini",
+        mode=Mode.REPLAY,
+        store=TranscriptStore(tempfile.mkdtemp()),
+        completion_fn=lambda **kw: None,
+        embedding_model=DEFAULT_EMBEDDING_MODEL,
+        embedding_fn=lambda **kw: pytest.fail("REPLAY reached the provider"),
+    )
+
+    with pytest.raises(TranscriptNotFoundError):
+        client.embed(["never recorded"])
+
+
+def test_a_client_with_no_embedding_model_says_so_rather_than_skipping_the_filter():
+    """Silently returning "no vectors" would disable the prefilter without
+    anyone noticing, which is the failure mode this whole issue is about."""
+
+    client = ModelClient(
+        model="openai/gpt-5.4-mini",
+        mode=Mode.RECORD,
+        store=TranscriptStore(tempfile.mkdtemp()),
+        completion_fn=lambda **kw: None,
+    )
+
+    with pytest.raises(LLMError, match="no embedding model"):
+        client.embed(["anything"])
+
+
+def test_embedding_nothing_makes_no_call():
+    def exploding(**kwargs):
+        raise AssertionError("embedded an empty input list")
+
+
+    client = ModelClient(
+        model="openai/gpt-5.4-mini",
+        mode=Mode.RECORD,
+        store=TranscriptStore(tempfile.mkdtemp()),
+        completion_fn=lambda **kw: None,
+        embedding_model=DEFAULT_EMBEDDING_MODEL,
+        embedding_fn=exploding,
+    )
+
+    assert client.embed([]) == []
+
+
+# --- the wiring, not just the function --------------------------------------
+
+
+def test_the_configured_threshold_reaches_the_linking_stage():
+    """`RunConfig`'s default is what a real run uses. A prefilter with a perfect
+    unit test that the pipeline never passes a threshold to is the exact shape of
+    hole defect injection keeps finding here."""
+    assert RunConfig().link_distance_threshold == DEFAULT_LINK_DISTANCE_THRESHOLD
+    assert RunConfig().embedding_model == DEFAULT_EMBEDDING_MODEL
+    assert RunConfig().build_client().embedding_model == DEFAULT_EMBEDDING_MODEL
+
+
+def test_embedding_text_is_description_and_observable_behavior():
+    """The threshold is calibrated against exactly this string (DR-259), so a
+    change here silently invalidates the default without changing it."""
+    obligation = _obligation("alpha", "the description")
+    assert embedding_text(obligation) == "the description alpha() holds"
+
+
+def test_cosine_distance_matches_the_definition():
+    assert cosine_distance([1.0, 0.0], [1.0, 0.0]) == pytest.approx(0.0)
+    assert cosine_distance([1.0, 0.0], [0.0, 1.0]) == pytest.approx(1.0)
+    assert cosine_distance([1.0, 0.0], [-1.0, 0.0]) == pytest.approx(2.0)
+    # A zero vector has no direction; treated as maximally far, the under-merging
+    # direction, rather than dividing by zero.
+    assert cosine_distance([0.0, 0.0], [1.0, 0.0]) == 2.0
+
+
+def test_a_pair_missing_a_vector_is_asked_rather_than_dropped():
+    """An embedding failure must not quietly shrink the sweep — that is the one
+    outcome the filter's accounting exists to prevent."""
+    ordered = ["alpha", "beta"]
+    vectors = {"alpha": _at(0.0)}  # beta has none
+
+    assert len(_pairs(ordered, None, vectors, 0.10)) == 1

--- a/tests/support.py
+++ b/tests/support.py
@@ -16,7 +16,7 @@ import pathlib
 import tempfile
 from types import SimpleNamespace
 
-from acceptance.config import DEFAULT_MODEL
+from acceptance.config import DEFAULT_EMBEDDING_MODEL, DEFAULT_MODEL
 from acceptance.llm import Mode, ModelClient, TranscriptStore
 from acceptance.review_state import Obligation, ObligationType
 
@@ -24,6 +24,43 @@ from acceptance.review_state import Obligation, ObligationType
 # stands in for a model the tool does not actually run. It had drifted to a
 # hardcoded Anthropic string while the real default was OpenAI.
 _DEFAULT_MODEL = DEFAULT_MODEL
+
+
+def constant_embedding_fn(**kwargs) -> dict:
+    """The neutral embedding double: every input gets the SAME vector.
+
+    Neutral on purpose. Every distance is then 0, so #259's prefilter admits
+    every pair and a test that is not about the prefilter exercises exactly the
+    sweep it did before the prefilter existed. A double returning arbitrary or
+    hash-derived vectors would put most pairs far apart and silently shrink the
+    sweep under every unrelated test — turning them into tests of the filter
+    rather than of what they are about.
+
+    A test that IS about the filter injects its own `embedding_fn`; see
+    `embedding_fn_for`.
+    """
+    return {"data": [{"embedding": [1.0, 0.0, 0.0]} for _ in kwargs["input"]]}
+
+
+def embedding_fn_for(vectors_by_text: dict[str, list[float]], default: list[float] | None = None):
+    """An embedding double answering from a text -> vector table.
+
+    Keyed by the exact string embedded, which for obligations is
+    `linking.embedding_text` — description and observable behavior joined by a
+    space — so a test states the geometry it wants rather than reverse-
+    engineering it from a hash.
+    """
+
+    def embedding_fn(**kwargs):
+        data = []
+        for text in kwargs["input"]:
+            vector = vectors_by_text.get(text, default)
+            if vector is None:
+                raise AssertionError(f"no vector supplied for embedded text: {text!r}")
+            data.append({"embedding": list(vector)})
+        return {"data": data}
+
+    return embedding_fn
 
 
 def _fake_response(content: str) -> SimpleNamespace:
@@ -196,7 +233,7 @@ def _completed(response: dict, **kwargs) -> dict:
     return _nest_obligations(response)
 
 
-def client_returning(response: dict, model: str = _DEFAULT_MODEL) -> ModelClient:
+def client_returning(response: dict, model: str = _DEFAULT_MODEL, embedding_fn=None) -> ModelClient:
     """A client whose every call returns the same fixed response.
 
     A `requirement_dispositions` of `[]` is completed from the requirements the
@@ -214,10 +251,12 @@ def client_returning(response: dict, model: str = _DEFAULT_MODEL) -> ModelClient
         mode=Mode.RECORD,
         store=TranscriptStore(tempfile.mkdtemp()),
         completion_fn=completion_fn,
+        embedding_model=DEFAULT_EMBEDDING_MODEL,
+        embedding_fn=embedding_fn or constant_embedding_fn,
     )
 
 
-def model_client_with(completion_fn, model: str = _DEFAULT_MODEL) -> ModelClient:
+def model_client_with(completion_fn, model: str = _DEFAULT_MODEL, embedding_fn=None) -> ModelClient:
     """A client backed by a caller-supplied `completion_fn`.
 
     For tests that need to vary the answer per call — which partitioned stages
@@ -229,11 +268,13 @@ def model_client_with(completion_fn, model: str = _DEFAULT_MODEL) -> ModelClient
         mode=Mode.RECORD,
         store=TranscriptStore(tempfile.mkdtemp()),
         completion_fn=completion_fn,
+        embedding_model=DEFAULT_EMBEDDING_MODEL,
+        embedding_fn=embedding_fn or constant_embedding_fn,
     )
 
 
 def client_answering_per_call(
-    responder, model: str = _DEFAULT_MODEL
+    responder, model: str = _DEFAULT_MODEL, embedding_fn=None
 ) -> tuple[ModelClient, list[dict]]:
     """A client that answers each call from the prompt it was given.
 
@@ -255,12 +296,14 @@ def client_answering_per_call(
         mode=Mode.RECORD,
         store=TranscriptStore(tempfile.mkdtemp()),
         completion_fn=completion_fn,
+        embedding_model=DEFAULT_EMBEDDING_MODEL,
+        embedding_fn=embedding_fn or constant_embedding_fn,
     )
     return client, calls
 
 
 def client_capturing_schemas(
-    response: dict, model: str = _DEFAULT_MODEL
+    response: dict, model: str = _DEFAULT_MODEL, embedding_fn=None
 ) -> tuple[ModelClient, list[dict]]:
     """A client returning a fixed response, recording the schema each call sent.
 
@@ -279,6 +322,8 @@ def client_capturing_schemas(
         mode=Mode.RECORD,
         store=TranscriptStore(tempfile.mkdtemp()),
         completion_fn=completion_fn,
+        embedding_model=DEFAULT_EMBEDDING_MODEL,
+        embedding_fn=embedding_fn or constant_embedding_fn,
     )
     return client, schemas
 
@@ -301,6 +346,7 @@ def client_dispatching(
     model: str = _DEFAULT_MODEL,
     temperature: float = 0.0,
     seed: int | None = None,
+    embedding_fn=None,
 ) -> ModelClient:
     """A client for multi-call hooks: each call returns the response keyed by
     its response schema's class name (e.g. `_Decomposition`, `_Coverage`).
@@ -329,6 +375,8 @@ def client_dispatching(
         temperature=temperature,
         seed=seed,
         completion_fn=completion_fn,
+        embedding_model=DEFAULT_EMBEDDING_MODEL,
+        embedding_fn=embedding_fn or constant_embedding_fn,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,16 +13,7 @@ def test_check_json_emits_a_structured_review(git_repo, fixture_task_path, capsy
     """--json emits the full structured Review. With a checker that finds
     nothing, the analysis fields are empty but the shape is complete."""
     exit_code = main(
-        [
-            "check",
-            "--json",
-            "--task",
-            fixture_task_path,
-            "--base",
-            git_repo["base"],
-            "--head",
-            git_repo["head"],
-        ]
+        ["check", "--json", "--task", fixture_task_path, "--base", git_repo["base"], "--head", git_repo["head"]]
     )
 
     assert exit_code == 0
@@ -51,16 +42,7 @@ def test_a_default_cli_run_is_seeded(git_repo, fixture_task_path, capsys, stub_m
     `seed is None`, which locked the defect in (#160).
     """
     exit_code = main(
-        [
-            "check",
-            "--json",
-            "--task",
-            fixture_task_path,
-            "--base",
-            git_repo["base"],
-            "--head",
-            git_repo["head"],
-        ]
+        ["check", "--json", "--task", fixture_task_path, "--base", git_repo["base"], "--head", git_repo["head"]]
     )
 
     assert exit_code == 0
@@ -71,22 +53,13 @@ def test_a_default_cli_run_is_seeded(git_repo, fixture_task_path, capsys, stub_m
     assert review["provenance"]["controls_in_force"] == {"temperature": 0.0, "seed": DEFAULT_SEED}
 
 
-def test_no_seed_is_the_deliberate_way_to_run_unpinned(
-    git_repo, fixture_task_path, capsys, stub_model
-):
+def test_no_seed_is_the_deliberate_way_to_run_unpinned(git_repo, fixture_task_path, capsys, stub_model):
     """Seeding by default must still leave a way out: M-B0.4 samples a provider
     repeatedly to disclose variance, which a fixed seed would suppress."""
     exit_code = main(
         [
-            "check",
-            "--json",
-            "--task",
-            fixture_task_path,
-            "--base",
-            git_repo["base"],
-            "--head",
-            git_repo["head"],
-            "--no-seed",
+            "check", "--json", "--task", fixture_task_path,
+            "--base", git_repo["base"], "--head", git_repo["head"], "--no-seed",
         ]
     )
 
@@ -98,27 +71,17 @@ def test_no_seed_is_the_deliberate_way_to_run_unpinned(
     assert provenance["controls_in_force"]["seed"] is None
 
 
-def test_check_records_determinism_flags_in_provenance(
-    git_repo, fixture_task_path, capsys, stub_model
-):
+def test_check_records_determinism_flags_in_provenance(git_repo, fixture_task_path, capsys, stub_model):
     exit_code = main(
         [
-            "check",
-            "--json",
-            "--task",
-            fixture_task_path,
-            "--base",
-            git_repo["base"],
-            "--head",
-            git_repo["head"],
-            "--model",
-            "openai/gpt-5",
-            "--mode",
-            "record",
-            "--seed",
-            "7",
-            "--temperature",
-            "0.4",
+            "check", "--json",
+            "--task", fixture_task_path,
+            "--base", git_repo["base"],
+            "--head", git_repo["head"],
+            "--model", "openai/gpt-5",
+            "--mode", "record",
+            "--seed", "7",
+            "--temperature", "0.4",
         ]
     )
 
@@ -135,10 +98,10 @@ def test_check_records_determinism_flags_in_provenance(
         # at different scale (#204); an EMPTY mapping is the "unpartitioned
         # run" claim, not a null.
         "request_partition_sizes": {"decompose": DEFAULT_DECOMPOSE_BATCH_SIZE},
-        # None, not a zero-valued record: this stub finds no obligations at all,
-        # so linking returns before it prefilters anything and the honest claim
-        # is that no filter ran (#259). A run that filtered and excluded nothing
-        # reports a record with `pairs_excluded: 0` instead — see LinkPrefilter.
+        # None, not a zero-valued record: this stub finds no obligations at
+        # all, so linking returns before it prefilters anything and the honest
+        # claim is that no filter ran (#259). A run that filtered and excluded
+        # nothing reports `pairs_excluded: 0` instead — see LinkPrefilter.
         "link_prefilter": None,
     }
 
@@ -148,29 +111,17 @@ def test_check_rejects_unknown_mode(git_repo, fixture_task_path):
         main(
             [
                 "check",
-                "--task",
-                fixture_task_path,
-                "--base",
-                git_repo["base"],
-                "--head",
-                git_repo["head"],
-                "--mode",
-                "live",
+                "--task", fixture_task_path,
+                "--base", git_repo["base"],
+                "--head", git_repo["head"],
+                "--mode", "live",
             ]
         )
 
 
-def test_two_runs_over_the_same_input_are_byte_identical(
-    git_repo, fixture_task_path, capsys, stub_model
-):
+def test_two_runs_over_the_same_input_are_byte_identical(git_repo, fixture_task_path, capsys, stub_model):
     args = [
-        "check",
-        "--task",
-        fixture_task_path,
-        "--base",
-        git_repo["base"],
-        "--head",
-        git_repo["head"],
+        "check", "--task", fixture_task_path, "--base", git_repo["base"], "--head", git_repo["head"]
     ]
 
     assert main(args) == 0
@@ -181,19 +132,9 @@ def test_two_runs_over_the_same_input_are_byte_identical(
     assert first == second
 
 
-def test_report_shell_renders_all_sections_present_and_empty(
-    git_repo, fixture_task_path, capsys, stub_model
-):
+def test_report_shell_renders_all_sections_present_and_empty(git_repo, fixture_task_path, capsys, stub_model):
     exit_code = main(
-        [
-            "check",
-            "--task",
-            fixture_task_path,
-            "--base",
-            git_repo["base"],
-            "--head",
-            git_repo["head"],
-        ]
+        ["check", "--task", fixture_task_path, "--base", git_repo["base"], "--head", git_repo["head"]]
     )
 
     assert exit_code == 0
@@ -210,20 +151,9 @@ def test_report_shell_renders_all_sections_present_and_empty(
 def test_check_persists_the_review_to_the_store(git_repo, fixture_task_path, stub_model):
     from acceptance.review_store import ReviewStore
 
-    assert (
-        main(
-            [
-                "check",
-                "--task",
-                fixture_task_path,
-                "--base",
-                git_repo["base"],
-                "--head",
-                git_repo["head"],
-            ]
-        )
-        == 0
-    )
+    assert main(
+        ["check", "--task", fixture_task_path, "--base", git_repo["base"], "--head", git_repo["head"]]
+    ) == 0
 
     # ReviewStore() defaults under the (chdir'd) repo; the review is keyed by head.
     stored = ReviewStore().read(git_repo["head"])
@@ -234,15 +164,7 @@ def test_check_persists_the_review_to_the_store(git_repo, fixture_task_path, stu
 
 def test_check_fails_cleanly_on_missing_task_file(git_repo, capsys):
     exit_code = main(
-        [
-            "check",
-            "--task",
-            "does-not-exist.md",
-            "--base",
-            git_repo["base"],
-            "--head",
-            git_repo["head"],
-        ]
+        ["check", "--task", "does-not-exist.md", "--base", git_repo["base"], "--head", git_repo["head"]]
     )
 
     assert exit_code == 1
@@ -251,15 +173,7 @@ def test_check_fails_cleanly_on_missing_task_file(git_repo, capsys):
 
 def test_check_fails_cleanly_on_unresolvable_revision(git_repo, fixture_task_path, capsys):
     exit_code = main(
-        [
-            "check",
-            "--task",
-            fixture_task_path,
-            "--base",
-            "not-a-real-revision",
-            "--head",
-            git_repo["head"],
-        ]
+        ["check", "--task", fixture_task_path, "--base", "not-a-real-revision", "--head", git_repo["head"]]
     )
 
     assert exit_code == 1
@@ -306,7 +220,6 @@ def test_run_check_rejects_a_revision_missing_from_the_given_repo(
 
 
 # --- decompose subcommand (M1.2/M1.3 dogfood path) ---
-
 
 def test_decompose_replay_without_transcript_fails_cleanly(tmp_path, monkeypatch, capsys):
     # REPLAY mode with no recorded transcript must not call live; it errors out.
@@ -358,24 +271,14 @@ def test_render_decomposition_lists_obligations_and_open_questions():
 
 # --- classify subcommand (M3.1 dogfood path) ---
 
-
 def test_classify_replay_without_transcript_fails_cleanly(
     fixture_task_path, git_repo, monkeypatch, capsys
 ):
     # REPLAY with no transcript: the first live call (decompose) can't replay.
     monkeypatch.chdir(git_repo["path"])
     exit_code = main(
-        [
-            "classify",
-            "--task",
-            fixture_task_path,
-            "--base",
-            git_repo["base"],
-            "--head",
-            git_repo["head"],
-            "--mode",
-            "replay",
-        ]
+        ["classify", "--task", fixture_task_path, "--base", git_repo["base"],
+         "--head", git_repo["head"], "--mode", "replay"]
     )
     assert exit_code == 1
     assert "model error" in capsys.readouterr().err
@@ -431,7 +334,6 @@ def test_run_classify_auto_ignores_the_task_file(git_repo, monkeypatch):
     def fake_extract_working_tree_change_set(repo, base, extra_ignore_patterns=None):
         captured["extra_ignore_patterns"] = extra_ignore_patterns
         from acceptance.review_state import ChangeSet
-
         return ChangeSet(base_revision=base, head_revision="<working-tree>")
 
     monkeypatch.setattr(
@@ -473,34 +375,18 @@ def test_render_classify_output():
     )
 
     obligations = [
-        Obligation(
-            id="ob-1",
-            description="Do the thing.",
-            type=ObligationType.FUNCTIONAL,
-            importance="critical",
-            explicit=True,
-            observable_behavior="...",
-        ),
-        Obligation(
-            id="ob-2",
-            description="Handle the edge.",
-            type=ObligationType.BOUNDARY,
-            importance="normal",
-            explicit=True,
-            observable_behavior="...",
-        ),
+        Obligation(id="ob-1", description="Do the thing.", type=ObligationType.FUNCTIONAL,
+                   importance="critical", explicit=True, observable_behavior="..."),
+        Obligation(id="ob-2", description="Handle the edge.", type=ObligationType.BOUNDARY,
+                   importance="normal", explicit=True, observable_behavior="..."),
     ]
     coverages = [
         ImplementationCoverage(
-            obligation_id="ob-1",
-            status=CoverageStatus.ADDRESSED,
-            rationale="done",
+            obligation_id="ob-1", status=CoverageStatus.ADDRESSED, rationale="done",
             diff_refs=[DiffRef(file="pkg.py", hunk_header="@@ -1 +1 @@")],
         ),
         ImplementationCoverage(
-            obligation_id="ob-2",
-            status=CoverageStatus.NOT_ADDRESSED,
-            rationale="missing",
+            obligation_id="ob-2", status=CoverageStatus.NOT_ADDRESSED, rationale="missing",
         ),
     ]
     dispositioned = [
@@ -519,10 +405,8 @@ def test_render_classify_output():
     open_questions = [
         OpenQuestion(id="q-1", question="Minus sign or parentheses?"),
         OpenQuestion(
-            id="q-2",
-            question="Should the total be tax-inclusive?",
-            resolved=True,
-            resolution_rationale="The diff always adds tax after the subtotal.",
+            id="q-2", question="Should the total be tax-inclusive?",
+            resolved=True, resolution_rationale="The diff always adds tax after the subtotal.",
             resolution_refs=[Link(kind="code", ref="pkg.py#@@ -1 +1 @@")],
         ),
     ]
@@ -587,6 +471,7 @@ def test_render_change_set_omits_ignored_section_when_empty():
     assert "Ignored" not in rendered
 
 
+
 # --- check: the M7.4 additions (optional declaration + working-tree review) ---
 
 
@@ -597,25 +482,15 @@ def test_check_threads_an_optional_declaration_into_the_review(
     declaration is parsed onto the Review and §7.4's "absent" minor finding is
     NOT raised. Guards a flag that parses but silently drops its value."""
     declaration = tmp_path / "declaration.md"
-    declaration.write_text("# Builder Declaration\n## Mandate as understood\nAdd the thing.\n")
-
-    assert (
-        main(
-            [
-                "check",
-                "--json",
-                "--task",
-                fixture_task_path,
-                "--base",
-                git_repo["base"],
-                "--head",
-                git_repo["head"],
-                "--declaration",
-                str(declaration),
-            ]
-        )
-        == 0
+    declaration.write_text(
+        "# Builder Declaration\n## Mandate as understood\nAdd the thing.\n"
     )
+
+    assert main([
+        "check", "--json", "--task", fixture_task_path,
+        "--base", git_repo["base"], "--head", git_repo["head"],
+        "--declaration", str(declaration),
+    ]) == 0
 
     with_declaration = json.loads(capsys.readouterr().out)
     assert with_declaration["declaration"] is not None
@@ -625,21 +500,10 @@ def test_check_threads_an_optional_declaration_into_the_review(
     # ...and the same invocation WITHOUT it succeeds too, differing only in the
     # §7.4 absent finding. Pairing both runs in one test means a --declaration
     # that parses but is ignored cannot pass: the two outputs would be identical.
-    assert (
-        main(
-            [
-                "check",
-                "--json",
-                "--task",
-                fixture_task_path,
-                "--base",
-                git_repo["base"],
-                "--head",
-                git_repo["head"],
-            ]
-        )
-        == 0
-    )
+    assert main([
+        "check", "--json", "--task", fixture_task_path,
+        "--base", git_repo["base"], "--head", git_repo["head"],
+    ]) == 0
     without = json.loads(capsys.readouterr().out)
     assert without["declaration"] is None
     assert "declaration_absent" in {f["type"] for f in without["findings"]}
@@ -653,19 +517,9 @@ def test_check_without_a_head_reviews_the_working_tree(
     — a fixture whose tree matched HEAD would pass either way."""
     (git_repo["path"] / "uncommitted.py").write_text("def added_after_head():\n    return 1\n")
 
-    assert (
-        main(
-            [
-                "check",
-                "--json",
-                "--task",
-                fixture_task_path,
-                "--base",
-                git_repo["base"],
-            ]
-        )
-        == 0
-    )
+    assert main([
+        "check", "--json", "--task", fixture_task_path, "--base", git_repo["base"],
+    ]) == 0
 
     review = json.loads(capsys.readouterr().out)
     assert review["reviewed_revision"] == "<working-tree>"
@@ -681,73 +535,43 @@ def _gap_client():
     it — i.e. a review with real gaps, and so a real recommendation to pull."""
     from tests.support import client_dispatching
 
-    return client_dispatching(
-        {
-            "_Decomposition": {
-                "obligations": [
-                    {
-                        "id": "gap-ob",
-                        "description": "Handle the empty case",
-                        "type": "functional",
-                        "importance": "critical",
-                        "explicit": True,
-                        "observable_behavior": "...",
-                        "source_quote": "Do the thing.",
-                    }
-                ],
-                "open_questions": [],
-                "requirement_dispositions": [],
-            },
-            "_Mappings": {"mappings": []},
-            "_Discrimination": {"discriminations": []},
-            "_Coverage": {
-                "classifications": [
-                    {
-                        "obligation_id": "gap-ob",
-                        "status": "not_addressed",
-                        "rationale": "no code handles the empty case",
-                        "diff_refs": [],
-                    }
-                ]
-            },
-            "_Detections": {"unrequested_changes": []},
-            "_Judgments": {"resolutions": []},
-            "_Recommendations": {
-                "recommendations": [
-                    {
-                        "obligation_id": "gap-ob",
-                        "required_inputs": "an empty collection",
-                        "boundary_conditions": "zero elements",
-                        "expected_output": "an empty result, not an error",
-                        "required_assertions": ["assert handle([]) == []"],
-                        "plausible_defect": "raises IndexError on an empty input",
-                        "repo_conventions": "follow the fixtures in tests/test_thing.py",
-                    }
-                ]
-            },
-            "_Mismatches": {"mismatches": []},
-        }
-    )
+    return client_dispatching({
+        "_Decomposition": {"obligations": [{
+            "id": "gap-ob", "description": "Handle the empty case",
+            "type": "functional", "importance": "critical", "explicit": True,
+            "observable_behavior": "...", "source_quote": "Do the thing.",
+        }], "open_questions": [], "requirement_dispositions": []},
+        "_Mappings": {"mappings": []},
+        "_Discrimination": {"discriminations": []},
+        "_Coverage": {"classifications": [{
+            "obligation_id": "gap-ob", "status": "not_addressed",
+            "rationale": "no code handles the empty case", "diff_refs": [],
+        }]},
+        "_Detections": {"unrequested_changes": []},
+        "_Judgments": {"resolutions": []},
+        "_Recommendations": {"recommendations": [{
+            "obligation_id": "gap-ob",
+            "required_inputs": "an empty collection",
+            "boundary_conditions": "zero elements",
+            "expected_output": "an empty result, not an error",
+            "required_assertions": ["assert handle([]) == []"],
+            "plausible_defect": "raises IndexError on an empty input",
+            "repo_conventions": "follow the fixtures in tests/test_thing.py",
+        }]},
+        "_Mismatches": {"mismatches": []},
+    })
 
 
 def _run_check_with_gaps(git_repo, fixture_task_path, monkeypatch):
     from acceptance.config import RunConfig
 
-    monkeypatch.setattr(RunConfig, "build_client", lambda self, completion_fn=None: _gap_client())
-    assert (
-        main(
-            [
-                "check",
-                "--task",
-                fixture_task_path,
-                "--base",
-                git_repo["base"],
-                "--head",
-                git_repo["head"],
-            ]
-        )
-        == 0
+    monkeypatch.setattr(
+        RunConfig, "build_client", lambda self, completion_fn=None: _gap_client()
     )
+    assert main([
+        "check", "--task", fixture_task_path,
+        "--base", git_repo["base"], "--head", git_repo["head"],
+    ]) == 0
 
 
 def test_check_writes_no_instruction_file_even_when_the_review_has_gaps(
@@ -778,20 +602,10 @@ def test_a_stale_instruction_file_is_removed_and_the_removal_reported(
     stale.parent.mkdir(parents=True, exist_ok=True)
     stale.write_text("# Next instruction\n\nSomething that is no longer true.\n")
 
-    assert (
-        main(
-            [
-                "check",
-                "--task",
-                fixture_task_path,
-                "--base",
-                git_repo["base"],
-                "--head",
-                git_repo["head"],
-            ]
-        )
-        == 0
-    )
+    assert main([
+        "check", "--task", fixture_task_path,
+        "--base", git_repo["base"], "--head", git_repo["head"],
+    ]) == 0
 
     assert not stale.exists()
     # Visible, not silent — it touched a file in the user's repo. On stderr so
@@ -808,20 +622,10 @@ def test_the_removal_leaves_the_report_as_the_only_statement_of_status(
     stale.parent.mkdir(parents=True, exist_ok=True)
     stale.write_text("# Next instruction\n\nStale gaps.\n")
 
-    assert (
-        main(
-            [
-                "check",
-                "--task",
-                fixture_task_path,
-                "--base",
-                git_repo["base"],
-                "--head",
-                git_repo["head"],
-            ]
-        )
-        == 0
-    )
+    assert main([
+        "check", "--task", fixture_task_path,
+        "--base", git_repo["base"], "--head", git_repo["head"],
+    ]) == 0
 
     assert not stale.exists()
     assert "Recommended next instruction: (none)" in capsys.readouterr().out
@@ -853,11 +657,8 @@ def test_recommendation_returns_the_stored_prescription_for_a_criterion(
     assert all(
         len(str(payload[field]).split()) > 1
         for field in (
-            "required_inputs",
-            "boundary_conditions",
-            "expected_output",
-            "plausible_defect",
-            "repo_conventions",
+            "required_inputs", "boundary_conditions", "expected_output",
+            "plausible_defect", "repo_conventions",
         )
     )
 
@@ -913,7 +714,9 @@ def _store_review_with(tmp_path, revision, criterion, defect):
     return ReviewStore(tmp_path / ".acceptance" / "cache" / "reviews").write(review)
 
 
-def test_retrieval_reads_the_named_revision_and_not_a_recomputation(monkeypatch, tmp_path, capsys):
+def test_retrieval_reads_the_named_revision_and_not_a_recomputation(
+    monkeypatch, tmp_path, capsys
+):
     """Two stored reviews disagree about the same criterion, so reading the
     wrong one — or recomputing instead of reading — is observable.
 
@@ -947,18 +750,18 @@ def test_retrieval_makes_no_model_call(monkeypatch, tmp_path, capsys):
 
     monkeypatch.setattr(RunConfig, "build_client", explode)
     monkeypatch.setattr(
-        cli,
-        "run_review",
-        lambda *a, **k: (_ for _ in ()).throw(
+        cli, "run_review", lambda *a, **k: (_ for _ in ()).throw(
             AssertionError("retrieval re-ran the review pipeline")
-        ),
+        )
     )
 
     assert main(["recommendation", "--criterion", "ob-1"]) == 0
     assert "a defect" in capsys.readouterr().out
 
 
-def test_retrieval_without_a_revision_uses_the_newest_stored_review(monkeypatch, tmp_path, capsys):
+def test_retrieval_without_a_revision_uses_the_newest_stored_review(
+    monkeypatch, tmp_path, capsys
+):
     """Oldest-vs-newest has to be observable, so the store holds two reviews
     that disagree, written in a known order."""
     import json
@@ -978,7 +781,9 @@ def test_retrieval_without_a_revision_uses_the_newest_stored_review(monkeypatch,
     assert json.loads(capsys.readouterr().out)["plausible_defect"] == "the NEWER defect"
 
 
-def test_the_newest_review_wins_regardless_of_filename_order(monkeypatch, tmp_path, capsys):
+def test_the_newest_review_wins_regardless_of_filename_order(
+    monkeypatch, tmp_path, capsys
+):
     """Reviews are keyed by revision, and revisions carry no order. A store that
     sorted by name would pass the test above by accident, so here the newest
     review is the alphabetically FIRST filename."""
@@ -996,7 +801,9 @@ def test_the_newest_review_wins_regardless_of_filename_order(monkeypatch, tmp_pa
     assert json.loads(capsys.readouterr().out)["plausible_defect"] == "the NEWER defect"
 
 
-def test_recommendation_without_a_stored_review_fails_cleanly(monkeypatch, tmp_path, capsys):
+def test_recommendation_without_a_stored_review_fails_cleanly(
+    monkeypatch, tmp_path, capsys
+):
     monkeypatch.chdir(tmp_path)
 
     assert main(["recommendation", "--criterion", "anything"]) == 1
@@ -1040,10 +847,8 @@ _DOCUMENTED_COMMAND = "acceptance recommendation --criterion <id>"
 def _spec_text():
     from pathlib import Path
 
-    spec = (
-        Path(__file__).resolve().parents[1]
-        / "docs"
-        / ("AI-Assisted-Software-Development-Review-Spec.md")
+    spec = Path(__file__).resolve().parents[1] / "docs" / (
+        "AI-Assisted-Software-Development-Review-Spec.md"
     )
     return spec.read_text()
 
@@ -1094,7 +899,9 @@ def build_parser_parse(argv):
     return build_parser().parse_args(argv)
 
 
-def test_the_removal_is_reported_in_json_mode_too(git_repo, fixture_task_path, capsys, stub_model):
+def test_the_removal_is_reported_in_json_mode_too(
+    git_repo, fixture_task_path, capsys, stub_model
+):
     """Deleting a file in the user's repo must never be silent, in any mode.
 
     The first version printed the notice only on the text branch, so `--json`
@@ -1107,21 +914,10 @@ def test_the_removal_is_reported_in_json_mode_too(git_repo, fixture_task_path, c
     stale.parent.mkdir(parents=True, exist_ok=True)
     stale.write_text("# Next instruction\n\nStale.\n")
 
-    assert (
-        main(
-            [
-                "check",
-                "--task",
-                fixture_task_path,
-                "--base",
-                git_repo["base"],
-                "--head",
-                git_repo["head"],
-                "--json",
-            ]
-        )
-        == 0
-    )
+    assert main([
+        "check", "--task", fixture_task_path,
+        "--base", git_repo["base"], "--head", git_repo["head"], "--json",
+    ]) == 0
 
     captured = capsys.readouterr()
     assert not stale.exists()
@@ -1184,10 +980,9 @@ def test_the_pipeline_persists_the_requirement_map(git_repo, tmp_path, stub_mode
         "## Scope exclusions\n- Changing the PDF renderer.\n"
     )
 
-    assert (
-        main(["check", "--task", str(task), "--base", git_repo["base"], "--head", git_repo["head"]])
-        == 0
-    )
+    assert main(
+        ["check", "--task", str(task), "--base", git_repo["base"], "--head", git_repo["head"]]
+    ) == 0
 
     stored = ReviewStore().read(git_repo["head"])
     assert stored.requirement_map is not None
@@ -1214,10 +1009,9 @@ def test_a_requirement_that_yielded_nothing_is_visible_in_the_report(
     task = tmp_path / "task.md"
     task.write_text("# Task\nRender each invoice line.\n\n## Constraints\n- Format money as USD.\n")
 
-    assert (
-        main(["check", "--task", str(task), "--base", git_repo["base"], "--head", git_repo["head"]])
-        == 0
-    )
+    assert main(
+        ["check", "--task", str(task), "--base", git_repo["base"], "--head", git_repo["head"]]
+    ) == 0
 
     report = capsys.readouterr().out
     assert "Mandate coverage: 0 of 2 requirements yielded obligations" in report

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,16 @@ def test_check_json_emits_a_structured_review(git_repo, fixture_task_path, capsy
     """--json emits the full structured Review. With a checker that finds
     nothing, the analysis fields are empty but the shape is complete."""
     exit_code = main(
-        ["check", "--json", "--task", fixture_task_path, "--base", git_repo["base"], "--head", git_repo["head"]]
+        [
+            "check",
+            "--json",
+            "--task",
+            fixture_task_path,
+            "--base",
+            git_repo["base"],
+            "--head",
+            git_repo["head"],
+        ]
     )
 
     assert exit_code == 0
@@ -42,7 +51,16 @@ def test_a_default_cli_run_is_seeded(git_repo, fixture_task_path, capsys, stub_m
     `seed is None`, which locked the defect in (#160).
     """
     exit_code = main(
-        ["check", "--json", "--task", fixture_task_path, "--base", git_repo["base"], "--head", git_repo["head"]]
+        [
+            "check",
+            "--json",
+            "--task",
+            fixture_task_path,
+            "--base",
+            git_repo["base"],
+            "--head",
+            git_repo["head"],
+        ]
     )
 
     assert exit_code == 0
@@ -53,13 +71,22 @@ def test_a_default_cli_run_is_seeded(git_repo, fixture_task_path, capsys, stub_m
     assert review["provenance"]["controls_in_force"] == {"temperature": 0.0, "seed": DEFAULT_SEED}
 
 
-def test_no_seed_is_the_deliberate_way_to_run_unpinned(git_repo, fixture_task_path, capsys, stub_model):
+def test_no_seed_is_the_deliberate_way_to_run_unpinned(
+    git_repo, fixture_task_path, capsys, stub_model
+):
     """Seeding by default must still leave a way out: M-B0.4 samples a provider
     repeatedly to disclose variance, which a fixed seed would suppress."""
     exit_code = main(
         [
-            "check", "--json", "--task", fixture_task_path,
-            "--base", git_repo["base"], "--head", git_repo["head"], "--no-seed",
+            "check",
+            "--json",
+            "--task",
+            fixture_task_path,
+            "--base",
+            git_repo["base"],
+            "--head",
+            git_repo["head"],
+            "--no-seed",
         ]
     )
 
@@ -71,17 +98,27 @@ def test_no_seed_is_the_deliberate_way_to_run_unpinned(git_repo, fixture_task_pa
     assert provenance["controls_in_force"]["seed"] is None
 
 
-def test_check_records_determinism_flags_in_provenance(git_repo, fixture_task_path, capsys, stub_model):
+def test_check_records_determinism_flags_in_provenance(
+    git_repo, fixture_task_path, capsys, stub_model
+):
     exit_code = main(
         [
-            "check", "--json",
-            "--task", fixture_task_path,
-            "--base", git_repo["base"],
-            "--head", git_repo["head"],
-            "--model", "openai/gpt-5",
-            "--mode", "record",
-            "--seed", "7",
-            "--temperature", "0.4",
+            "check",
+            "--json",
+            "--task",
+            fixture_task_path,
+            "--base",
+            git_repo["base"],
+            "--head",
+            git_repo["head"],
+            "--model",
+            "openai/gpt-5",
+            "--mode",
+            "record",
+            "--seed",
+            "7",
+            "--temperature",
+            "0.4",
         ]
     )
 
@@ -98,6 +135,11 @@ def test_check_records_determinism_flags_in_provenance(git_repo, fixture_task_pa
         # at different scale (#204); an EMPTY mapping is the "unpartitioned
         # run" claim, not a null.
         "request_partition_sizes": {"decompose": DEFAULT_DECOMPOSE_BATCH_SIZE},
+        # None, not a zero-valued record: this stub finds no obligations at all,
+        # so linking returns before it prefilters anything and the honest claim
+        # is that no filter ran (#259). A run that filtered and excluded nothing
+        # reports a record with `pairs_excluded: 0` instead — see LinkPrefilter.
+        "link_prefilter": None,
     }
 
 
@@ -106,17 +148,29 @@ def test_check_rejects_unknown_mode(git_repo, fixture_task_path):
         main(
             [
                 "check",
-                "--task", fixture_task_path,
-                "--base", git_repo["base"],
-                "--head", git_repo["head"],
-                "--mode", "live",
+                "--task",
+                fixture_task_path,
+                "--base",
+                git_repo["base"],
+                "--head",
+                git_repo["head"],
+                "--mode",
+                "live",
             ]
         )
 
 
-def test_two_runs_over_the_same_input_are_byte_identical(git_repo, fixture_task_path, capsys, stub_model):
+def test_two_runs_over_the_same_input_are_byte_identical(
+    git_repo, fixture_task_path, capsys, stub_model
+):
     args = [
-        "check", "--task", fixture_task_path, "--base", git_repo["base"], "--head", git_repo["head"]
+        "check",
+        "--task",
+        fixture_task_path,
+        "--base",
+        git_repo["base"],
+        "--head",
+        git_repo["head"],
     ]
 
     assert main(args) == 0
@@ -127,9 +181,19 @@ def test_two_runs_over_the_same_input_are_byte_identical(git_repo, fixture_task_
     assert first == second
 
 
-def test_report_shell_renders_all_sections_present_and_empty(git_repo, fixture_task_path, capsys, stub_model):
+def test_report_shell_renders_all_sections_present_and_empty(
+    git_repo, fixture_task_path, capsys, stub_model
+):
     exit_code = main(
-        ["check", "--task", fixture_task_path, "--base", git_repo["base"], "--head", git_repo["head"]]
+        [
+            "check",
+            "--task",
+            fixture_task_path,
+            "--base",
+            git_repo["base"],
+            "--head",
+            git_repo["head"],
+        ]
     )
 
     assert exit_code == 0
@@ -146,9 +210,20 @@ def test_report_shell_renders_all_sections_present_and_empty(git_repo, fixture_t
 def test_check_persists_the_review_to_the_store(git_repo, fixture_task_path, stub_model):
     from acceptance.review_store import ReviewStore
 
-    assert main(
-        ["check", "--task", fixture_task_path, "--base", git_repo["base"], "--head", git_repo["head"]]
-    ) == 0
+    assert (
+        main(
+            [
+                "check",
+                "--task",
+                fixture_task_path,
+                "--base",
+                git_repo["base"],
+                "--head",
+                git_repo["head"],
+            ]
+        )
+        == 0
+    )
 
     # ReviewStore() defaults under the (chdir'd) repo; the review is keyed by head.
     stored = ReviewStore().read(git_repo["head"])
@@ -159,7 +234,15 @@ def test_check_persists_the_review_to_the_store(git_repo, fixture_task_path, stu
 
 def test_check_fails_cleanly_on_missing_task_file(git_repo, capsys):
     exit_code = main(
-        ["check", "--task", "does-not-exist.md", "--base", git_repo["base"], "--head", git_repo["head"]]
+        [
+            "check",
+            "--task",
+            "does-not-exist.md",
+            "--base",
+            git_repo["base"],
+            "--head",
+            git_repo["head"],
+        ]
     )
 
     assert exit_code == 1
@@ -168,7 +251,15 @@ def test_check_fails_cleanly_on_missing_task_file(git_repo, capsys):
 
 def test_check_fails_cleanly_on_unresolvable_revision(git_repo, fixture_task_path, capsys):
     exit_code = main(
-        ["check", "--task", fixture_task_path, "--base", "not-a-real-revision", "--head", git_repo["head"]]
+        [
+            "check",
+            "--task",
+            fixture_task_path,
+            "--base",
+            "not-a-real-revision",
+            "--head",
+            git_repo["head"],
+        ]
     )
 
     assert exit_code == 1
@@ -215,6 +306,7 @@ def test_run_check_rejects_a_revision_missing_from_the_given_repo(
 
 
 # --- decompose subcommand (M1.2/M1.3 dogfood path) ---
+
 
 def test_decompose_replay_without_transcript_fails_cleanly(tmp_path, monkeypatch, capsys):
     # REPLAY mode with no recorded transcript must not call live; it errors out.
@@ -266,14 +358,24 @@ def test_render_decomposition_lists_obligations_and_open_questions():
 
 # --- classify subcommand (M3.1 dogfood path) ---
 
+
 def test_classify_replay_without_transcript_fails_cleanly(
     fixture_task_path, git_repo, monkeypatch, capsys
 ):
     # REPLAY with no transcript: the first live call (decompose) can't replay.
     monkeypatch.chdir(git_repo["path"])
     exit_code = main(
-        ["classify", "--task", fixture_task_path, "--base", git_repo["base"],
-         "--head", git_repo["head"], "--mode", "replay"]
+        [
+            "classify",
+            "--task",
+            fixture_task_path,
+            "--base",
+            git_repo["base"],
+            "--head",
+            git_repo["head"],
+            "--mode",
+            "replay",
+        ]
     )
     assert exit_code == 1
     assert "model error" in capsys.readouterr().err
@@ -329,6 +431,7 @@ def test_run_classify_auto_ignores_the_task_file(git_repo, monkeypatch):
     def fake_extract_working_tree_change_set(repo, base, extra_ignore_patterns=None):
         captured["extra_ignore_patterns"] = extra_ignore_patterns
         from acceptance.review_state import ChangeSet
+
         return ChangeSet(base_revision=base, head_revision="<working-tree>")
 
     monkeypatch.setattr(
@@ -370,18 +473,34 @@ def test_render_classify_output():
     )
 
     obligations = [
-        Obligation(id="ob-1", description="Do the thing.", type=ObligationType.FUNCTIONAL,
-                   importance="critical", explicit=True, observable_behavior="..."),
-        Obligation(id="ob-2", description="Handle the edge.", type=ObligationType.BOUNDARY,
-                   importance="normal", explicit=True, observable_behavior="..."),
+        Obligation(
+            id="ob-1",
+            description="Do the thing.",
+            type=ObligationType.FUNCTIONAL,
+            importance="critical",
+            explicit=True,
+            observable_behavior="...",
+        ),
+        Obligation(
+            id="ob-2",
+            description="Handle the edge.",
+            type=ObligationType.BOUNDARY,
+            importance="normal",
+            explicit=True,
+            observable_behavior="...",
+        ),
     ]
     coverages = [
         ImplementationCoverage(
-            obligation_id="ob-1", status=CoverageStatus.ADDRESSED, rationale="done",
+            obligation_id="ob-1",
+            status=CoverageStatus.ADDRESSED,
+            rationale="done",
             diff_refs=[DiffRef(file="pkg.py", hunk_header="@@ -1 +1 @@")],
         ),
         ImplementationCoverage(
-            obligation_id="ob-2", status=CoverageStatus.NOT_ADDRESSED, rationale="missing",
+            obligation_id="ob-2",
+            status=CoverageStatus.NOT_ADDRESSED,
+            rationale="missing",
         ),
     ]
     dispositioned = [
@@ -400,8 +519,10 @@ def test_render_classify_output():
     open_questions = [
         OpenQuestion(id="q-1", question="Minus sign or parentheses?"),
         OpenQuestion(
-            id="q-2", question="Should the total be tax-inclusive?",
-            resolved=True, resolution_rationale="The diff always adds tax after the subtotal.",
+            id="q-2",
+            question="Should the total be tax-inclusive?",
+            resolved=True,
+            resolution_rationale="The diff always adds tax after the subtotal.",
             resolution_refs=[Link(kind="code", ref="pkg.py#@@ -1 +1 @@")],
         ),
     ]
@@ -466,7 +587,6 @@ def test_render_change_set_omits_ignored_section_when_empty():
     assert "Ignored" not in rendered
 
 
-
 # --- check: the M7.4 additions (optional declaration + working-tree review) ---
 
 
@@ -477,15 +597,25 @@ def test_check_threads_an_optional_declaration_into_the_review(
     declaration is parsed onto the Review and §7.4's "absent" minor finding is
     NOT raised. Guards a flag that parses but silently drops its value."""
     declaration = tmp_path / "declaration.md"
-    declaration.write_text(
-        "# Builder Declaration\n## Mandate as understood\nAdd the thing.\n"
-    )
+    declaration.write_text("# Builder Declaration\n## Mandate as understood\nAdd the thing.\n")
 
-    assert main([
-        "check", "--json", "--task", fixture_task_path,
-        "--base", git_repo["base"], "--head", git_repo["head"],
-        "--declaration", str(declaration),
-    ]) == 0
+    assert (
+        main(
+            [
+                "check",
+                "--json",
+                "--task",
+                fixture_task_path,
+                "--base",
+                git_repo["base"],
+                "--head",
+                git_repo["head"],
+                "--declaration",
+                str(declaration),
+            ]
+        )
+        == 0
+    )
 
     with_declaration = json.loads(capsys.readouterr().out)
     assert with_declaration["declaration"] is not None
@@ -495,10 +625,21 @@ def test_check_threads_an_optional_declaration_into_the_review(
     # ...and the same invocation WITHOUT it succeeds too, differing only in the
     # §7.4 absent finding. Pairing both runs in one test means a --declaration
     # that parses but is ignored cannot pass: the two outputs would be identical.
-    assert main([
-        "check", "--json", "--task", fixture_task_path,
-        "--base", git_repo["base"], "--head", git_repo["head"],
-    ]) == 0
+    assert (
+        main(
+            [
+                "check",
+                "--json",
+                "--task",
+                fixture_task_path,
+                "--base",
+                git_repo["base"],
+                "--head",
+                git_repo["head"],
+            ]
+        )
+        == 0
+    )
     without = json.loads(capsys.readouterr().out)
     assert without["declaration"] is None
     assert "declaration_absent" in {f["type"] for f in without["findings"]}
@@ -512,9 +653,19 @@ def test_check_without_a_head_reviews_the_working_tree(
     — a fixture whose tree matched HEAD would pass either way."""
     (git_repo["path"] / "uncommitted.py").write_text("def added_after_head():\n    return 1\n")
 
-    assert main([
-        "check", "--json", "--task", fixture_task_path, "--base", git_repo["base"],
-    ]) == 0
+    assert (
+        main(
+            [
+                "check",
+                "--json",
+                "--task",
+                fixture_task_path,
+                "--base",
+                git_repo["base"],
+            ]
+        )
+        == 0
+    )
 
     review = json.loads(capsys.readouterr().out)
     assert review["reviewed_revision"] == "<working-tree>"
@@ -530,43 +681,73 @@ def _gap_client():
     it — i.e. a review with real gaps, and so a real recommendation to pull."""
     from tests.support import client_dispatching
 
-    return client_dispatching({
-        "_Decomposition": {"obligations": [{
-            "id": "gap-ob", "description": "Handle the empty case",
-            "type": "functional", "importance": "critical", "explicit": True,
-            "observable_behavior": "...", "source_quote": "Do the thing.",
-        }], "open_questions": [], "requirement_dispositions": []},
-        "_Mappings": {"mappings": []},
-        "_Discrimination": {"discriminations": []},
-        "_Coverage": {"classifications": [{
-            "obligation_id": "gap-ob", "status": "not_addressed",
-            "rationale": "no code handles the empty case", "diff_refs": [],
-        }]},
-        "_Detections": {"unrequested_changes": []},
-        "_Judgments": {"resolutions": []},
-        "_Recommendations": {"recommendations": [{
-            "obligation_id": "gap-ob",
-            "required_inputs": "an empty collection",
-            "boundary_conditions": "zero elements",
-            "expected_output": "an empty result, not an error",
-            "required_assertions": ["assert handle([]) == []"],
-            "plausible_defect": "raises IndexError on an empty input",
-            "repo_conventions": "follow the fixtures in tests/test_thing.py",
-        }]},
-        "_Mismatches": {"mismatches": []},
-    })
+    return client_dispatching(
+        {
+            "_Decomposition": {
+                "obligations": [
+                    {
+                        "id": "gap-ob",
+                        "description": "Handle the empty case",
+                        "type": "functional",
+                        "importance": "critical",
+                        "explicit": True,
+                        "observable_behavior": "...",
+                        "source_quote": "Do the thing.",
+                    }
+                ],
+                "open_questions": [],
+                "requirement_dispositions": [],
+            },
+            "_Mappings": {"mappings": []},
+            "_Discrimination": {"discriminations": []},
+            "_Coverage": {
+                "classifications": [
+                    {
+                        "obligation_id": "gap-ob",
+                        "status": "not_addressed",
+                        "rationale": "no code handles the empty case",
+                        "diff_refs": [],
+                    }
+                ]
+            },
+            "_Detections": {"unrequested_changes": []},
+            "_Judgments": {"resolutions": []},
+            "_Recommendations": {
+                "recommendations": [
+                    {
+                        "obligation_id": "gap-ob",
+                        "required_inputs": "an empty collection",
+                        "boundary_conditions": "zero elements",
+                        "expected_output": "an empty result, not an error",
+                        "required_assertions": ["assert handle([]) == []"],
+                        "plausible_defect": "raises IndexError on an empty input",
+                        "repo_conventions": "follow the fixtures in tests/test_thing.py",
+                    }
+                ]
+            },
+            "_Mismatches": {"mismatches": []},
+        }
+    )
 
 
 def _run_check_with_gaps(git_repo, fixture_task_path, monkeypatch):
     from acceptance.config import RunConfig
 
-    monkeypatch.setattr(
-        RunConfig, "build_client", lambda self, completion_fn=None: _gap_client()
+    monkeypatch.setattr(RunConfig, "build_client", lambda self, completion_fn=None: _gap_client())
+    assert (
+        main(
+            [
+                "check",
+                "--task",
+                fixture_task_path,
+                "--base",
+                git_repo["base"],
+                "--head",
+                git_repo["head"],
+            ]
+        )
+        == 0
     )
-    assert main([
-        "check", "--task", fixture_task_path,
-        "--base", git_repo["base"], "--head", git_repo["head"],
-    ]) == 0
 
 
 def test_check_writes_no_instruction_file_even_when_the_review_has_gaps(
@@ -597,10 +778,20 @@ def test_a_stale_instruction_file_is_removed_and_the_removal_reported(
     stale.parent.mkdir(parents=True, exist_ok=True)
     stale.write_text("# Next instruction\n\nSomething that is no longer true.\n")
 
-    assert main([
-        "check", "--task", fixture_task_path,
-        "--base", git_repo["base"], "--head", git_repo["head"],
-    ]) == 0
+    assert (
+        main(
+            [
+                "check",
+                "--task",
+                fixture_task_path,
+                "--base",
+                git_repo["base"],
+                "--head",
+                git_repo["head"],
+            ]
+        )
+        == 0
+    )
 
     assert not stale.exists()
     # Visible, not silent — it touched a file in the user's repo. On stderr so
@@ -617,10 +808,20 @@ def test_the_removal_leaves_the_report_as_the_only_statement_of_status(
     stale.parent.mkdir(parents=True, exist_ok=True)
     stale.write_text("# Next instruction\n\nStale gaps.\n")
 
-    assert main([
-        "check", "--task", fixture_task_path,
-        "--base", git_repo["base"], "--head", git_repo["head"],
-    ]) == 0
+    assert (
+        main(
+            [
+                "check",
+                "--task",
+                fixture_task_path,
+                "--base",
+                git_repo["base"],
+                "--head",
+                git_repo["head"],
+            ]
+        )
+        == 0
+    )
 
     assert not stale.exists()
     assert "Recommended next instruction: (none)" in capsys.readouterr().out
@@ -652,8 +853,11 @@ def test_recommendation_returns_the_stored_prescription_for_a_criterion(
     assert all(
         len(str(payload[field]).split()) > 1
         for field in (
-            "required_inputs", "boundary_conditions", "expected_output",
-            "plausible_defect", "repo_conventions",
+            "required_inputs",
+            "boundary_conditions",
+            "expected_output",
+            "plausible_defect",
+            "repo_conventions",
         )
     )
 
@@ -709,9 +913,7 @@ def _store_review_with(tmp_path, revision, criterion, defect):
     return ReviewStore(tmp_path / ".acceptance" / "cache" / "reviews").write(review)
 
 
-def test_retrieval_reads_the_named_revision_and_not_a_recomputation(
-    monkeypatch, tmp_path, capsys
-):
+def test_retrieval_reads_the_named_revision_and_not_a_recomputation(monkeypatch, tmp_path, capsys):
     """Two stored reviews disagree about the same criterion, so reading the
     wrong one — or recomputing instead of reading — is observable.
 
@@ -745,18 +947,18 @@ def test_retrieval_makes_no_model_call(monkeypatch, tmp_path, capsys):
 
     monkeypatch.setattr(RunConfig, "build_client", explode)
     monkeypatch.setattr(
-        cli, "run_review", lambda *a, **k: (_ for _ in ()).throw(
+        cli,
+        "run_review",
+        lambda *a, **k: (_ for _ in ()).throw(
             AssertionError("retrieval re-ran the review pipeline")
-        )
+        ),
     )
 
     assert main(["recommendation", "--criterion", "ob-1"]) == 0
     assert "a defect" in capsys.readouterr().out
 
 
-def test_retrieval_without_a_revision_uses_the_newest_stored_review(
-    monkeypatch, tmp_path, capsys
-):
+def test_retrieval_without_a_revision_uses_the_newest_stored_review(monkeypatch, tmp_path, capsys):
     """Oldest-vs-newest has to be observable, so the store holds two reviews
     that disagree, written in a known order."""
     import json
@@ -776,9 +978,7 @@ def test_retrieval_without_a_revision_uses_the_newest_stored_review(
     assert json.loads(capsys.readouterr().out)["plausible_defect"] == "the NEWER defect"
 
 
-def test_the_newest_review_wins_regardless_of_filename_order(
-    monkeypatch, tmp_path, capsys
-):
+def test_the_newest_review_wins_regardless_of_filename_order(monkeypatch, tmp_path, capsys):
     """Reviews are keyed by revision, and revisions carry no order. A store that
     sorted by name would pass the test above by accident, so here the newest
     review is the alphabetically FIRST filename."""
@@ -796,9 +996,7 @@ def test_the_newest_review_wins_regardless_of_filename_order(
     assert json.loads(capsys.readouterr().out)["plausible_defect"] == "the NEWER defect"
 
 
-def test_recommendation_without_a_stored_review_fails_cleanly(
-    monkeypatch, tmp_path, capsys
-):
+def test_recommendation_without_a_stored_review_fails_cleanly(monkeypatch, tmp_path, capsys):
     monkeypatch.chdir(tmp_path)
 
     assert main(["recommendation", "--criterion", "anything"]) == 1
@@ -842,8 +1040,10 @@ _DOCUMENTED_COMMAND = "acceptance recommendation --criterion <id>"
 def _spec_text():
     from pathlib import Path
 
-    spec = Path(__file__).resolve().parents[1] / "docs" / (
-        "AI-Assisted-Software-Development-Review-Spec.md"
+    spec = (
+        Path(__file__).resolve().parents[1]
+        / "docs"
+        / ("AI-Assisted-Software-Development-Review-Spec.md")
     )
     return spec.read_text()
 
@@ -894,9 +1094,7 @@ def build_parser_parse(argv):
     return build_parser().parse_args(argv)
 
 
-def test_the_removal_is_reported_in_json_mode_too(
-    git_repo, fixture_task_path, capsys, stub_model
-):
+def test_the_removal_is_reported_in_json_mode_too(git_repo, fixture_task_path, capsys, stub_model):
     """Deleting a file in the user's repo must never be silent, in any mode.
 
     The first version printed the notice only on the text branch, so `--json`
@@ -909,10 +1107,21 @@ def test_the_removal_is_reported_in_json_mode_too(
     stale.parent.mkdir(parents=True, exist_ok=True)
     stale.write_text("# Next instruction\n\nStale.\n")
 
-    assert main([
-        "check", "--task", fixture_task_path,
-        "--base", git_repo["base"], "--head", git_repo["head"], "--json",
-    ]) == 0
+    assert (
+        main(
+            [
+                "check",
+                "--task",
+                fixture_task_path,
+                "--base",
+                git_repo["base"],
+                "--head",
+                git_repo["head"],
+                "--json",
+            ]
+        )
+        == 0
+    )
 
     captured = capsys.readouterr()
     assert not stale.exists()
@@ -975,9 +1184,10 @@ def test_the_pipeline_persists_the_requirement_map(git_repo, tmp_path, stub_mode
         "## Scope exclusions\n- Changing the PDF renderer.\n"
     )
 
-    assert main(
-        ["check", "--task", str(task), "--base", git_repo["base"], "--head", git_repo["head"]]
-    ) == 0
+    assert (
+        main(["check", "--task", str(task), "--base", git_repo["base"], "--head", git_repo["head"]])
+        == 0
+    )
 
     stored = ReviewStore().read(git_repo["head"])
     assert stored.requirement_map is not None
@@ -1004,9 +1214,10 @@ def test_a_requirement_that_yielded_nothing_is_visible_in_the_report(
     task = tmp_path / "task.md"
     task.write_text("# Task\nRender each invoice line.\n\n## Constraints\n- Format money as USD.\n")
 
-    assert main(
-        ["check", "--task", str(task), "--base", git_repo["base"], "--head", git_repo["head"]]
-    ) == 0
+    assert (
+        main(["check", "--task", str(task), "--base", git_repo["base"], "--head", git_repo["head"]])
+        == 0
+    )
 
     report = capsys.readouterr().out
     assert "Mandate coverage: 0 of 2 requirements yielded obligations" in report


### PR DESCRIPTION
Closes #259.

`link_duplicate_obligations` asked the model about every admissible pair, quadratically, and the answer was `false` for almost all of them. Pairs whose obligations are too far apart in embedding space are now dropped before any call.

## What changed

- **An embedding path in the harness** (`llm.py`). Records and replays through the same transcript store as every other model call, so the suite and CI still need no provider and no key. Deliberately *not* folded into `complete()`, which is built around a response schema an embedding reply does not have.
- **The prefilter** (`linking.py`). Composes with the existing type gate rather than replacing it; `pairs_considered` is the type-gated set, so `pairs_excluded` means "excluded by distance" and not "excluded by either rule".
- **Determinism.** Threshold and embedding model are hashed into the linking request as `stage_controls`, so moving either invalidates recorded linking transcripts the way the seed does — including when the surviving pair set comes out the same, which is exactly when the prompt alone would not show it.
- **Accounting** (`LinkPrefilter` on `ReviewProvenance`). A question never asked leaves no verdict, no unusable answer and no unreconciled cluster, so without the count a merge the filter removed is indistinguishable from one that never existed. A filter that ran and excluded nothing reports `pairs_excluded: 0`; no filter at all reports `None`.

`linking.py`'s docstring asserted the sweep was complete and that #211 had to exist before anything traded that away. It doesn't, and the trade was made anyway, so the docstring now says so rather than asserting a rule the code no longer follows.

## The threshold is 0.10, but not for the reason DR-259 first gave

Gate 1 produced a fifth task file, held out from DR-259's calibration. Applying the DR's own method to it — with labels taken from the model's own verdicts rather than from reading distances — found a **genuine** merge at **0.2257**, far outside the 0.094–0.115 band the record called a clean separator.

Raising the default was considered and rejected. The nearest calibration *spurious* merge sits at 0.116, **below** that genuine one, so the two overlap and no threshold does both:

| threshold | calibration genuine | calibration spurious admitted | held-out genuine | pairs asked |
|---|---|---|---|---|
| **0.10** | 20/20 | **0/10** | 11/12 | 2.1% |
| 0.15 | 20/20 | 2/10 | 11/12 | 3.4% |
| 0.25 | 20/20 | **9/10** | 12/12 | 8.1% |

At 0.25 the filter stops being a quality filter at all. So 0.10 stands as the deliberate **under-merging** side of a real trade — a missed merge leaves a visible redundant obligation; a spurious merge destroys a requirement silently — matching the bias `linking.py` already declares. DR-259 is updated and its clean-separation claim withdrawn; #211 moves from nice-to-have to the way this number gets settled.

## Evidence

1104 tests pass, `ruff check` clean. **Seven defect injections, all caught**, including one that initially was not: mutating `<=` to `<` passed all 1101 tests, which is how the boundary gap was confirmed real before acting on it.

| injected defect | caught by |
|---|---|
| prefilter never drops anything | `test_a_pair_beyond_the_threshold_is_never_sent_to_the_model` |
| threshold not hashed into the request | `test_changing_the_threshold_invalidates_the_recorded_linking_requests` |
| excluded count always zero | `test_the_number_of_pairs_excluded_by_distance_reaches_review_state` |
| `link_prefilter` dropped from persisted provenance | `test_both_records_survive_a_round_trip_through_the_persisted_review` |
| only the first obligation embedded | `test_a_pair_beyond_the_threshold_is_never_sent_to_the_model` |
| type gate skipped when a threshold is in force | `test_pairs_excluded_counts_only_the_distance_exclusions` |
| `<=` weakened to `<` | `test_a_pair_exactly_at_the_threshold_is_asked_about` |

## Gate 2 is NOT clean, and that is deliberate

29 of 30 obligations strongly supported. The holdout is `completion-10` reported as having **no mapped test** — while the same report cites that exact test twice elsewhere, on its Constraint twin and on an unrelated obligation. It mapped correctly in runs 1 and 2 and regressed in run 3 with nothing about it changed. That is **#245**; no code change answers it, and writing a second determinism test to satisfy a mapper that already found the first is chasing a rating.

Three runs are committed under `dogfood-logs/259-gate2-run{1,2,3}/` with the judgement, because the movement between them is itself a finding: run 1 → 2 dropped an obligation from `strongly` to `partially` on **byte-identical** evidence, and run 2 → 3 moved **twelve** obligations *up* on the strength of two boundary tests. Every prior #225 instance showed ratings falling, which reads as a conservative judge; twelve unearned promotions rules that out. Both are queued as filings.

Merged on the strength of the injections rather than the rating, with the human's explicit call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
