### PR TITLE
Clear the lint findings and make CI fail on both gates (#239)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # 1. Get the code onto the runner.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # Full history, not the default shallow clone: the #190 rating-regression
           # cases are pinned to real commits in this repository and materialize a
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       # 2. Install the Python the project targets (see plan §3.1).
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -36,11 +36,24 @@ jobs:
           if [ -f pyproject.toml ]; then pip install -e ".[dev]" || pip install -e . ; fi
           if [ -f requirements.txt ]; then pip install -r requirements.txt ; fi
 
-      # 4. Lint. Non-blocking until ruff is configured.
-      - name: Lint (ruff)
+      # 4. Format and lint. Both fail the build.
+      #
+      #    No `pip install ruff` here: that floated the version, so CI enforced
+      #    whatever ruff had most recently released rather than what the project
+      #    pins. ruff comes from the pinned dev extra installed in step 3, and
+      #    the version is echoed so a run's findings can be attributed to it.
+      #
+      #    The `|| echo` these steps replaced dates from when this repo was
+      #    docs-only. It swallowed the exit code, so CI stayed green through 86
+      #    lint findings on an untouched tree (#239) — lint that structurally
+      #    cannot fail is lint everyone stops reading.
+      - name: Format check (ruff)
         run: |
-          pip install ruff
-          ruff check . || echo "ruff not configured yet — skipping"
+          ruff --version
+          ruff format --check .
+
+      - name: Lint (ruff)
+        run: ruff check .
 
       # 5. Tests. pytest exit code 5 means "no tests collected"; treat that as
       #    success so CI stays green until the first tests land (M0).

--- a/current-task.md
+++ b/current-task.md
@@ -1,52 +1,33 @@
 # Task
-Plausible defects are enumerated for an obligation in one step, and the verdict
-on each of them is reached in a separate step that covers one obligation at a
-time.
+The repository's Python sources are formatter-clean and lint-clean, and the
+automated build fails any change that leaves them otherwise.
 
 ## Constraints
-- The plausible defects for an obligation are enumerated by a call of their own.
-- The verdict on an enumerated defect is reached by a call separate from the one
-  that enumerated it.
-- A verdict call carries the defects of a bounded number of obligations.
-- That number of obligations is configurable.
-- That number of obligations is part of the recorded request.
-- The enumeration request is determined by the obligation's text and by the
-  changed code.
-- The enumeration request is not determined by the tests mapped to the
-  obligation.
-- Editing a test mapped to one obligation leaves a different obligation's
-  enumerated defects unchanged.
-- Adding a test mapped to an obligation leaves that obligation's enumerated
-  defects unchanged.
-- The review pipeline reaches its defect verdicts through the separated steps.
-- The change does not reduce the defects the tool identifies.
-- Two runs over the same obligations and the same changed code enumerate the
-  same defects.
-- Two runs over the same obligations and the same changed code reach the same
-  verdicts.
-- Tests issue no live model calls.
+- Every Python file in the repository is formatted the way `ruff format` formats
+  it.
+- No Python file in the repository violates a selected `ruff check` rule.
+- The reformatting alters no program logic.
+- The test in `tests/test_partition.py` that expects `Exception` expects instead
+  the specific exception type the code under test raises.
+- That test is narrowed to the specific exception rather than annotated to be
+  ignored.
+- The project's development dependencies pin an exact `ruff` version.
+- The automated build runs a formatting check over the repository.
+- The automated build fails when the formatting check reports a file.
+- The automated build fails when the lint check reports an error.
+- The automated build's lint step does not discard the lint tool's exit code.
+- The automated build checks out the repository's full commit history.
+- The automated build's checkout action is at a major version that does not
+  target Node 20.
+- The automated build's Python setup action is at a major version that does not
+  target Node 20.
 
 ## Scope exclusions
-- How a rating is derived from the defect verdicts, which is #252.
-- Which tests are mapped to an obligation.
-- How an obligation is derived from a requirement.
-- Reporting a rating that could not be reproduced, which is #254.
-- Choosing the number of obligations per call for cost or latency.
-- Whether a defect verdict is correct about the test it describes.
+- Which lint rules are selected.
+- Formatting files that are not Python.
+- The behaviour of the review pipeline.
+- Which Python version the build targets.
+- Failures in the test suite that are unrelated to formatting or linting.
 
 ## Completion expectations
 - Implementation
-- A test asserts that enumerating an obligation's defects and reaching a verdict
-  on them are separate calls.
-- A test asserts that a verdict call carries the defects of no more than the
-  configured number of obligations.
-- A test asserts that the number of obligations per verdict call reaches the
-  recorded request.
-- A test asserts that editing a test mapped to one obligation leaves a different
-  obligation's enumerated defects unchanged.
-- A test asserts that adding a test mapped to an obligation leaves that
-  obligation's enumerated defects unchanged.
-- A test asserts that the review pipeline reaches its defect verdicts through the
-  separated steps.
-- A test asserts that two runs over the same obligations and the same changed
-  code enumerate the same defects and reach the same verdicts.

--- a/docs/experiments/obligation-dedup/linking_corpus.py
+++ b/docs/experiments/obligation-dedup/linking_corpus.py
@@ -109,7 +109,7 @@ def _parse_batch(prompt: str) -> tuple[dict[str, Obligation], list[Pair]]:
         if line.startswith("[pair-"):
             current_pair = line.strip("[]")
             pairs.append(Pair(pair_id=current_pair, left="", right=""))
-        elif line.startswith("A: [") or line.startswith("B: ["):
+        elif line.startswith(("A: [", "B: [")):
             current_ob = line.split("[", 1)[1].split("]", 1)[0]
             obligations.setdefault(current_ob, Obligation(id=current_ob))
             if pairs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,11 @@ license = { text = "MIT" }
 dependencies = ["pydantic>=2", "litellm>=1.50", "markdown-it-py>=3", "pathspec>=0.12"]
 
 [project.optional-dependencies]
-dev = ["pytest", "ruff"]
+# ruff is pinned exactly, not floated. Its default rule set widens between
+# releases, so an unpinned `pip install -e ".[dev]"` silently changes what CI
+# enforces — that is how 86 findings accumulated on an untouched tree (#239).
+# Bumping it is a deliberate commit that clears whatever the new release adds.
+dev = ["pytest", "ruff==0.16.2"]
 
 [project.scripts]
 acceptance = "acceptance.cli:main"

--- a/src/acceptance/benchmark/case.py
+++ b/src/acceptance/benchmark/case.py
@@ -195,7 +195,7 @@ class GroundTruthLabels(PersistableModel):
     open_questions: list[GroundTruthOpenQuestion] = Field(default_factory=list)
 
     @model_validator(mode="after")
-    def _check_tree_integrity(self) -> "GroundTruthLabels":
+    def _check_tree_integrity(self) -> GroundTruthLabels:
         if not self.obligations:
             raise ValueError("GroundTruthLabels requires at least one obligation")
 

--- a/src/acceptance/benchmark/instability.py
+++ b/src/acceptance/benchmark/instability.py
@@ -47,11 +47,12 @@ import shutil
 import subprocess
 import tempfile
 from collections import Counter
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from enum import Enum
 from itertools import combinations
 from pathlib import Path
-from typing import Any, Callable, Sequence
+from typing import Any
 
 from pydantic import Field
 

--- a/src/acceptance/benchmark/scoring.py
+++ b/src/acceptance/benchmark/scoring.py
@@ -63,10 +63,10 @@ class _MatchCounts:
     reported_total: int
 
     @staticmethod
-    def zero() -> "_MatchCounts":
+    def zero() -> _MatchCounts:
         return _MatchCounts(0, 0, 0)
 
-    def __add__(self, other: "_MatchCounts") -> "_MatchCounts":
+    def __add__(self, other: _MatchCounts) -> _MatchCounts:
         return _MatchCounts(
             self.matched + other.matched,
             self.ground_truth_total + other.ground_truth_total,

--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -43,13 +43,13 @@ from acceptance.pipeline import run_review
 from acceptance.recommendation import lookup as lookup_recommendation
 from acceptance.recommendation import render as render_recommendation
 from acceptance.report import render_report
-from acceptance.rerun import find_prior_review
 from acceptance.requirement.linking import link_duplicate_obligations
-from acceptance.supplied_ids import UnusableAnswerLog
 from acceptance.requirement.obligations import Decomposition, Obligation, decompose
 from acceptance.requirement.task_file import parse_task_file
+from acceptance.rerun import find_prior_review
 from acceptance.review_state import ChangeSet, OpenQuestion, Review
 from acceptance.review_store import ReviewStore
+from acceptance.supplied_ids import UnusableAnswerLog
 
 
 class CliError(Exception):
@@ -449,7 +449,7 @@ def _flatten(text: str) -> str:
     flattening happens here, at the point of display.
     """
     collapsed = " ".join(text.split())
-    return collapsed[2:] if collapsed.startswith("- ") else collapsed
+    return collapsed.removeprefix("- ")
 
 
 def _wrap(text: str, indent: str, hang: str) -> list[str]:

--- a/src/acceptance/config.py
+++ b/src/acceptance/config.py
@@ -15,9 +15,10 @@ the review so a reader can tell how it was produced.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 

--- a/src/acceptance/coverage/classify.py
+++ b/src/acceptance/coverage/classify.py
@@ -22,9 +22,9 @@ from pydantic import Field
 
 from acceptance.coverage.prompt import DiffRef, hunk_labels, render_diff_prompt, resolve_refs
 from acceptance.llm import ModelClient, StrictResponseModel
-from acceptance.supplied_ids import UnusableAnswerLog, constrain, scan
 from acceptance.model_base import PersistableModel
 from acceptance.review_state import AdmissibleEvidence, ChangeSet, Obligation
+from acceptance.supplied_ids import UnusableAnswerLog, constrain, scan
 
 __all__ = ["CoverageStatus", "DiffRef", "ImplementationCoverage", "classify_coverage"]
 

--- a/src/acceptance/coverage/open_questions.py
+++ b/src/acceptance/coverage/open_questions.py
@@ -23,7 +23,6 @@ from pydantic import Field
 
 from acceptance.coverage.prompt import DiffRef, hunk_labels, render_diff_section, resolve_refs
 from acceptance.llm import ModelClient, StrictResponseModel
-from acceptance.supplied_ids import UnusableAnswerLog, constrain, scan
 from acceptance.model_base import PersistableModel
 from acceptance.review_state import (
     ChangeSet,
@@ -32,6 +31,7 @@ from acceptance.review_state import (
     ObligationType,
     OpenQuestion,
 )
+from acceptance.supplied_ids import UnusableAnswerLog, constrain, scan
 
 _STAGE = "open-question judgment"
 

--- a/src/acceptance/coverage/recommendations.py
+++ b/src/acceptance/coverage/recommendations.py
@@ -25,13 +25,13 @@ from __future__ import annotations
 from acceptance.coverage.prompt import render_diff_section
 from acceptance.evidence.discrimination import ObligationDiscrimination
 from acceptance.llm import ModelClient, SchemaValidationError, StrictResponseModel
-from acceptance.supplied_ids import UnusableAnswerLog, constrain, scan
 from acceptance.review_state import (
     AdmissibleEvidence,
     ChangeSet,
     Obligation,
     TestRecommendation,
 )
+from acceptance.supplied_ids import UnusableAnswerLog, constrain, scan
 
 # §9.3 classes that represent a real evidence gap — anything short of
 # strongly_supported earns a recommendation (the M7.1 trigger). An obligation

--- a/src/acceptance/coverage/unrequested.py
+++ b/src/acceptance/coverage/unrequested.py
@@ -28,9 +28,9 @@ from pydantic import Field
 
 from acceptance.coverage.prompt import DiffRef, hunk_labels, render_diff_prompt, resolve_refs
 from acceptance.llm import ModelClient, StrictResponseModel
-from acceptance.supplied_ids import UnusableAnswerLog, constrain, scan
 from acceptance.model_base import PersistableModel
 from acceptance.review_state import ChangeSet, Obligation
+from acceptance.supplied_ids import UnusableAnswerLog, constrain, scan
 
 
 class UnrequestedChangeKind(str, Enum):

--- a/src/acceptance/evidence/discrimination.py
+++ b/src/acceptance/evidence/discrimination.py
@@ -24,9 +24,9 @@ the predictions by execution.
 from __future__ import annotations
 
 from acceptance.llm import ModelClient, StrictResponseModel
-from acceptance.supplied_ids import UnusableAnswerLog, constrain, scan
 from acceptance.model_base import PersistableModel
 from acceptance.review_state import ChangeSet, Obligation, TestEvidence
+from acceptance.supplied_ids import UnusableAnswerLog, constrain, scan
 
 _STAGE = "discrimination judgment"
 

--- a/src/acceptance/evidence/extraction.py
+++ b/src/acceptance/evidence/extraction.py
@@ -90,10 +90,13 @@ def _production_import_names(file_path: Path, changed_modules: set[str]) -> set[
         return set()
     names: set[str] = set()
     for node in ast.walk(module):
-        if isinstance(node, ast.ImportFrom) and node.module:
-            if node.module.split(".")[0] in changed_modules:
-                for alias in node.names:
-                    names.add(alias.asname or alias.name)
+        if (
+            isinstance(node, ast.ImportFrom)
+            and node.module
+            and node.module.split(".")[0] in changed_modules
+        ):
+            for alias in node.names:
+                names.add(alias.asname or alias.name)
     return names
 
 

--- a/src/acceptance/evidence/mapping.py
+++ b/src/acceptance/evidence/mapping.py
@@ -19,6 +19,8 @@ the field the §11.1 mapping-accuracy metric (scoring.py) already scores.
 
 from __future__ import annotations
 
+from pydantic import Field
+
 from acceptance.config import DEFAULT_MAPPING_BATCH_SIZE
 from acceptance.evidence.discovery import DiscoveredTest
 from acceptance.llm import ModelClient, StrictResponseModel
@@ -69,8 +71,8 @@ class MappingResult(PersistableModel):
     # Obligations whose mapping could not be honoured. Disjoint from
     # `unmapped_obligation_ids` in meaning: unmapped is a substantive negative
     # answer, this is the absence of an answer.
-    indeterminate_obligation_ids: list[str] = []
-    unusable_answers: list[UnusableAnswer] = []
+    indeterminate_obligation_ids: list[str] = Field(default_factory=list)
+    unusable_answers: list[UnusableAnswer] = Field(default_factory=list)
 
 
 class _TestMapping(StrictResponseModel):

--- a/src/acceptance/evidence/strength.py
+++ b/src/acceptance/evidence/strength.py
@@ -29,6 +29,8 @@ field the §11.1 evidence-classification-agreement metric (scoring.py) reads.
 
 from __future__ import annotations
 
+from pydantic import Field
+
 from acceptance.evidence.discrimination import ObligationDiscrimination
 from acceptance.evidence_tier import EvidenceTier
 from acceptance.model_base import PersistableModel
@@ -42,7 +44,8 @@ class EvidenceStrength(PersistableModel):
     obligation_id: str
     evidence_class: EvidenceClassification
     explanation: str
-    test_links: list[str] = []  # pytest nodeids of the mapped tests
+    # pytest nodeids of the mapped tests
+    test_links: list[str] = Field(default_factory=list)
 
 
 def _evidence_by_obligation(

--- a/src/acceptance/llm.py
+++ b/src/acceptance/llm.py
@@ -27,9 +27,10 @@ from __future__ import annotations
 import hashlib
 import json
 import sys
+from collections.abc import Callable, Sequence
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, Sequence, TypeVar
+from typing import Any, TypeVar
 
 from pydantic import BaseModel, ConfigDict, ValidationError
 
@@ -263,8 +264,13 @@ def _extract_usage(response: Any) -> dict:
     if litellm is not None:
         try:
             cost = litellm.completion_cost(completion_response=response)
-        except Exception:
-            # Unpriced/unknown model; never fail a call over a cost lookup.
+        except Exception:  # noqa: BLE001 — see below
+            # Deliberately blind. This is a cost *annotation* on a call that has
+            # already succeeded, and litellm raises whatever the provider's
+            # pricing table happens to raise for an unknown model. Narrowing the
+            # catch would let a new provider's exception type fail a review that
+            # otherwise completed, which is a strictly worse trade than losing a
+            # cost figure.
             cost = None
         if cost is not None:
             usage["cost_usd"] = cost

--- a/src/acceptance/partition.py
+++ b/src/acceptance/partition.py
@@ -20,7 +20,8 @@ tokens on stages with no observed failure (DR-164, decision 2).
 
 from __future__ import annotations
 
-from typing import Any, Callable, Generic, Iterable, Sequence, TypeVar
+from collections.abc import Callable, Iterable, Sequence
+from typing import Any, Generic, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field
 

--- a/src/acceptance/pipeline.py
+++ b/src/acceptance/pipeline.py
@@ -28,14 +28,6 @@ from acceptance.config import (
     ScopeExpansionPolicy,
     provenance_for,
 )
-from acceptance.rerun import (
-    carried_findings,
-    carried_recommendations,
-    compute_delta,
-    merge_carried_forward,
-    obligations_to_rederive,
-    task_source_for,
-)
 from acceptance.coverage.classify import CoverageStatus, ImplementationCoverage, classify_coverage
 from acceptance.coverage.declaration_comparison import (
     compare_declaration,
@@ -54,13 +46,20 @@ from acceptance.evidence.discrimination import judge_discrimination
 from acceptance.evidence.extraction import extract_test_evidence
 from acceptance.evidence.mapping import apply_test_mapping, map_tests_to_obligations
 from acceptance.evidence.strength import apply_evidence_strength, classify_strength
-from acceptance.supplied_ids import UnusableAnswer, UnusableAnswerLog
 from acceptance.evidence_tier import Component, EvidenceTier
 from acceptance.llm import ModelClient
 from acceptance.requirement.declaration import declaration_absent_finding, parse_declaration
 from acceptance.requirement.linking import link_duplicate_obligations
 from acceptance.requirement.obligations import decompose
 from acceptance.requirement.task_file import parse_task_file
+from acceptance.rerun import (
+    carried_findings,
+    carried_recommendations,
+    compute_delta,
+    merge_carried_forward,
+    obligations_to_rederive,
+    task_source_for,
+)
 from acceptance.review_state import (
     UNREQUESTED_CHANGE,
     UNUSABLE_ANSWER,
@@ -71,6 +70,7 @@ from acceptance.review_state import (
     Review,
     UnrequestedChangeDisposition,
 )
+from acceptance.supplied_ids import UnusableAnswer, UnusableAnswerLog
 from acceptance.verdict import derive_verdict
 
 _SEVERITY_BY_STATUS = {

--- a/src/acceptance/report.py
+++ b/src/acceptance/report.py
@@ -20,8 +20,8 @@ from acceptance.review_state import (
     UNREQUESTED_CHANGE,
     AdmissibleEvidence,
     CompletionVerdict,
-    Obligation,
     MandateCoverage,
+    Obligation,
     RequirementMap,
     Review,
     TestRecommendation,
@@ -306,8 +306,10 @@ def _unread_block(requirement_map: RequirementMap) -> list[str]:
         return []
     lines = [
         "",
-        f"  Not read as any requirement: {len(requirement_map.unread_source)} block(s)"
-        " — outside every recognised section, so no obligation could derive from them.",
+        (
+            f"  Not read as any requirement: {len(requirement_map.unread_source)} block(s)"
+            " — outside every recognised section, so no obligation could derive from them."
+        ),
     ]
     for span in requirement_map.unread_source:
         excerpt = " ".join(span.text.split())

--- a/src/acceptance/requirement/declaration.py
+++ b/src/acceptance/requirement/declaration.py
@@ -25,7 +25,7 @@ from markdown_it.tree import SyntaxTreeNode
 from acceptance.evidence_tier import Component, EvidenceTier
 from acceptance.review_state import DECLARATION_ABSENT, BuilderDeclaration, Finding, Link
 
-__all__ = ["parse_declaration", "declaration_absent_finding"]
+__all__ = ["declaration_absent_finding", "parse_declaration"]
 
 # §7.4 template section headings, normalized (lowercased), to the
 # BuilderDeclaration field each fills. A section a declaration omits is left

--- a/src/acceptance/requirement/linking.py
+++ b/src/acceptance/requirement/linking.py
@@ -56,7 +56,7 @@ model's judgement rather than of how it happened to order a response.
 from __future__ import annotations
 
 import math
-from typing import Sequence
+from collections.abc import Sequence
 
 from acceptance.config import DEFAULT_LINK_PAIR_BATCH_SIZE
 from acceptance.llm import ModelClient, StrictResponseModel

--- a/src/acceptance/requirement/obligations.py
+++ b/src/acceptance/requirement/obligations.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Literal, Union
+from typing import Literal
 
 from pydantic import Field
 
@@ -349,12 +349,12 @@ class _RaisedOpenQuestion(StrictResponseModel):
         return [self.open_question_id, *self.more_open_question_ids]
 
 
-# A plain `Union`, deliberately not `Field(discriminator=...)`: pydantic renders
+# A plain union, deliberately not `Field(discriminator=...)`: pydantic renders
 # a tagged union as `oneOf` + `discriminator`, and strict mode accepts neither,
 # while `inline_schema_refs` would leave the discriminator mapping pointing at
 # `$defs` it had just inlined. A plain union renders `anyOf`, which strict mode
 # does accept, and the `Literal` tags still make the match unambiguous.
-_RequirementDisposition = Union[_Yielded, _NoObligation, _RaisedOpenQuestion]
+_RequirementDisposition = _Yielded | _NoObligation | _RaisedOpenQuestion
 
 
 class _Decomposition(StrictResponseModel):
@@ -420,9 +420,11 @@ def _user_prompt(registry: list[RequirementRef], answer_for: set[str]) -> str:
             "",
             ", ".join(sorted(answer_for)),
             "",
-            "The rest are shown so you can read the mandate as a whole. Do not "
-            "dispose of them and do not derive obligations for them; another call "
-            "answers for those.",
+            (
+                "The rest are shown so you can read the mandate as a whole. Do not "
+                "dispose of them and do not derive obligations for them; another call "
+                "answers for those."
+            ),
         ]
     )
     return "\n".join(lines)

--- a/src/acceptance/requirement/task_file.py
+++ b/src/acceptance/requirement/task_file.py
@@ -15,11 +15,12 @@ from __future__ import annotations
 
 from markdown_it import MarkdownIt
 from markdown_it.tree import SyntaxTreeNode
+from pydantic import Field
 
 from acceptance.model_base import PersistableModel
 from acceptance.source_ref import TextSpan
 
-__all__ = ["TextSpan", "ParsedTaskFile", "parse_task_file"]
+__all__ = ["ParsedTaskFile", "TextSpan", "parse_task_file"]
 
 # §7.1 section headings, normalized (lowercased). A file may add other
 # sections; unknown ones are ignored rather than rejected.
@@ -61,11 +62,11 @@ class ParsedTaskFile(PersistableModel):
     """
 
     source: str
-    behavior: list[TextSpan] = []
-    constraints: list[TextSpan] = []
-    scope_exclusions: list[TextSpan] = []
-    completion_expectations: list[TextSpan] = []
-    unclaimed: list[TextSpan] = []
+    behavior: list[TextSpan] = Field(default_factory=list)
+    constraints: list[TextSpan] = Field(default_factory=list)
+    scope_exclusions: list[TextSpan] = Field(default_factory=list)
+    completion_expectations: list[TextSpan] = Field(default_factory=list)
+    unclaimed: list[TextSpan] = Field(default_factory=list)
 
 
 def parse_task_file(text: str) -> ParsedTaskFile:

--- a/src/acceptance/rerun.py
+++ b/src/acceptance/rerun.py
@@ -69,6 +69,7 @@ def _is_ancestor(candidate: str, head: str, repo: Path) -> bool:
         capture_output=True,
         text=True,
         cwd=repo,
+        check=False,
     )
     return result.returncode == 0
 
@@ -80,6 +81,7 @@ def _commit_distance(ancestor: str, head: str, repo: Path) -> int | None:
         capture_output=True,
         text=True,
         cwd=repo,
+        check=False,
     )
     if result.returncode != 0:
         return None

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -24,43 +24,43 @@ from acceptance.serialization import canonical_json
 from acceptance.source_ref import TextSpan
 
 __all__ = [
-    "Component",
-    "EvidenceTier",
-    "TextSpan",
-    "ObligationType",
-    "AdmissibleEvidence",
-    "EvidenceClassification",
-    "UnrequestedChangeDisposition",
-    "UNREQUESTED_CHANGE",
     "DECLARATION_ABSENT",
     "DECLARATION_MISMATCH",
-    "Project",
-    "TaskSource",
-    "MandateInterpretation",
+    "UNREQUESTED_CHANGE",
+    "AdmissibleEvidence",
     "BuilderDeclaration",
-    "DiffHunk",
-    "FileChange",
     "ChangeSet",
-    "RequirementSection",
-    "RequirementRef",
+    "CompletionResult",
+    "CompletionVerdict",
+    "Component",
+    "DeterminismControls",
+    "DiffHunk",
     "Disposition",
+    "EvidenceClassification",
+    "EvidenceTier",
+    "ExecutionEvidence",
+    "FileChange",
+    "Finding",
+    "Link",
+    "MandateCoverage",
+    "MandateInterpretation",
+    "Obligation",
+    "ObligationChange",
+    "ObligationType",
+    "OpenQuestion",
+    "Project",
     "RequirementDisposition",
     "RequirementMap",
-    "Obligation",
-    "OpenQuestion",
-    "TestEvidence",
-    "ExecutionEvidence",
-    "Link",
-    "Finding",
-    "TestRecommendation",
-    "CompletionVerdict",
-    "CompletionResult",
-    "MandateCoverage",
-    "DeterminismControls",
-    "ReviewProvenance",
-    "ObligationChange",
-    "ReviewDelta",
+    "RequirementRef",
+    "RequirementSection",
     "Review",
+    "ReviewDelta",
+    "ReviewProvenance",
+    "TaskSource",
+    "TestEvidence",
+    "TestRecommendation",
+    "TextSpan",
+    "UnrequestedChangeDisposition",
 ]
 
 
@@ -563,12 +563,12 @@ class Finding(_Model):
         return value
 
     @model_validator(mode="after")
-    def _require_authorized_tier(self) -> "Finding":
+    def _require_authorized_tier(self) -> Finding:
         authorize_tier(self.produced_by, self.evidence_tier)
         return self
 
     @model_validator(mode="after")
-    def _obligation_less_only_for_allowed_types(self) -> "Finding":
+    def _obligation_less_only_for_allowed_types(self) -> Finding:
         obligation_less_ok = self.type in _OBLIGATION_LESS_TYPES
         if self.related_obligation is None and not obligation_less_ok:
             raise ValueError(
@@ -583,7 +583,7 @@ class Finding(_Model):
         return self
 
     @model_validator(mode="after")
-    def _disposition_only_for_unrequested_change(self) -> "Finding":
+    def _disposition_only_for_unrequested_change(self) -> Finding:
         if self.disposition is not None and self.type != UNREQUESTED_CHANGE:
             raise ValueError(
                 f"disposition is only valid on an {UNREQUESTED_CHANGE!r} finding, not {self.type!r}"

--- a/src/acceptance/supplied_ids.py
+++ b/src/acceptance/supplied_ids.py
@@ -81,7 +81,10 @@ def _constrained_nested(annotation: Any, allowed: Mapping[str, Sequence[str]]) -
         rebuilt = [_constrained_nested(member, allowed) or member for member in members]
         if all(new is old for new, old in zip(rebuilt, members)):
             return None
-        return Union[tuple(rebuilt)]
+        # Not rewritable as `X | Y`: the members are a runtime tuple of unknown
+        # length, and PEP 604 has no subscript form. `functools.reduce(or_, ...)`
+        # would build the same object less legibly.
+        return Union[tuple(rebuilt)]  # noqa: UP007
     if get_origin(annotation) is list:
         args = get_args(annotation)
         item = args[0] if args else None
@@ -193,17 +196,18 @@ def scan(
 
     def visit(node: Any) -> None:
         if isinstance(node, BaseModel):
-            for name, _ in type(node).model_fields.items():
+            for name in type(node).model_fields:
                 value = getattr(node, name)
                 if name in supplied:
                     values = value if isinstance(value, list) else [value]
                     for item in values:
-                        if isinstance(item, str) and item not in supplied[name]:
-                            if (name, item) not in seen:
-                                seen.add((name, item))
-                                found.append(
-                                    UnusableAnswer(stage=stage, field=name, returned_id=item)
-                                )
+                        if (
+                            isinstance(item, str)
+                            and item not in supplied[name]
+                            and (name, item) not in seen
+                        ):
+                            seen.add((name, item))
+                            found.append(UnusableAnswer(stage=stage, field=name, returned_id=item))
                 else:
                     visit(value)
         elif isinstance(node, list):

--- a/tests/benchmark/degenerate_judges.py
+++ b/tests/benchmark/degenerate_judges.py
@@ -33,6 +33,7 @@ is reworded.
 from __future__ import annotations
 
 import json
+import tempfile
 from typing import Any
 
 from acceptance.config import DEFAULT_EMBEDDING_MODEL, DEFAULT_MODEL
@@ -43,8 +44,6 @@ from tests.support import (
     _fake_response,
     constant_embedding_fn,
 )
-
-import tempfile
 
 
 def _enums(schema: Any, field: str) -> list[str]:

--- a/tests/benchmark/test_alignment.py
+++ b/tests/benchmark/test_alignment.py
@@ -28,7 +28,6 @@ from acceptance.review_state import (
 )
 from tests.support import client_returning
 
-
 # --- align_obligations ---
 
 
@@ -69,6 +68,7 @@ def test_unknown_labels_are_ignored():
 def test_empty_sides_make_no_call():
     # No obligations on a side -> no possible match, no model call needed.
     import tempfile
+
     from acceptance.llm import Mode, ModelClient, TranscriptStore
 
     def boom(**kwargs):

--- a/tests/benchmark/test_case.py
+++ b/tests/benchmark/test_case.py
@@ -22,21 +22,21 @@ def _round_trip(instance):
 
 
 def _obligation(**overrides) -> GroundTruthObligation:
-    defaults = dict(
-        id="csv-generation",
-        description="CSV generation",
-        explicit=True,
-        evidence_class="strongly_supported",
-        evidence_rationale="The test asserts the generated CSV exactly.",
-        candidate_tests=["test_csv.py::test_basic"],
-    )
+    defaults = {
+        "id": "csv-generation",
+        "description": "CSV generation",
+        "explicit": True,
+        "evidence_class": "strongly_supported",
+        "evidence_rationale": "The test asserts the generated CSV exactly.",
+        "candidate_tests": ["test_csv.py::test_basic"],
+    }
     defaults.update(overrides)
     return GroundTruthObligation(**defaults)
 
 
 def _labels(**overrides) -> GroundTruthLabels:
-    defaults = dict(
-        obligations=[
+    defaults = {
+        "obligations": [
             _obligation(),
             _obligation(
                 id="filters",
@@ -46,7 +46,7 @@ def _labels(**overrides) -> GroundTruthLabels:
                 candidate_tests=[],
             ),
         ],
-        gaps=[
+        "gaps": [
             GroundTruthGap(
                 id="gap-filters",
                 description="Active filters not applied",
@@ -54,23 +54,23 @@ def _labels(**overrides) -> GroundTruthLabels:
                 severity="high",
             )
         ],
-    )
+    }
     defaults.update(overrides)
     return GroundTruthLabels(**defaults)
 
 
 def _case(**overrides) -> BenchmarkCase:
-    defaults = dict(
-        case_id="archetype-01",
-        source=BenchmarkCaseSource(kind="archetype", identifier="missed-obligation"),
-        inputs=BenchmarkCaseInputs(
+    defaults = {
+        "case_id": "archetype-01",
+        "source": BenchmarkCaseSource(kind="archetype", identifier="missed-obligation"),
+        "inputs": BenchmarkCaseInputs(
             repo="fixtures/archetype-01",
             task_text="## Deliverable\nAdd CSV export.\n",
             base_revision="abc123",
             head_revision="def456",
         ),
-        ground_truth=_labels(),
-    )
+        "ground_truth": _labels(),
+    }
     defaults.update(overrides)
     return BenchmarkCase(**defaults)
 

--- a/tests/benchmark/test_corpus.py
+++ b/tests/benchmark/test_corpus.py
@@ -14,10 +14,10 @@ import pytest
 from acceptance.benchmark.corpus import (
     UnresolvableRevisionError,
     build_corpus_case,
-    resolve_case_revisions,
     load_corpus_meta,
     materialize_corpus_run,
     remove_corpus_worktree,
+    resolve_case_revisions,
 )
 
 REPO = Path(__file__).resolve().parents[2]

--- a/tests/benchmark/test_coverage.py
+++ b/tests/benchmark/test_coverage.py
@@ -32,13 +32,13 @@ from acceptance.cli import run_check
 from acceptance.config import DEFAULT_MODEL, RunConfig
 from acceptance.llm import Mode, ModelClient, TranscriptStore
 from acceptance.review_store import ReviewStore
-from tests.support import client_dispatching as _client_dispatching
 from tests.support import (
     _EMPTY_BY_SCHEMA,
     _completed,
     _fake_response,
     client_finding_nothing,
 )
+from tests.support import client_dispatching as _client_dispatching
 
 ARCHETYPES_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "archetypes"
 

--- a/tests/benchmark/test_decompose_regression.py
+++ b/tests/benchmark/test_decompose_regression.py
@@ -347,7 +347,7 @@ def test_precision_is_not_asserted_where_a_re_split_is_ground_truth(case_dir):
 def test_scoring_goes_through_the_shared_benchmark_path(monkeypatch):
     """The cases are scored by `benchmark/scoring.py::score_case`, not by a
     second scorer written for this task."""
-    import acceptance.benchmark.hooks as hooks
+    from acceptance.benchmark import hooks
 
     calls = []
     original = hooks.score_case
@@ -411,7 +411,7 @@ def test_the_cases_issue_no_live_model_calls(monkeypatch):
     `_default_completion_fn` is the single door to litellm (`llm.py`), so
     breaking it is sufficient.
     """
-    import acceptance.llm as llm
+    from acceptance import llm
 
     def forbidden(**kwargs):
         raise AssertionError("the suite reached the live provider path")

--- a/tests/benchmark/test_fixtures.py
+++ b/tests/benchmark/test_fixtures.py
@@ -281,6 +281,7 @@ def test_head_pytest_runs_with_the_intended_outcome(fixture_dir, tmp_path):
         cwd=fixture.repo_path,
         capture_output=True,
         text=True,
+        check=False,
     )
 
     if fixture.meta.intended_pytest == "pass":

--- a/tests/benchmark/test_instability.py
+++ b/tests/benchmark/test_instability.py
@@ -14,8 +14,10 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from acceptance.benchmark.fixtures import build_benchmark_case  # noqa: E402
-from acceptance.benchmark.instability import (  # noqa: E402
+from support import _completed, client_dispatching, client_finding_nothing
+
+from acceptance.benchmark.fixtures import build_benchmark_case
+from acceptance.benchmark.instability import (
     DEFAULT_MODELS,
     DEFAULT_RUNS_PER_MODEL,
     ClassDistribution,
@@ -24,8 +26,8 @@ from acceptance.benchmark.instability import (  # noqa: E402
     InstabilityReport,
     ModelInstability,
     ObservingClient,
-    PerturbationResult,
     Perturbation,
+    PerturbationResult,
     RunKey,
     RunSnapshot,
     add_unrelated_test,
@@ -37,8 +39,7 @@ from acceptance.benchmark.instability import (  # noqa: E402
     seeds_for,
     summarize_model,
 )
-from acceptance.config import Mode, RunConfig  # noqa: E402
-from support import _completed, client_dispatching, client_finding_nothing  # noqa: E402
+from acceptance.config import Mode, RunConfig
 
 _EMPTY_BY_SCHEMA = {
     "_Decomposition": {"obligations": [], "open_questions": [], "requirement_dispositions": []},
@@ -504,7 +505,7 @@ def test_measure_instability_varies_the_seed_across_runs(tmp_path):
         client_factory=_observing_factory(calls),
     )
 
-    assert len(set(seed for seed, _ in calls)) == 2
+    assert len({seed for seed, _ in calls}) == 2
 
 
 def test_measure_instability_records_the_conditions_that_produced_it(tmp_path):
@@ -558,8 +559,9 @@ def test_a_perturbation_run_is_included_when_one_is_supplied(tmp_path):
 def test_observations_do_not_leak_between_clients():
     """A mutable class-level default would make every run share one list, so all
     runs would look identical — stability faked by the measuring instrument."""
-    from acceptance.llm import TranscriptStore
     import tempfile
+
+    from acceptance.llm import TranscriptStore
 
     def build():
         return ObservingClient(

--- a/tests/benchmark/test_rating_regression.py
+++ b/tests/benchmark/test_rating_regression.py
@@ -204,7 +204,7 @@ def test_scoring_goes_through_the_shared_benchmark_path(monkeypatch, corpus_work
     the way the CLI and benchmark pipelines drifted before M7.4 — and the
     divergence would be invisible, because both would keep returning numbers.
     """
-    import acceptance.benchmark.scoring as scoring
+    from acceptance.benchmark import scoring
 
     calls = []
     real = scoring.score_case_set
@@ -422,7 +422,7 @@ def test_each_case_is_scored_through_score_case_itself(corpus_worktrees):
     spirit. This scores every case through `score_case` directly and requires
     the two paths to agree, so a private scorer cannot diverge unnoticed.
     """
-    import acceptance.benchmark.scoring as scoring
+    from acceptance.benchmark import scoring
 
     scored, seen = [], []
     real = scoring.score_case

--- a/tests/benchmark/test_scoring.py
+++ b/tests/benchmark/test_scoring.py
@@ -13,16 +13,16 @@ from acceptance.review_state import Review
 
 
 def _archetype_case(**overrides) -> BenchmarkCase:
-    defaults = dict(
-        case_id="archetype-01-missed-obligation",
-        source=BenchmarkCaseSource(kind="archetype", identifier="missed-obligation"),
-        inputs=BenchmarkCaseInputs(
+    defaults = {
+        "case_id": "archetype-01-missed-obligation",
+        "source": BenchmarkCaseSource(kind="archetype", identifier="missed-obligation"),
+        "inputs": BenchmarkCaseInputs(
             repo="fixtures/archetype-01",
             task_text="## Deliverable\nAdd CSV export with active filters.\n",
             base_revision="abc123",
             head_revision="def456",
         ),
-        ground_truth=GroundTruthLabels(
+        "ground_truth": GroundTruthLabels(
             obligations=[
                 GroundTruthObligation(
                     id="csv-generation",
@@ -50,7 +50,7 @@ def _archetype_case(**overrides) -> BenchmarkCase:
                 )
             ],
         ),
-    )
+    }
     defaults.update(overrides)
     return BenchmarkCase(**defaults)
 

--- a/tests/coverage/test_classify.py
+++ b/tests/coverage/test_classify.py
@@ -11,8 +11,8 @@ diff-region links. Classification *accuracy* is measured by the benchmark (M3.3)
 
 from pathlib import Path
 
-from acceptance.change.diff import extract_change_set
 from acceptance.benchmark.fixtures import materialize_archetype
+from acceptance.change.diff import extract_change_set
 from acceptance.coverage.classify import (
     CoverageStatus,
     ImplementationCoverage,

--- a/tests/coverage/test_recommendations.py
+++ b/tests/coverage/test_recommendations.py
@@ -9,8 +9,8 @@ Recommendation *quality* against the real model is shown by the PR's record run.
 import pytest
 
 from acceptance.coverage.recommendations import recommend_tests
-from acceptance.llm import SchemaValidationError
 from acceptance.evidence.discrimination import ObligationDiscrimination, PlausibleDefect
+from acceptance.llm import SchemaValidationError
 from acceptance.review_state import (
     AdmissibleEvidence,
     ChangeSet,
@@ -59,8 +59,9 @@ def _change_set() -> ChangeSet:
 
 
 def _exploding_client():
-    from acceptance.llm import Mode, ModelClient, TranscriptStore
     import tempfile
+
+    from acceptance.llm import Mode, ModelClient, TranscriptStore
 
     def boom(**kwargs):
         raise AssertionError("a model call was issued with no weak obligations")

--- a/tests/evidence/test_discrimination.py
+++ b/tests/evidence/test_discrimination.py
@@ -59,6 +59,7 @@ def _change_set() -> ChangeSet:
 
 def _exploding_client():
     import tempfile
+
     from acceptance.llm import Mode, ModelClient, TranscriptStore
 
     def boom(**kwargs):

--- a/tests/requirement/region_coverage.py
+++ b/tests/requirement/region_coverage.py
@@ -39,7 +39,7 @@ from markdown_it.tree import SyntaxTreeNode
 
 from acceptance.requirement.task_file import ParsedTaskFile, parse_task_file
 
-__all__ = ["uncovered_regions", "assert_total_region_coverage"]
+__all__ = ["assert_total_region_coverage", "uncovered_regions"]
 
 # A list marker at the head of a line, with its indentation and trailing space.
 _MARKER = re.compile(r"^(\s*)([-*+]|\d+[.)])(\s+)")

--- a/tests/requirement/test_linking.py
+++ b/tests/requirement/test_linking.py
@@ -11,11 +11,10 @@ attributable.
 
 from __future__ import annotations
 
-
 from acceptance.requirement.linking import (
-    _PairVerdict,
     _confirmed_clusters,
     _pairs,
+    _PairVerdict,
     _Verdicts,
     link_duplicate_obligations,
 )

--- a/tests/requirement/test_region_coverage.py
+++ b/tests/requirement/test_region_coverage.py
@@ -21,7 +21,6 @@ from markdown_it.tree import SyntaxTreeNode
 from acceptance.requirement.registry import build_registry
 from acceptance.requirement.task_file import parse_task_file
 from acceptance.source_ref import TextSpan
-
 from tests.requirement.region_coverage import assert_total_region_coverage, uncovered_regions
 
 REPO_ROOT = Path(__file__).resolve().parents[2]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -143,7 +143,6 @@ def test_provenance_reports_the_partition_size_the_run_actually_used():
     controls (#160). A review that reported a configured partition size while
     its calls ran unpartitioned would describe a run that did not happen."""
     from acceptance.requirement.obligations import _Decomposition
-
     from tests.support import client_finding_nothing
 
     client = client_finding_nothing()
@@ -162,7 +161,6 @@ def test_provenance_of_an_unpartitioned_run_reports_no_partition_size():
     different claim from a partition of size one — the same distinction
     controls_in_force draws between "ignored" and "nothing observed"."""
     from acceptance.requirement.obligations import _Decomposition
-
     from tests.support import client_finding_nothing
 
     client = client_finding_nothing()

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -5,17 +5,16 @@ from types import SimpleNamespace
 import pytest
 from pydantic import BaseModel
 
-from acceptance.review_state import UnrequestedChangeDisposition as UnrequestedDisposition
-
 from acceptance.llm import (
     Mode,
-    inline_schema_refs,
     ModelClient,
     SchemaValidationError,
     TranscriptNotFoundError,
     TranscriptStore,
+    inline_schema_refs,
     request_key,
 )
+from acceptance.review_state import UnrequestedChangeDisposition as UnrequestedDisposition
 
 
 class Verdict(BaseModel):

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -7,6 +7,7 @@ without carrying the batch's position.
 """
 
 import pytest
+from pydantic import ValidationError
 
 from acceptance.partition import Batch, partition
 
@@ -129,5 +130,8 @@ def test_the_mechanism_does_not_depend_on_the_stage_that_uses_it():
 def test_a_batch_is_immutable():
     batch = partition(["a", "b"], 2, key=str)[0]
 
-    with pytest.raises(Exception):
+    # ValidationError, not Exception: a bare Exception would be satisfied by an
+    # AttributeError from a renamed field or a TypeError from a changed
+    # signature, so the test would keep passing after immutability was lost.
+    with pytest.raises(ValidationError):
         batch.size = 99

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -2,9 +2,10 @@
 evidence with a per-line evidence tier, advisory unrequested changes, and the
 computed verdict."""
 
+from acceptance.report import render_report
 from acceptance.review_state import (
-    AdmissibleEvidence,
     UNREQUESTED_CHANGE,
+    AdmissibleEvidence,
     CompletionResult,
     CompletionVerdict,
     Component,
@@ -18,8 +19,6 @@ from acceptance.review_state import (
     TestRecommendation,
     UnrequestedChangeDisposition,
 )
-
-from acceptance.report import render_report
 
 
 def test_empty_review_renders_the_full_shell():

--- a/tests/test_rerun.py
+++ b/tests/test_rerun.py
@@ -5,6 +5,16 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+from acceptance.rerun import (
+    carried_findings,
+    carried_recommendations,
+    compute_delta,
+    find_prior_review,
+    merge_carried_forward,
+    obligations_to_rederive,
+    stale_obligation_ids,
+    task_source_for,
+)
 from acceptance.review_state import (
     ChangeSet,
     Component,
@@ -18,16 +28,6 @@ from acceptance.review_state import (
     TestRecommendation,
 )
 from acceptance.review_store import ReviewStore
-from acceptance.rerun import (
-    carried_findings,
-    carried_recommendations,
-    compute_delta,
-    find_prior_review,
-    merge_carried_forward,
-    obligations_to_rederive,
-    stale_obligation_ids,
-    task_source_for,
-)
 
 TASK = "# Task\nRound half to even.\n"
 
@@ -482,9 +482,9 @@ def test_archetype_9_rerun_flips_the_weak_obligation_and_updates_the_verdict(tmp
     M3/M5's accuracy, scored by the benchmark. Both obligations cite files the
     head touches, so both are re-derived here; carry-forward is covered above.
     """
+    from acceptance.benchmark.fixtures import build_benchmark_case
     from acceptance.cli import run_check
     from acceptance.config import RunConfig
-    from acceptance.benchmark.fixtures import build_benchmark_case
     from tests.support import client_dispatching
 
     case = build_benchmark_case(ARCHETYPES_DIR / "09-revision-cycle", tmp_path / "repo")
@@ -615,8 +615,8 @@ def test_a_rerun_still_reports_a_gap_in_code_the_new_work_never_touched(tmp_path
     carry-forward of prior findings survived the unit tests, which only covered
     the helper; nothing checked the pipeline actually used it.
     """
-    from acceptance.pipeline import run_review
     from acceptance.change.diff import extract_change_set
+    from acceptance.pipeline import run_review
     from tests.support import client_dispatching
 
     repo = tmp_path / "repo"
@@ -717,9 +717,9 @@ def test_a_review_written_under_an_older_schema_is_skipped_not_fatal(tmp_path):
     root = tmp_path / "reviews"
     root.mkdir()
     (root / f"{first}.json").write_text(
-        '{"mode": "local", "reviewed_revision": "%s",'
+        f'{{"mode": "local", "reviewed_revision": "{first}",'
         ' "provenance": {"determinism_mode": "record", "model": "m",'
-        ' "temperature": 0.0, "seed": null}}' % first
+        ' "temperature": 0.0, "seed": null}}'
     )
     store = ReviewStore(root)
 
@@ -735,8 +735,8 @@ def test_only_the_affected_obligation_is_re_derived(tmp_path):
     that the affected one was actually re-derived. A build that carried
     everything forward would have passed it.
     """
-    from acceptance.pipeline import run_review
     from acceptance.change.diff import extract_change_set
+    from acceptance.pipeline import run_review
     from tests.support import client_dispatching
 
     repo = tmp_path / "repo"
@@ -910,7 +910,7 @@ def test_a_working_tree_review_builds_on_the_review_of_head(tmp_path):
     incremental feature is unreachable from the primary local path. Found by
     dogfooding: this project's own runs silently never used it.
     """
-    repo, first, second = _repo_with_two_commits(tmp_path)
+    repo, _first, second = _repo_with_two_commits(tmp_path)
     store = ReviewStore(tmp_path / "reviews")
     store.write(_review(second, [_obligation("a")]))
 

--- a/tests/test_review_state.py
+++ b/tests/test_review_state.py
@@ -243,15 +243,15 @@ def test_finding_requires_authorized_producer():
 
 
 def _unrequested_finding(**overrides) -> Finding:
-    defaults = dict(
-        type=UNREQUESTED_CHANGE,
-        severity="medium",
-        description="checkout signature changed; not requested.",
-        evidence_tier=EvidenceTier.STATIC,
-        produced_by=Component.STATIC_ANALYZER,
-        links=[Link(kind="code", ref="cart.py:4")],
-        disposition=UnrequestedChangeDisposition.SEPARABLE,
-    )
+    defaults = {
+        "type": UNREQUESTED_CHANGE,
+        "severity": "medium",
+        "description": "checkout signature changed; not requested.",
+        "evidence_tier": EvidenceTier.STATIC,
+        "produced_by": Component.STATIC_ANALYZER,
+        "links": [Link(kind="code", ref="cart.py:4")],
+        "disposition": UnrequestedChangeDisposition.SEPARABLE,
+    }
     defaults.update(overrides)
     return Finding(**defaults)
 

--- a/tests/test_supplied_ids.py
+++ b/tests/test_supplied_ids.py
@@ -13,7 +13,7 @@ honour is RECORDED rather than dropped.
 """
 
 import json
-from typing import Literal, Union
+from typing import Literal
 
 import pytest
 from pydantic import ValidationError
@@ -49,7 +49,7 @@ class _SecondShape(StrictResponseModel):
 
 
 class _UnionContainer(StrictResponseModel):
-    items: list[Union[_FirstShape, _SecondShape]]
+    items: list[_FirstShape | _SecondShape]
 
 
 def _test(test_id: str, source: str = "def t():\n    pass") -> DiscoveredTest:
@@ -121,14 +121,15 @@ def test_a_foreign_id_does_not_validate_against_the_constrained_schema():
     )
     assert ok.items[0].obligation_id == "ob-1"
 
-    try:
+    # ValidationError specifically: catching bare Exception here would also pass
+    # on a typo in the schema name or a JSON syntax error, neither of which is
+    # the rejection this test claims to demonstrate.
+    with pytest.raises(ValidationError) as rejection:
         constrained.model_validate_json(
             '{"items":[{"obligation_id":"show-fields","obligation_ids":[],"rationale":"r"}]}'
         )
-    except Exception as exc:
-        assert "show-fields" in str(exc)
-    else:
-        raise AssertionError("a foreign id validated against the constrained schema")
+
+    assert "show-fields" in str(rejection.value)
 
 
 def test_the_schema_name_is_preserved_so_the_request_key_stays_meaningful():

--- a/tests/test_verdict.py
+++ b/tests/test_verdict.py
@@ -9,6 +9,7 @@ model call is involved in the headline result at all."""
 
 import inspect
 
+from acceptance.evidence_tier import Component, EvidenceTier
 from acceptance.review_state import (
     AdmissibleEvidence,
     CompletionVerdict,
@@ -18,7 +19,6 @@ from acceptance.review_state import (
     ObligationType,
     OpenQuestion,
 )
-from acceptance.evidence_tier import Component, EvidenceTier
 from acceptance.verdict import derive_verdict
 
 


### PR DESCRIPTION
Closes #239. Completes #261, whose formatting half is already on `main` as d06508f.

## What this is

The **lint and build half** of the format-and-lint work. #261's reformat landed on `main` on its own, deliberately: this repo squash-merges, so carrying it here would have fused 53 files of reflow with the lint work into one unreviewable commit — the opposite of what #261 asks for. Review that commit separately if you want the formatting; this PR is 52 files of substance.

Both issues were taken as one mandate because they change the same two files and force the same churn.

## The load-bearing change is `ci.yml`

CI step 4 was `ruff check . || echo "ruff not configured yet — skipping"`. The `|| echo` swallowed the exit code, so the build stayed green through **86 lint findings on an untouched tree**. Clearing the findings without removing that would just reset a counter that starts climbing on ruff's next release.

- Two blocking steps now, `ruff format --check .` and `ruff check .`.
- **Neither installs ruff.** `pip install ruff` floated the version, so CI enforced whatever ruff had most recently released rather than what the project pins. It now comes from the pinned dev extra, with `ruff --version` echoed so findings can be attributed to a version.
- `actions/checkout` v4 → v7, `actions/setup-python` v5 → v7, off Node 20.
- `pyproject.toml` pins `ruff==0.16.2`.

## The findings, and how each was resolved

61 auto-fixed, 14 more with `--unsafe-fixes` reviewed by diff. The rest by hand, none suppressed wholesale:

- **RUF012 ×8** — pydantic models with `= []` defaults. Fixed as `Field(default_factory=list)` rather than by ignoring the rule, so RUF012 stays armed for plain classes where a shared mutable default is a real bug. All 8 are `PersistableModel`, not `StrictResponseModel`, so no request schema moved.
- **B017** in `test_partition.py` — the finding #239 says has teeth. Narrowed to `ValidationError`. A bare `Exception` there would be satisfied by an `AttributeError` from a renamed field, so the test could not fail for the right reason. Same treatment for the `BLE001` in `test_supplied_ids.py`.
- **PLW1510 ×3** — `check=False` made explicit; all three already branch on `returncode`.
- **UP007** in `obligations.py` — `Union[...]` → `|` on the *decompose response schema*. Verified inert rather than assumed: the rendered schema is byte-identical before and after, so no transcripts orphaned.
- **Two `noqa`s, both with stated reasons.** `Union[tuple(rebuilt)]` has no PEP 604 form — the members are a runtime tuple. `llm.py`'s blind catch annotates cost onto a call that already succeeded, and narrowing it would let a new provider's exception fail a completed review.

## Markdown excluded from ruff

ruff 0.16 reformats Python code blocks inside Markdown, and it reflowed the spec. Its snippets are didactic — `result = calculate_coupon(input); assert result is not None` sits on one line precisely to illustrate a non-discriminating test (§13.6). Reflowing it edits the argument. `*.md` is now in `extend-exclude`; without it the formatting commit fails its own acceptance, since `ruff format --check .` cannot exit zero while the spec stays untouched.

## Evidence

Every acceptance item is observed, not argued.

| item | evidence |
|---|---|
| `ruff format --check .` exits zero | 117 files clean |
| reformat changed no behaviour | 1107 passed before and after; **AST byte-identical for 51 of 52 files**, the one exception a docstring that gained a separating space |
| `ruff check .` exits 0 | `All checks passed!` |
| ruff pinned, and the pin reaches CI | `ruff 0.16.2` echoed on the runner |
| actions off Node 20 | zero deprecation warnings in the run |
| **`fetch-depth: 0` still behaves** | 1108 passed, **0 skipped**, #190's rating-regression cases among them — they materialize worktrees at real pinned commits and fail *by name* under a shallow clone |

**Both gates were demonstrated failing, not just passing** — watching a gate pass on a clean tree shows nothing. Two dispatched runs on a throwaway branch, each carrying one file that isolates a single gate so a red build can only come from the step under test:

| run | file | `format --check` | `check` | result |
|---|---|---|---|---|
| [31629989729](https://github.com/alipeles/acceptance-review/actions/runs/31629989729) | `def add( a,b ):` | **fails** | passes | failed at *Format check*; Lint and Tests skipped |
| [31630137817](https://github.com/alipeles/acceptance-review/actions/runs/31630137817) | unsorted imports | passes | **fails** (I001) | *Format check* green, failed at *Lint* |

The second carries the weight: the format step went green and the build still went red, so the lint step's exit code is genuinely honoured rather than the job failing for a shared cause.

## Dogfooding — Gate 2 is NOT clean, and this is why

Stated plainly rather than buried. `acceptance check` **aborted and produced no report**:

```
acceptance: model error: no recommendation for 9 of 12 weak obligation(s)
```

`coverage/recommendations.py:182` requires a recommendation for every weak obligation. Nine of these are properties of `ci.yml` steps, Action major versions and a version pin — **no pytest evidences them**. The model recommended for exactly the three a test could evidence and declined the nine. That answer was principled, not partial; the stage treats it as a schema violation.

The coverage stage had already classified **all 19 obligations `addressed`**, unanimously, citing real diff hunks. None of it reaches the user, so this is a hard abort rather than a degraded report — a configuration-only change cannot be reviewed at all.

It was **predicted before the run** (`dogfood-logs/261-gate1-run2/judgement.md`) rather than rationalised after, and is not a defect in this delivery. #258's Gate 2 hit it independently; it is filed as one issue from that session. Not worked around by writing ruff-invoking tests — those are ruled out — nor by softening the task file, since the nine obligations are faithful to what #239 asks for.

Gate 1 and Gate 2 logs are committed under `dogfood-logs/261-gate1-run{1,2}/` and `dogfood-logs/261-gate2-run1/`, each with its input, output and judgement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
