### PR TITLE
Carry an obligation forward when its requirement did not change, and record every derivation in a decompose ledger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,14 @@ htmlcov/
 # the checker reads and is committed. Judge anything new here on its own merits.
 .acceptance/cache/
 .acceptance/reviews/
+# The decompose ledger (#269), judged on its own merits as the comment above
+# asks. It is per-run local state, like the transcript cache: one file per run,
+# holding the obligations that run derived, so committing it would add a file
+# per decomposition and put one worktree's run history in another's way. It
+# lives OUTSIDE `.acceptance/cache/` all the same, so that clearing the cache
+# does not take it — DR-259 lost two runs that way. Losing it costs re-derivation
+# and nothing else: carry-forward defaults to fresh.
+.acceptance/ledger/
 *.local
 
 # OS / editor

--- a/current-task.md
+++ b/current-task.md
@@ -1,36 +1,101 @@
 # Task
-No test's outcome or case list depends on the task file at the repository root,
-which is a scratch input rewritten for every task.
+Make decomposition incremental over recorded state. A requirement whose text did
+not change keeps the obligations already derived from it, and costs no model
+call. A requirement that was edited is re-derived from what it was and what it
+became; one that is new is derived fresh; one that disappeared has its
+obligations dropped.
+
+Each run identifies itself and records what it derived, so that a later run can
+name it as the run it continues.
 
 ## Constraints
-- No test reads the task file at the repository root.
-- The task-file parse test takes its inputs from the committed task files under
-  `dogfood-logs/`.
-- The parse test runs one case per committed task file.
-- The parse test asserts, for each case, that the parsed behavior, constraints
-  and completion expectations are each non-empty.
-- The parse test asserts, for each case, that every parsed span reproduces its
-  own text from the source it was parsed from.
-- The region-coverage case list is built only from the committed task files
-  under `dogfood-logs/`.
-- The region-coverage case list is non-empty.
-- The region-coverage case list omits a path that is not present in the tree.
-- A test run reports no failures when no task file is present at the repository
-  root.
-- The parse test's documentation states which inputs it covers.
+- A requirement whose text is unchanged from the continued run causes no model
+  call during decomposition.
+- The obligations of an unchanged requirement are carried forward with their
+  identifiers unchanged.
+- The obligations of an unchanged requirement are carried forward with their
+  descriptions unchanged.
+- An edited requirement is re-derived in one model call carrying the previous
+  text, the new text, and the obligations previously derived from that
+  requirement.
+- An obligation that persists across an edit to its requirement keeps the
+  identifier it already had.
+- A requirement present in the continued run and absent from the task file under
+  review has its obligations dropped.
+- The removal of such a requirement is reported.
+- A requirement with no counterpart in the continued run is derived without
+  reference to any previously derived obligation.
+- Two requirements are the same requirement when their text matches exactly.
+- Requirements left unmatched by exact text are matched to each other through
+  `benchmark/alignment.py::align_obligations`, which distinguishes an edited
+  requirement from a new one.
+- A merge decision over two obligations that are both unchanged is carried
+  forward without a model call.
+- A merge decision over two obligations of which either changed is asked again.
+- Carry-forward reads only the run named as the continued run.
+- No obligation is carried forward when no continued run is named.
+- A carried obligation's `source_quote` is an exact substring of its
+  requirement's text in the task file under review.
+- An obligation whose `source_quote` is not such a substring is re-derived rather
+  than carried.
+- An entry is carried only when re-deriving it would issue the same request key
+  it was recorded under.
+- Decomposition carries a stage-logic version identifying behaviour that changes
+  its output without changing its request.
+- An entry recorded under a different stage-logic version is not carried.
+- Every run reports an identifier for itself.
+- A run that continues a previous run records that run's identifier as its
+  parent.
+- A run identifier appears in no review state.
+- A run identifier appears in no rendered report.
+- Each run records its derivations in a ledger file of its own.
+- A ledger file is appended to and never rewritten.
+- No ledger file is written under `.acceptance/cache/`.
+- A run's ledger records which requirements were carried, which were derived and
+  which were revised.
+- A run's ledger records the request key of each derivation it performed.
+- A run's ledger records the stage-logic version it ran under.
+- A run's ledger records how many model calls it issued.
+- `review_state.py::RequirementDisposition` records whether its requirement was
+  derived, carried or revised.
+- A carried requirement's disposition records the content digest of the
+  derivation it was carried from.
+- A revised requirement's disposition records why it was revised.
+- Each field added to `RequirementDisposition` has a default that preserves the
+  meaning of dispositions written before this change.
+- Review state records no wall-clock time.
 
 ## Scope exclusions
-- Whether the task file at the repository root is tracked by version control.
-- How a task file is parsed into sections.
-- How region coverage is computed.
-- Which sections a task file is required to contain.
-- The content of the committed task files.
+- Inferring that a task file continues a previous run without being told which
+  run it continues.
+- Any form of naming the continued run other than by its identifier.
+- Prior-review selection for stages other than decomposition, which
+  `rerun.py::find_prior_review` performs over git ancestry.
+- Counting how many runs a decomposition took to settle.
+- Deriving a requirement more than once within a single run.
+- What the decomposer derives from a requirement it does derive fresh.
+- The wording the decomposer chooses for an obligation it derives fresh.
 
 ## Completion expectations
 - Implementation
-- A test asserts that parsing succeeds for every committed task file under
-  `dogfood-logs/`.
-- A test asserts that the region-coverage case list is non-empty.
-- A test asserts that no path in the region-coverage case list lies outside
-  `dogfood-logs/`.
-- A check asserts that no test reads the task file at the repository root.
+- A run over an unchanged task file naming a continued run issues no decompose
+  model call.
+- A run over an unchanged task file naming a continued run produces byte-identical
+  obligations, identifiers and descriptions.
+- A decomposition run against ledger state recording a different task file
+  produces the same obligations as one run against no ledger state at all.
+- Editing one requirement re-derives that requirement and leaves the obligations
+  of every other requirement unchanged.
+- A tool change that leaves the decompose request unaltered carries every
+  previously derived obligation.
+- A change to the decompose prompt prevents carrying the obligations derived
+  under the previous prompt.
+- A change to the decompose response schema prevents carrying the obligations
+  derived under the previous schema.
+- A change to the model or the seed prevents carrying the obligations derived
+  under the previous one.
+- The decomposition movements recorded as correct in
+  `tests/fixtures/decompose-stability/` are still produced when the task file
+  genuinely changes.
+- `tests/test_cli.py::test_two_runs_over_the_same_input_are_byte_identical`
+  passes, over a task file and continued-run state that are both unchanged.

--- a/docs/DR-269-carry-key-excludes-registry-context.md
+++ b/docs/DR-269-carry-key-excludes-registry-context.md
@@ -1,0 +1,120 @@
+# DR-269 — a carried entry's validity key excludes the rest of the registry
+
+**Issue:** #269 · **Status:** accepted · **Date:** 2026-08-19
+
+## The rule as written, and why it cannot be implemented literally
+
+#269's mandate says:
+
+> An entry is carried only when re-deriving it would issue the same request key
+> it was recorded under.
+
+Taken at face value that is unimplementable in a useful form, and the reason is
+#178. The decompose prompt carries **the whole registry** on every call — every
+requirement's text, with the batch's ids marked `ANSWER FOR THIS` and the rest
+marked `context only`. That is deliberate: a call shown only its own bullets
+cannot notice that a later section settles a term an earlier one leaves open, and
+#178 is the record of that failure.
+
+So the real request key for any one requirement moves whenever **any other**
+requirement is edited. Under the literal reading, a carried entry is valid only
+when nothing in the task file changed at all — which is the one case where
+carrying forward buys nothing, since an unchanged file replays from its
+transcript for free anyway. Per-requirement carry-forward would be dead code, and
+the mandate's own `constraint-04` — an edited requirement is re-derived while
+others are carried — could never occur, because the edit that triggers it is the
+same edit that invalidates every other entry.
+
+The mandate contains both rules and they contradict each other. This records
+which one wins.
+
+## Decision
+
+The **carry key** hashes only:
+
+- the decompose system prompt,
+- the unconstrained `_Decomposition` response schema,
+- model, temperature, seed,
+- the stage-logic version,
+- **that requirement's own text**.
+
+It does **not** hash the rest of the registry, and it does not hash the
+constrained per-batch schema. (The batch constraint is excluded for a second,
+independent reason: it is a function of how the run happened to be partitioned,
+so hashing it would discard work when `--decompose-batch-size` changed, which has
+nothing to do with whether the answer is still right.)
+
+## What this costs, stated plainly
+
+Because the model sees the whole registry, an unchanged requirement **could
+legitimately decompose differently once its neighbours change**. Carrying it
+forward suppresses that. A requirement whose meaning is genuinely altered by an
+edit elsewhere — a later section that redefines a term it uses — will keep
+obligations derived under the old reading, and nothing in the system will notice.
+
+That is not a bug being tolerated; it is the trade the feature exists to make.
+#191 measured what the alternative costs: three runs over one unchanged task
+file, differing only by seed, produced 38 distinct criterion wordings across ~20
+criteria — 8 appearing in all three runs, 23 in exactly one — with identifiers
+re-minted alongside them and **zero obligation content difference**. Nothing was
+being lost to re-derivation except stability, and criterion text is the prompt
+for every later stage, so that churn floors every downstream stability number.
+
+Suppressing a rare, real cross-requirement re-reading is the price of removing a
+constant, measured, spurious re-wording. The judgement is that the trade is
+strongly favourable, and it is reversible: including the registry digest in the
+carry key is a one-line change if the cross-requirement case ever proves to
+matter more than the churn.
+
+## What still invalidates an entry, so the key is not doing all the work
+
+Carrying is gated on four independent checks, and the key is one of them:
+
+1. **Exact text match** of the requirement, against the continued run.
+2. **Carry key equality** — this document's subject.
+3. **Stage-logic version equality** — `DECOMPOSE_STAGE_LOGIC_VERSION`, bumped by
+   hand, covering code changes that alter the output without changing the
+   request. The request key cannot see those; nothing else can either.
+4. **Source spans still present** in the new requirement text
+   (`carry.py::stale_spans`), which is `_locate_quotation`'s rule applied to a
+   carried entry rather than a freshly derived one.
+
+## The consequence for cross-task contamination
+
+Identity is the requirement's exact text, so a ledger recording an unrelated task
+matches nothing and every requirement derives fresh. That is what makes #269's
+acceptance item — *a decomposition run against a ledger recording a different
+task file produces the same obligations as one run against no ledger at all* —
+hold, and note that it holds by **identity**, independently of the lineage
+signal. Two mechanisms, not one.
+
+**The known boundary:** two task files sharing a byte-identical requirement — a
+bare `- Implementation` bullet, say — will carry that one requirement across.
+Text identity cannot distinguish "the same requirement" from "the same words",
+and no threshold is available to help: DR-259's *"0.10 is a clean separator"* was
+withdrawn and #211 exists to settle whether any threshold is defensible. The
+residual risk is one carried obligation over a bullet whose wording is identical
+in both mandates, which is bounded and visible in the ledger. It is recorded here
+rather than fixed because fixing it well needs #211.
+
+## Alternatives rejected
+
+**Hash the whole registry.** The literal reading. Rejected above: it makes the
+feature inert.
+
+**Hash the registry but exclude requirements marked `context only`.** Does not
+help — every requirement is `context only` to every batch but its own, so the
+digest still moves for everyone when one bullet changes.
+
+**Re-derive a carried requirement and compare, keeping the old id if the
+substance matches.** This is what the previous shape effectively did, and it
+costs a model call per requirement — the exact cost #269 exists to remove. It
+also re-introduces the anchoring problem: showing the model its own prior answer
+for approval is not a judgement, it is a rubber stamp.
+
+## Related
+
+#178 (whole registry as context), #191 (the churn measurement), #193 (the defect
+report), #209 (requirement identity across versions), #211 (whether any
+similarity threshold is defensible), DR-204 (derivation performs no linking),
+DR-259 (the withdrawn threshold, and the cache clear that lost two runs).

--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -43,10 +43,16 @@ from acceptance.pipeline import run_review
 from acceptance.recommendation import lookup as lookup_recommendation
 from acceptance.recommendation import render as render_recommendation
 from acceptance.report import render_report
+from acceptance.requirement.ledger import LedgerStore, new_run_id
 from acceptance.requirement.linking import link_duplicate_obligations
-from acceptance.requirement.obligations import Decomposition, Obligation, decompose
+from acceptance.requirement.obligations import (
+    Decomposition,
+    Obligation,
+    build_ledger_entry,
+    decompose,
+)
 from acceptance.requirement.task_file import parse_task_file
-from acceptance.rerun import find_prior_review
+from acceptance.rerun import find_prior_review, task_digest
 from acceptance.review_state import ChangeSet, OpenQuestion, Review
 from acceptance.review_store import ReviewStore
 from acceptance.supplied_ids import UnusableAnswerLog
@@ -120,6 +126,9 @@ def run_check(
     declaration: str | None = None,
     client: ModelClient | None = None,
     since: str | None = None,
+    continue_from: str | None = None,
+    ledger: LedgerStore | None = None,
+    run_id: str | None = None,
 ) -> Review:
     """Walking-skeleton pipeline: ingest → build empty Review → persist.
 
@@ -171,6 +180,12 @@ def run_check(
             store, reviewed_revision, repo_path, task_text, ancestry_ref=anchor
         )
 
+    # A `check` decomposes too, so it mints a run id and records what it derived
+    # on the same terms `decompose` does — otherwise the two entry points would
+    # disagree about what a run is, and only one of them could be continued.
+    run_id = run_id or new_run_id()
+    sink: list = []
+
     review = run_review(
         task_text=task_text,
         change_set=change_set,
@@ -185,8 +200,21 @@ def run_check(
         link_distance_threshold=config.link_distance_threshold,
         task_identifier=task,
         prior=prior,
+        ledger_prior=ledger.read_if_present(continue_from) if ledger is not None else None,
+        ledger_sink=sink,
     )
     store.write(review)
+    if ledger is not None and sink:
+        derived, linked = sink[0]
+        ledger.write(
+            build_ledger_entry(
+                derived,
+                run_id=run_id,
+                parent_run_id=continue_from,
+                task_digest=task_digest(task_text),
+                linked=linked,
+            )
+        )
     return review
 
 
@@ -215,13 +243,28 @@ def remove_legacy_instruction_file(repo: Path) -> Path | None:
     return _LEGACY_INSTRUCTION_PATH
 
 
-def run_decompose(task: str, config: RunConfig) -> tuple[Decomposition, UnusableAnswerLog]:
+def run_decompose(
+    task: str,
+    config: RunConfig,
+    continue_from: str | None = None,
+    ledger: LedgerStore | None = None,
+) -> tuple[Decomposition, UnusableAnswerLog, str]:
     """Parse a task file and decompose it into obligations + open questions.
 
     Uses a live model call (in RECORD mode) — the dogfooding path for M1.2/M1.3.
+
+    Returns this run's identifier alongside the result. Every run mints one and
+    records what it derived, so a later run can name it with `--continue` and keep
+    the obligations of every requirement it did not change (#269). `continue_from`
+    naming an unknown run is not an error: carry-forward defaults to fresh, and
+    the failure mode of that default is lost work rather than imported work.
     """
-    parsed = parse_task_file(_read_task(task))
+    text = _read_task(task)
+    parsed = parse_task_file(text)
     client = config.build_client()
+    store = ledger if ledger is not None else LedgerStore()
+    prior = store.read_if_present(continue_from)
+    run_id = new_run_id()
     # The log is created HERE and rendered below. Linking can reject a whole
     # group of obligations as self-contradictory, and that rejection is the
     # difference between "nothing looked like a duplicate" and "the answers
@@ -229,7 +272,12 @@ def run_decompose(task: str, config: RunConfig) -> tuple[Decomposition, Unusable
     # would make a decompose silently report the former while the latter
     # happened — the exact silence this project exists to remove.
     unusable = UnusableAnswerLog()
-    derived = decompose(parsed, client, batch_size=config.decompose_batch_size)
+    derived = decompose(
+        parsed,
+        client,
+        batch_size=config.decompose_batch_size,
+        prior=prior,
+    )
     # De-duplication runs here too, not only in `check` (#144). Obligation
     # determination is two stages, and `decompose` reports the OUTPUT of that
     # determination — a decompose that skipped linking would show a different
@@ -241,8 +289,51 @@ def run_decompose(task: str, config: RunConfig) -> tuple[Decomposition, Unusable
         unusable,
         pair_batch_size=config.link_pair_batch_size,
         distance_threshold=config.link_distance_threshold,
+        prior=prior,
     )
-    return linked, unusable
+    # Written from the DERIVED decomposition, not the linked one. What a later
+    # run carries forward is what this stage derived per requirement; linking is
+    # a separate decision over that set, and laundering a post-merge obligation
+    # back into the ledger would let one run's merge become the next run's
+    # premise (DR-204: derivation performs no linking).
+    store.write(
+        build_ledger_entry(
+            derived,
+            run_id=run_id,
+            parent_run_id=continue_from,
+            task_digest=task_digest(text),
+            linked=linked,
+        )
+    )
+    return linked, unusable, run_id
+
+
+def _report_run(run_id: str, continued_from: str | None, result: Decomposition) -> None:
+    """What this run was, on stderr — its id, what it carried, what disappeared.
+
+    The removals are the part that must not be silent. A requirement that vanished
+    between two task files took its obligations with it, and a review that simply
+    stops mentioning them is indistinguishable from one where they were never
+    written.
+    """
+    carried = sum(1 for entry in result.derivations if entry.derivation.value == "carried")
+    revised = sum(1 for entry in result.derivations if entry.derivation.value == "revised")
+    derived = sum(1 for entry in result.derivations if entry.derivation.value == "derived")
+    print(f"run {run_id}", file=sys.stderr)
+    if continued_from:
+        print(f"  continuing {continued_from}", file=sys.stderr)
+    print(
+        f"  requirements: {derived} derived, {carried} carried, {revised} revised; "
+        f"{result.calls_issued} decompose call(s)",
+        file=sys.stderr,
+    )
+    for removal in result.removed_requirements:
+        print(
+            f"  REMOVED {removal.requirement_id}: {removal.text.strip()} "
+            f"({len(removal.obligations)} obligation(s) dropped)",
+            file=sys.stderr,
+        )
+    print(f"  continue this run with: --continue {run_id}", file=sys.stderr)
 
 
 _WIDTH = 88
@@ -690,6 +781,17 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Path to an optional §7.4 builder declaration (absence is a minor finding).",
     )
+    # Distinct from `--since`, and the two answer different questions. `--since`
+    # names a stored REVIEW to build judgements on, selected over git ancestry.
+    # `--continue` names a decompose RUN to carry the obligation set from. A
+    # review can want either, both, or neither.
+    check.add_argument(
+        "--continue",
+        dest="continue_from",
+        default=None,
+        metavar="RUN_ID",
+        help="Run id to continue: carry forward each requirement whose text is unchanged.",
+    )
     _add_model_flags(check, default_mode=Mode.REPLAY.value)  # never call live unbidden
     rec = subparsers.add_parser(
         "recommendation",
@@ -723,6 +825,18 @@ def build_parser() -> argparse.ArgumentParser:
         "--json",
         action="store_true",
         help="Emit the structured Decomposition as JSON.",
+    )
+    # Naming the prior run is the ONLY way to continue one. There is deliberately
+    # no bare `--continue` meaning "the last run here": that is implicit lineage
+    # detection, and the default has to be fresh, because the failure mode of
+    # defaulting to fresh is lost work while the failure mode of guessing is a
+    # decomposition silently built on another task's obligations.
+    dec.add_argument(
+        "--continue",
+        dest="continue_from",
+        default=None,
+        metavar="RUN_ID",
+        help="Run id to continue: carry forward each requirement whose text is unchanged.",
     )
 
     diff = subparsers.add_parser(
@@ -780,6 +894,7 @@ def main(argv: list[str] | None = None) -> int:
             link_distance_threshold=args.link_distance_threshold,
         )
         try:
+            run_id = new_run_id()
             review = run_check(
                 args.task,
                 args.base,
@@ -788,6 +903,9 @@ def main(argv: list[str] | None = None) -> int:
                 ReviewStore(),
                 declaration=args.declaration,
                 since=args.since,
+                continue_from=args.continue_from,
+                ledger=LedgerStore(),
+                run_id=run_id,
             )
         except CliError as exc:
             print(f"acceptance: error: {exc}", file=sys.stderr)
@@ -812,6 +930,13 @@ def main(argv: list[str] | None = None) -> int:
             print(json.dumps(review.to_dict(), indent=2))
         else:
             print(render_report(review))
+        # stderr in both modes, for the same reason the removal notice above is:
+        # the run id must not appear on stdout, where it would make two reviews
+        # over the same input differ in their bytes.
+        print(f"run {run_id}", file=sys.stderr)
+        if args.continue_from:
+            print(f"  continuing {args.continue_from}", file=sys.stderr)
+        print(f"  continue this run with: --continue {run_id}", file=sys.stderr)
         return 0
 
     if args.command == "recommendation":
@@ -839,7 +964,7 @@ def main(argv: list[str] | None = None) -> int:
             link_distance_threshold=args.link_distance_threshold,
         )
         try:
-            result, unusable = run_decompose(args.task, config)
+            result, unusable, run_id = run_decompose(args.task, config, args.continue_from)
         except CliError as exc:
             print(f"acceptance: error: {exc}", file=sys.stderr)
             return 1
@@ -853,6 +978,13 @@ def main(argv: list[str] | None = None) -> int:
             for answer in unusable.answers:
                 print(f"\nUnreconciled linking answers: {answer.reason}")
                 print(f"  affected: {answer.returned_id}")
+        # The run id and what it carried go to STDERR, never stdout. Two runs
+        # over the same input must produce byte-identical output, and a run id is
+        # minted randomly — putting it on stdout would break that for every
+        # consumer that captures the report, which is how the dogfood logs are
+        # made. stderr is where the CLI already puts everything that is about the
+        # run rather than about the review.
+        _report_run(run_id, args.continue_from, result)
         return 0
 
     if args.command == "diff":

--- a/src/acceptance/pipeline.py
+++ b/src/acceptance/pipeline.py
@@ -49,6 +49,7 @@ from acceptance.evidence.strength import apply_evidence_strength, classify_stren
 from acceptance.evidence_tier import Component, EvidenceTier
 from acceptance.llm import ModelClient
 from acceptance.requirement.declaration import declaration_absent_finding, parse_declaration
+from acceptance.requirement.ledger import LedgerEntry
 from acceptance.requirement.linking import link_duplicate_obligations
 from acceptance.requirement.obligations import decompose
 from acceptance.requirement.task_file import parse_task_file
@@ -237,6 +238,8 @@ def run_review(
     link_distance_threshold: float | None = DEFAULT_LINK_DISTANCE_THRESHOLD,
     task_identifier: str = "<inline>",
     prior: Review | None = None,
+    ledger_prior: LedgerEntry | None = None,
+    ledger_sink: list | None = None,
 ) -> Review:
     """Run the full static review pipeline and return the assembled Review.
 
@@ -254,7 +257,17 @@ def run_review(
     unusable = UnusableAnswerLog()
 
     parsed = parse_task_file(task_text)
-    derived = decompose(parsed, client, unusable, batch_size=decompose_batch_size)
+    # `ledger_prior` is a DIFFERENT kind of prior from `prior` above, and the two
+    # are deliberately not merged. `prior` is a stored Review, selected by git
+    # ancestry, and it carries JUDGEMENTS forward — the ratings over an obligation
+    # set. `ledger_prior` is a decompose ledger entry, named explicitly by the
+    # operator, and it carries the OBLIGATION SET itself. #269 exists because the
+    # second was missing: a changed task invalidated the whole decomposition, so
+    # judgements were being carried over a set that had been re-derived and
+    # re-identified underneath them.
+    derived = decompose(
+        parsed, client, unusable, batch_size=decompose_batch_size, prior=ledger_prior
+    )
     # Obligation determination is two stages (#144). Derivation accounts for each
     # requirement alone and cannot link (#204), so a requirement stated twice
     # yields two obligations; linking resolves them into one obligation named by
@@ -262,8 +275,13 @@ def run_review(
     # provenance so a movement in the final set can be attributed to the stage
     # that caused it.
     decomposition = link_duplicate_obligations(
-        derived, client, unusable, link_pair_batch_size, link_distance_threshold
+        derived, client, unusable, link_pair_batch_size, link_distance_threshold, ledger_prior
     )
+    # Handed back rather than written here: the pipeline does not own the run id,
+    # the parent pointer or the file, and a stage that wrote to disk on the way
+    # past would make the benchmark's own runs leave ledger entries behind.
+    if ledger_sink is not None:
+        ledger_sink.append((derived, decomposition))
 
     # Open-question resolution runs HERE, ahead of every judging stage, because
     # a question the diff resolves yields an obligation (#214) and that

--- a/src/acceptance/requirement/carry.py
+++ b/src/acceptance/requirement/carry.py
@@ -1,0 +1,222 @@
+"""Deciding, per requirement, what a run may take from the run it continues (#269).
+
+Four outcomes, and the whole feature is the difference between them:
+
+| the requirement | what happens |
+|---|---|
+| text unchanged | **carried** — no model call, obligations verbatim |
+| text edited | **revised** — one call carrying old text, new text and prior obligations |
+| no counterpart | **derived** — fresh, with nothing to anchor on |
+| gone | **removed** — obligations dropped, and the removal reported |
+
+**Identity is content, not position.** Requirement ids are `section-ordinal`
+(`registry.py`), so inserting one bullet renames every later requirement in its
+section while changing none of them. Matching on id would report a whole section
+as edited every time a bullet is inserted above it. Matching on text is exact,
+free, and needs no model call — which is what makes the unchanged case cost
+nothing.
+
+**The residue needs a judgement, and only the residue.** After exact matching,
+what is left is requirements that changed and requirements that are new, and
+telling those apart is #209's problem. That is the one place a model call is
+issued, over two short lists, and only when both sides are non-empty. No
+similarity threshold is involved: DR-259's *"0.10 is a clean separator"* was
+withdrawn, and #211 exists to settle it.
+
+**Anchoring bias is defeated by not asking.** The model is never shown its own
+prior answer for approval. Either the input did not change and there is no call
+at all, or it changed and there is a real diff to justify against. A stale
+carry-over is caught in code rather than by trusting the model to notice it:
+every carried obligation's source span must still be found in the new
+requirement text (`stale_spans`).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from acceptance.llm import ModelClient
+from acceptance.review_state import RequirementRef
+
+from .ledger import (
+    DECOMPOSE_STAGE_LOGIC_VERSION,
+    Derivation,
+    LedgerEntry,
+    RequirementDerivation,
+)
+
+
+@dataclass(frozen=True)
+class CarryPlan:
+    """What each requirement in the current registry is owed.
+
+    `carried` and `revised` are keyed by the *current* requirement id and hold the
+    prior derivation they draw on. `derived` is the set of ids with nothing to
+    draw on. `removed` are prior derivations whose requirement is gone.
+    """
+
+    carried: dict[str, RequirementDerivation] = field(default_factory=dict)
+    revised: dict[str, RequirementDerivation] = field(default_factory=dict)
+    derived: tuple[str, ...] = ()
+    removed: tuple[RequirementDerivation, ...] = ()
+    # The key each current requirement's derivation is valid under, carried on
+    # the plan so the ledger records what this run would re-derive against rather
+    # than recomputing it and risking a different answer.
+    keys: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def issues_calls_for(self) -> set[str]:
+        """Requirement ids this run must ask the model about."""
+        return set(self.derived) | set(self.revised)
+
+    def is_fresh(self) -> bool:
+        """True when nothing was taken from a prior run — today's behaviour."""
+        return not self.carried and not self.revised
+
+
+def stale_spans(derivation: RequirementDerivation, requirement_text: str) -> bool:
+    """True when some carried obligation quotes text the requirement no longer has.
+
+    `_locate_quotation` already enforces that an obligation's quotation lands
+    inside a requirement's span when it is first derived. The same rule is what
+    catches an obligation carried over from an older wording: if its span text is
+    no longer present, the obligation is describing text that is gone, and it is
+    re-derived rather than carried.
+
+    Whitespace-insensitive for the same reason `_locate_quotation` is — task prose
+    is hard-wrapped, so a reflowed paragraph is not a changed one.
+    """
+    haystack = " ".join(requirement_text.split())
+    for obligation in derivation.obligations:
+        for span in obligation.source_spans:
+            needle = " ".join(span.text.split())
+            if needle and needle not in haystack:
+                return True
+    return False
+
+
+def plan_carry(
+    registry: list[RequirementRef],
+    prior: LedgerEntry | None,
+    current_keys: dict[str, str],
+    client: ModelClient | None = None,
+) -> CarryPlan:
+    """Decide what each requirement in `registry` may take from `prior`.
+
+    `current_keys` maps requirement id to the carry key this run would record for
+    it — computed by the caller, which is the only place that knows the prompt and
+    the response schema.
+
+    With no prior, everything is derived and nothing is removed: that is today's
+    behaviour exactly, and it is what "no signal means no carry-forward" reduces
+    to in code.
+    """
+    if prior is None:
+        return CarryPlan(
+            derived=tuple(requirement.id for requirement in registry),
+            keys=dict(current_keys),
+        )
+
+    # An entry recorded under different stage logic is not carried. The request
+    # key cannot see a change to what we do with an unchanged response, so this
+    # is the only thing that can (`ledger.DECOMPOSE_STAGE_LOGIC_VERSION`).
+    # Removals are still reported: whether a requirement disappeared is a fact
+    # about the two task files, not about the tool that read them.
+    usable = prior.stage_logic_version == DECOMPOSE_STAGE_LOGIC_VERSION
+
+    prior_by_text = prior.by_text()
+    carried: dict[str, RequirementDerivation] = {}
+    revised: dict[str, RequirementDerivation] = {}
+    derived: list[str] = []
+    matched_prior: set[str] = set()
+
+    unmatched: list[RequirementRef] = []
+    for requirement in registry:
+        candidate = prior_by_text.get(requirement.text)
+        if candidate is None:
+            unmatched.append(requirement)
+            continue
+
+        matched_prior.add(candidate.text)
+        # Text is identical, so the only question left is whether re-deriving it
+        # today would issue the same request. If it would not, the entry is not
+        # carried — but it is also not *revised*, because nothing about the
+        # requirement changed. It is derived fresh, like any other requirement
+        # the tool has no valid answer for.
+        # Three independent reasons the answer on file cannot stand, named
+        # separately because they fail for different causes: the tool moved under
+        # it, the request that produced it would not be reissued, or it quotes
+        # text the requirement no longer has.
+        stale = (
+            not usable
+            or candidate.carry_key != current_keys.get(requirement.id)
+            or stale_spans(candidate, requirement.text)
+        )
+        if stale:
+            derived.append(requirement.id)
+        else:
+            carried[requirement.id] = candidate
+
+    # What is left on each side is the residue: requirements whose text moved, and
+    # requirements that are new. Only a judgement can tell those apart.
+    residue_prior = [
+        derivation for derivation in prior.derivations if derivation.text not in matched_prior
+    ]
+    if unmatched and residue_prior and usable and client is not None:
+        from acceptance.benchmark.alignment import align_obligations
+
+        # ground truth = the prior wordings, reviewer = this run's. The returned
+        # map is `current text -> prior text`, and it is bijective, so an inserted
+        # requirement is left unmatched and correctly derived fresh.
+        alignment = align_obligations(
+            [derivation.text for derivation in residue_prior],
+            [requirement.text for requirement in unmatched],
+            client,
+        )
+        prior_by_residue_text = {derivation.text: derivation for derivation in residue_prior}
+        for requirement in unmatched:
+            prior_text = alignment.get(requirement.text)
+            candidate = prior_by_residue_text.get(prior_text) if prior_text else None
+            if candidate is None:
+                derived.append(requirement.id)
+            else:
+                revised[requirement.id] = candidate
+                matched_prior.add(candidate.text)
+    else:
+        derived.extend(requirement.id for requirement in unmatched)
+
+    removed = tuple(
+        derivation for derivation in prior.derivations if derivation.text not in matched_prior
+    )
+    # Registry order, so two runs over the same input plan identically.
+    order = {requirement.id: index for index, requirement in enumerate(registry)}
+    return CarryPlan(
+        carried=carried,
+        revised=revised,
+        derived=tuple(sorted(set(derived), key=lambda id_: order.get(id_, 0))),
+        removed=removed,
+        keys=dict(current_keys),
+    )
+
+
+def describe_removals(plan: CarryPlan) -> list[str]:
+    """One line per dropped requirement, for the run's own report.
+
+    A removal that is not reported is indistinguishable from a requirement that
+    was never there, which is the whole reason this is not simply dropped on the
+    floor.
+    """
+    return [
+        f"{derivation.requirement_id}: {derivation.text.strip()} "
+        f"({len(derivation.obligations)} obligation(s) dropped)"
+        for derivation in plan.removed
+    ]
+
+
+def derivation_kind(plan: CarryPlan, requirement_id: str) -> Derivation:
+    """How `requirement_id` was settled in this run."""
+    if requirement_id in plan.carried:
+        return Derivation.CARRIED
+    if requirement_id in plan.revised:
+        return Derivation.REVISED
+    return Derivation.DERIVED

--- a/src/acceptance/requirement/ledger.py
+++ b/src/acceptance/requirement/ledger.py
@@ -1,0 +1,301 @@
+"""The decompose ledger: what each run derived, and what it carried (#269).
+
+Decomposition used to be re-derived from scratch on every run. `rerun.py` states
+the rule it worked under — *"A changed task invalidates everything. Obligations
+are a function of the task text, so if that changed, nothing carries forward"* —
+so one edited character discarded a whole prior decomposition and asked the model
+for all of it again. #191 measured the cost: three runs over one unchanged task
+file differing only by seed produced 38 distinct criterion wordings across ~20
+criteria, with identifiers re-minted alongside them, and zero content difference.
+The criterion text is the prompt for every later stage, so that churn is a floor
+under every downstream stability number.
+
+This module holds the record that makes carrying forward possible.
+
+**Why a ledger and not the review store.** `ReviewStore` writes one file per
+reviewed revision and overwrites it in place, and an uncommitted run stores under
+the literal `<working-tree>` — so the Gate 1 loop, which is exactly where this
+feature earns its keep, keeps no history at all. `decompose` also never
+constructs a `Review`, so there is no review to read on that path. The ledger is
+therefore both the log and the carry-forward store: it holds the derivations
+themselves, not pointers to them.
+
+**Append-only, one file per run.** Three worktrees run concurrently in this
+repository, and a single shared file would have three writers. It lives outside
+`.acceptance/cache/` so that clearing the cache cannot take it — DR-259 lost two
+runs that way.
+
+**No wall-clock reaches review state.** `Review` deliberately carries no
+timestamp: it would break the byte-identical guarantee (M0.5), which is why
+ordering came from git ancestry instead. Ordering lives here, where byte
+stability is not claimed, and is never read back as an input to a review.
+
+**Identity is a parent pointer, not a shared lineage id.** Each run mints its own
+`run_id` and records the run it continues as `parent_run_id`. A lineage is the
+transitive closure of those pointers, derived rather than stored. The alternative
+— one id shared by every run in a lineage — needs "the latest run in the lineage"
+to select a prior, which needs ordering, which needs wall-clock or a sequence
+number. A parent pointer never reads time at all.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from enum import Enum
+from pathlib import Path
+
+from pydantic import Field
+
+from acceptance.model_base import PersistableModel
+from acceptance.review_state import Disposition, Obligation, OpenQuestion
+from acceptance.serialization import canonical_json
+
+DEFAULT_LEDGER_ROOT = Path(".acceptance/ledger")
+
+# Decompose behaviour that changes the output without changing the request.
+#
+# The request key already invalidates a carried entry when the prompt, the
+# response schema, the model or the seed moves — that is what makes a minor tool
+# update lose no work. It cannot see a code change that alters what we do with an
+# unchanged response: post-processing a quotation differently, marking
+# `satisfied_by_absence` from a different signal, changing how ids are uniqued.
+# Bump this by hand when that happens. It is deliberately an integer and not a
+# hash of the module: a hash would invalidate on every comment edit, which is the
+# failure mode that trains people to clear the ledger instead of reading it.
+DECOMPOSE_STAGE_LOGIC_VERSION = 1
+
+
+class Derivation(str, Enum):
+    """How a requirement's obligations came to be, for this run."""
+
+    DERIVED = "derived"
+    """Asked of the model in this run — a new requirement, or a re-derivation."""
+
+    CARRIED = "carried"
+    """Taken verbatim from the continued run; no model call was issued."""
+
+    REVISED = "revised"
+    """The requirement's text changed, so it was re-asked against its old text."""
+
+
+class RequirementDerivation(PersistableModel):
+    """One requirement's outcome in one run.
+
+    `text` is the requirement's exact text, and it is the identity used to decide
+    whether a later run may carry this entry. Not the requirement id: ids are
+    positional (`section-ordinal`), so inserting one bullet renames every later
+    requirement in its section while changing none of them.
+    """
+
+    requirement_id: str
+    text: str
+    carry_key: str
+    derivation: Derivation
+    disposition: Disposition
+    reason: str | None = None
+    carried_from: str | None = None
+    revision_reason: str | None = Field(
+        default=None,
+        description=(
+            "Why this requirement was re-asked: the old wording it had in the run "
+            "this one continues. A requirement revision, never a git revision."
+        ),
+    )
+    obligations: list[Obligation] = Field(default_factory=list)
+    open_questions: list[OpenQuestion] = Field(default_factory=list)
+
+    def digest(self) -> str:
+        """Content digest of this derivation, for `carried_from`.
+
+        What a later run records when it carries this entry forward. A run id
+        would be the obvious thing to record and is the wrong one: it is minted
+        randomly, so putting it in review state would make two runs over the same
+        input differ in their bytes. This digest is a function of the derivation's
+        content alone, so it is stable, and it is the more useful value anyway —
+        it identifies *what* was carried rather than which run happened to hold it.
+        """
+        payload = {
+            "carry_key": self.carry_key,
+            "text": self.text,
+            "disposition": self.disposition.value,
+            "obligations": [obligation.to_dict() for obligation in self.obligations],
+            "open_questions": [question.to_dict() for question in self.open_questions],
+        }
+        return hashlib.sha256(canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def obligation_fingerprint(obligation: Obligation) -> str:
+    """What makes an obligation the same obligation, for a merge decision.
+
+    The triple `rerun.py::_linking_inputs` already compares — id, description,
+    observable behaviour — because those are exactly the fields the linking prompt
+    shows the model. Two obligations with the same triple were shown identically,
+    so the answer that came back is still the answer to this question. A field the
+    prompt never renders cannot change the verdict and is deliberately not here.
+    """
+    payload = {
+        "id": obligation.id,
+        "description": obligation.description,
+        "observable_behavior": obligation.observable_behavior,
+    }
+    return hashlib.sha256(canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+class MergeDecision(PersistableModel):
+    """One answered "are these the same requirement?" pair.
+
+    Keyed by the two obligations' fingerprints rather than their ids, and stored
+    sorted, so the decision is about the two obligations rather than about the
+    order they happened to be enumerated in. Pair ids cannot be used: they are
+    positional (`pair-0007`), assigned before filtering, so carrying one
+    obligation forward renumbers every pair after it.
+    """
+
+    left: str
+    right: str
+    same_requirement: bool
+
+    @classmethod
+    def between(cls, left: Obligation, right: Obligation, same_requirement: bool) -> MergeDecision:
+        pair = sorted((obligation_fingerprint(left), obligation_fingerprint(right)))
+        return cls(left=pair[0], right=pair[1], same_requirement=same_requirement)
+
+    @property
+    def key(self) -> tuple[str, str]:
+        return (self.left, self.right)
+
+
+class LedgerEntry(PersistableModel):
+    """One run's record. Written once, never rewritten."""
+
+    run_id: str
+    parent_run_id: str | None = None
+    stage_logic_version: int = DECOMPOSE_STAGE_LOGIC_VERSION
+    task_digest: str = ""
+    calls_issued: int = 0
+    derivations: list[RequirementDerivation] = Field(default_factory=list)
+    merge_decisions: list[MergeDecision] = Field(default_factory=list)
+
+    def decisions_by_pair(self) -> dict[tuple[str, str], bool]:
+        """Every merge decision this run holds, keyed by fingerprint pair."""
+        return {decision.key: decision.same_requirement for decision in self.merge_decisions}
+
+    def by_text(self) -> dict[str, RequirementDerivation]:
+        """This run's derivations keyed by requirement text — the join a later
+        run makes to decide what it may carry.
+
+        Later entries win on a duplicate text, which cannot arise from
+        `build_registry` (two identical bullets would be two requirements with the
+        same text and the same obligations, so either answer is the same answer).
+        """
+        return {derivation.text: derivation for derivation in self.derivations}
+
+    def carried_count(self) -> int:
+        return sum(1 for entry in self.derivations if entry.derivation is Derivation.CARRIED)
+
+    def derived_count(self) -> int:
+        return sum(1 for entry in self.derivations if entry.derivation is Derivation.DERIVED)
+
+    def revised_count(self) -> int:
+        return sum(1 for entry in self.derivations if entry.derivation is Derivation.REVISED)
+
+
+def new_run_id() -> str:
+    """A fresh run identifier.
+
+    Random, not derived from content: two runs over identical input are two runs,
+    and the ledger has to be able to tell them apart to stay append-only. This is
+    also exactly why a run id must never reach `Review` — see `LedgerEntry`.
+    """
+    return secrets.token_hex(8)
+
+
+def carry_key(
+    *,
+    system_prompt: str,
+    response_schema: dict,
+    model: str,
+    temperature: float,
+    seed: int | None,
+    stage_logic_version: int,
+    requirement_text: str,
+) -> str:
+    """The key a carried entry is valid under.
+
+    A carried entry stays valid exactly while re-deriving it today would issue the
+    same request — so this hashes the determinism controls that `llm.py` puts in a
+    request key, plus the stage-logic version the request cannot see.
+
+    **What it deliberately excludes: the rest of the registry.** The decompose
+    prompt carries the whole task file as context on every call (#178), so the
+    real request key for any one requirement moves whenever any *other*
+    requirement is edited. Hashing that here would mean a carried entry is valid
+    only when nothing in the file changed at all, which is the one case where
+    carrying forward buys nothing — per-requirement carry-forward would be dead
+    code, and `constraint-04`'s edited-requirement path could never coexist with a
+    carried one.
+
+    The cost of excluding it is real and worth stating plainly: because the model
+    sees the whole registry, an unchanged requirement *could* legitimately
+    decompose differently once its neighbours change. Carrying it forward
+    suppresses that. That suppression is the stability this feature buys, not an
+    oversight — see `docs/DR-269-carry-key-excludes-registry-context.md`.
+    """
+    payload = {
+        "system_prompt": system_prompt,
+        "response_schema": response_schema,
+        "model": model,
+        "temperature": temperature,
+        "seed": seed,
+        "stage_logic_version": stage_logic_version,
+        "requirement_text": requirement_text,
+    }
+    return hashlib.sha256(canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+class LedgerStore:
+    """Append-only run records under `root`, one file per run."""
+
+    def __init__(self, root: Path | str = DEFAULT_LEDGER_ROOT) -> None:
+        self.root = Path(root)
+
+    def path_for(self, run_id: str) -> Path:
+        return self.root / f"{run_id}.json"
+
+    def write(self, entry: LedgerEntry) -> Path:
+        """Write one run's record.
+
+        Refuses to overwrite. The append-only property is what lets a later
+        feature count how many runs a decomposition took to settle, and it is
+        worth an error rather than a silent clobber — a run id collision means
+        something minted one twice, which is a bug worth hearing about.
+        """
+        path = self.path_for(entry.run_id)
+        if path.exists():
+            raise FileExistsError(f"ledger entry already written for run {entry.run_id}")
+        self.root.mkdir(parents=True, exist_ok=True)
+        path.write_text(canonical_json(entry.to_dict()) + "\n", encoding="utf-8")
+        return path
+
+    def read(self, run_id: str) -> LedgerEntry:
+        path = self.path_for(run_id)
+        if not path.exists():
+            raise FileNotFoundError(f"no ledger entry for run {run_id}")
+        import json
+
+        return LedgerEntry.from_dict(json.loads(path.read_text(encoding="utf-8")))
+
+    def read_if_present(self, run_id: str | None) -> LedgerEntry | None:
+        """The continued run's record, or None.
+
+        None means no carry-forward, which is today's behaviour exactly. The
+        default is fresh and the failure mode of the default is lost work, never
+        imported work — so an unreadable or absent prior is not an error here.
+        """
+        if not run_id:
+            return None
+        try:
+            return self.read(run_id)
+        except (FileNotFoundError, ValueError):
+            return None

--- a/src/acceptance/requirement/linking.py
+++ b/src/acceptance/requirement/linking.py
@@ -61,6 +61,7 @@ from collections.abc import Sequence
 from acceptance.config import DEFAULT_LINK_PAIR_BATCH_SIZE
 from acceptance.llm import ModelClient, StrictResponseModel
 from acceptance.partition import partition
+from acceptance.requirement.ledger import LedgerEntry, MergeDecision
 from acceptance.requirement.obligations import Decomposition
 from acceptance.review_state import (
     Obligation,
@@ -432,6 +433,7 @@ def link_duplicate_obligations(
     unusable_answers: UnusableAnswerLog | None = None,
     pair_batch_size: int = DEFAULT_LINK_PAIR_BATCH_SIZE,
     distance_threshold: float | None = None,
+    prior: LedgerEntry | None = None,
 ) -> Decomposition:
     """Link the obligations that state the same requirement.
 
@@ -477,9 +479,33 @@ def link_duplicate_obligations(
             },
         )
 
-    if not askable:
+    # A merge decision over two obligations that are BOTH unchanged is the same
+    # question it was last time, so it is not asked again (#269). Either side
+    # changing puts the pair back in front of the model: the prompt renders both
+    # obligations, so a decision made about one wording is not a decision about
+    # another. `askable` shrinks to the genuinely open pairs.
+    carried_decisions: dict[tuple[str, str], bool] = {}
+    if prior is not None:
+        on_file = prior.decisions_by_pair()
+        still_askable = []
+        for pair in askable:
+            _, left, right = pair
+            key = MergeDecision.between(by_id[left], by_id[right], False).key
+            if key in on_file:
+                carried_decisions[key] = on_file[key]
+                if on_file[key]:
+                    confirmed.add(frozenset((left, right)))
+            else:
+                still_askable.append(pair)
+        askable = still_askable
+
+    # Nothing left to ask AND nothing carried means nothing to merge — the
+    # original early exit. With carried decisions in hand the tail below still has
+    # to run, because those decisions are what the clusters are built from.
+    if not askable and not carried_decisions:
         return decomposition
 
+    fresh_decisions: list[MergeDecision] = []
     for batch in partition(askable, pair_batch_size, key=lambda pair: pair[0]):
         by_pair_id = {pair_id: (left, right) for pair_id, left, right in batch.items}
         allowed = {"pair_id": list(by_pair_id)}
@@ -497,8 +523,14 @@ def link_duplicate_obligations(
         if unusable_answers is not None:
             unusable_answers.record(scan(result, allowed, _STAGE))
         for verdict in result.verdicts:
-            if verdict.same_requirement and verdict.pair_id in by_pair_id:
-                confirmed.add(frozenset(by_pair_id[verdict.pair_id]))
+            if verdict.pair_id not in by_pair_id:
+                continue
+            left, right = by_pair_id[verdict.pair_id]
+            fresh_decisions.append(
+                MergeDecision.between(by_id[left], by_id[right], verdict.same_requirement)
+            )
+            if verdict.same_requirement:
+                confirmed.add(frozenset((left, right)))
 
     survivor_of, inconsistent = _confirmed_clusters(ordered_ids, confirmed)
     if unusable_answers is not None and inconsistent:
@@ -516,9 +548,19 @@ def link_duplicate_obligations(
             for members in inconsistent
         )
 
+    # Every decision this run stands on, carried and fresh alike, so the next run
+    # inherits the whole set rather than only what this one happened to re-ask.
+    # Sorted, because two runs over the same input must record it identically.
+    decisions = [
+        MergeDecision(left=key[0], right=key[1], same_requirement=value)
+        for key, value in carried_decisions.items()
+    ] + fresh_decisions
+    decisions.sort(key=lambda decision: decision.key)
+
     return decomposition.model_copy(
         update={
             "obligations": _merged_obligations(obligations, survivor_of),
             "requirement_map": _relinked_map(decomposition.requirement_map, survivor_of),
+            "merge_decisions": decisions,
         }
     )

--- a/src/acceptance/requirement/obligations.py
+++ b/src/acceptance/requirement/obligations.py
@@ -992,6 +992,13 @@ def decompose(
         parsed.unclaimed,
         carried_dispositions,
     )
+    # A revised requirement's disposition is built by the ordinary path, because
+    # it WAS asked of the model — so without this it would report itself as
+    # `derived` and carry no reason, which is the same thing a genuinely fresh
+    # requirement reports. The two are different: one had a predecessor and was
+    # re-asked against it, and losing that distinction loses the only record that
+    # an identifier could have been reused and was not.
+    requirement_map = _stamp_revisions(requirement_map, plan)
 
     if not plan.is_fresh():
         # Rebuild both flat lists by walking the map, so a carried obligation
@@ -1011,6 +1018,34 @@ def decompose(
         removed_requirements=list(plan.removed),
         calls_issued=calls_issued,
     )
+
+
+def _revision_reason(source: RequirementDerivation) -> str:
+    """Why a requirement was re-asked: the wording it used to have.
+
+    One definition, used by both the disposition and the ledger record, so the two
+    cannot drift into disagreeing about the same event.
+    """
+    return f"requirement text changed from: {source.text.strip()}"
+
+
+def _stamp_revisions(requirement_map: RequirementMap, plan: CarryPlan) -> RequirementMap:
+    """Mark the dispositions of requirements this run re-asked against a predecessor."""
+    if not plan.revised:
+        return requirement_map
+    stamped = [
+        disposition.model_copy(
+            update={
+                "derivation": Derivation.REVISED.value,
+                "carried_from": plan.revised[disposition.requirement_id].digest(),
+                "revision_reason": _revision_reason(plan.revised[disposition.requirement_id]),
+            }
+        )
+        if disposition.requirement_id in plan.revised
+        else disposition
+        for disposition in requirement_map.dispositions
+    ]
+    return requirement_map.model_copy(update={"dispositions": stamped})
 
 
 def _carried_disposition(
@@ -1096,7 +1131,7 @@ def _derivations(
                 reason=disposition.reason,
                 carried_from=source.digest() if source is not None else None,
                 revision_reason=(
-                    f"requirement text changed from: {source.text.strip()}"
+                    _revision_reason(source)
                     if kind is Derivation.REVISED and source is not None
                     else None
                 ),

--- a/src/acceptance/requirement/obligations.py
+++ b/src/acceptance/requirement/obligations.py
@@ -41,9 +41,23 @@ from typing import Literal
 from pydantic import Field
 
 from acceptance.config import DEFAULT_DECOMPOSE_BATCH_SIZE
-from acceptance.llm import ModelClient, SchemaValidationError, StrictResponseModel
+from acceptance.llm import (
+    ModelClient,
+    SchemaValidationError,
+    StrictResponseModel,
+    inline_schema_refs,
+)
 from acceptance.model_base import PersistableModel
 from acceptance.partition import partition
+from acceptance.requirement.carry import CarryPlan, derivation_kind, plan_carry
+from acceptance.requirement.ledger import (
+    DECOMPOSE_STAGE_LOGIC_VERSION,
+    Derivation,
+    LedgerEntry,
+    MergeDecision,
+    RequirementDerivation,
+    carry_key,
+)
 from acceptance.requirement.registry import build_registry
 from acceptance.requirement.task_file import ParsedTaskFile
 from acceptance.review_state import (
@@ -440,9 +454,28 @@ class Decomposition(PersistableModel):
     obligations: list[Obligation] = Field(default_factory=list)
     open_questions: list[OpenQuestion] = Field(default_factory=list)
     requirement_map: RequirementMap = Field(default_factory=RequirementMap)
+    # What this run settled per requirement, ready for the ledger (#269). Held
+    # here rather than written from inside `decompose` so that the stage stays a
+    # function of its inputs: the caller owns the run id, the parent pointer and
+    # the file, and decomposition owns only what it derived.
+    derivations: list[RequirementDerivation] = Field(default_factory=list)
+    # Requirements the continued run had and this task file does not. Reported
+    # rather than silently dropped — a removal that goes unreported is
+    # indistinguishable from a requirement that was never there.
+    removed_requirements: list[RequirementDerivation] = Field(default_factory=list)
+    calls_issued: int = 0
+    # Every "are these the same requirement?" answer this run stands on, carried
+    # and freshly asked alike. Populated by `link_duplicate_obligations`, which is
+    # a later stage — a bare `decompose` leaves it empty, and that is correct:
+    # derivation performs no linking (DR-204).
+    merge_decisions: list[MergeDecision] = Field(default_factory=list)
 
 
-def _user_prompt(registry: list[RequirementRef], answer_for: set[str]) -> str:
+def _user_prompt(
+    registry: list[RequirementRef],
+    answer_for: set[str],
+    revisions: dict[str, RequirementDerivation] | None = None,
+) -> str:
     """The identified requirements, as typed fields — all of them, every call.
 
     Deliberately NOT `parsed.source`. The pipeline runs `parse_task_file`, which
@@ -486,7 +519,67 @@ def _user_prompt(registry: list[RequirementRef], answer_for: set[str]) -> str:
             ),
         ]
     )
+    lines.extend(_revision_block(revisions or {}, answer_for))
     return "\n".join(lines)
+
+
+def _revision_block(
+    revisions: dict[str, RequirementDerivation],
+    answer_for: set[str],
+) -> list[str]:
+    """What a requirement used to say, and what it yielded, for the ones that changed.
+
+    **Appended only when this call is answering for a revised requirement**, so a
+    run with nothing to carry produces a prompt byte-identical to the one this
+    stage produced before carry-forward existed. That is what makes "a tool change
+    that leaves the decompose request unaltered carries every previously derived
+    obligation" true rather than aspirational: a fresh decomposition hashes to the
+    same request key it always did, and every recorded transcript still replays.
+
+    The model is shown the previous wording and what it produced, and asked to
+    justify the difference against a real diff. It is never shown its own prior
+    answer for bare approval — the input genuinely changed, so there is something
+    to reconcile. Reusing an id is offered, not demanded: an obligation that no
+    longer follows from the new text should not keep its identifier just because
+    one was available.
+    """
+    applicable = {
+        requirement_id: derivation
+        for requirement_id, derivation in sorted(revisions.items())
+        if requirement_id in answer_for
+    }
+    if not applicable:
+        return []
+
+    lines = [
+        "",
+        "PREVIOUSLY DERIVED",
+        "",
+        (
+            "These requirements were worded differently in the run this one "
+            "continues, and each already produced the obligations listed under it. "
+            "Where an obligation below still follows from the NEW wording, reuse its "
+            "id so it keeps its identity across the edit. Where the edit changed what "
+            "is required, derive what the new wording says and let the old id go — do "
+            "not preserve an obligation the new text no longer supports, and do not "
+            "reuse an id for something it did not previously mean."
+        ),
+    ]
+    for requirement_id, derivation in applicable.items():
+        lines.extend(
+            [
+                "",
+                f"[{requirement_id}] previously read:",
+                f"    {derivation.text.strip()}",
+            ]
+        )
+        if derivation.obligations:
+            lines.append("  and produced:")
+            for obligation in derivation.obligations:
+                lines.append(f"    {obligation.id}: {obligation.description}")
+        else:
+            lines.append(f"  and produced no obligation ({derivation.disposition.value}).")
+    return lines
 
 
 def _importance(value: str) -> str:
@@ -667,11 +760,39 @@ def _resolve_attributions(
     return obligations, derived_ids
 
 
+def decompose_carry_keys(client: ModelClient, registry: list[RequirementRef]) -> dict[str, str]:
+    """The key each requirement's derivation would be valid under, this run.
+
+    The response schema here is the UNCONSTRAINED `_Decomposition`, deliberately.
+    The real request constrains `requirement_id` to the batch's ids, so the schema
+    inside a request key depends on how the run happened to be partitioned — and a
+    carry key that moved when the batch size changed would discard work for a
+    reason that has nothing to do with whether the answer is still right.
+    """
+    schema = {
+        "name": _Decomposition.__name__,
+        "schema": inline_schema_refs(_Decomposition.model_json_schema()),
+    }
+    return {
+        requirement.id: carry_key(
+            system_prompt=_SYSTEM_PROMPT,
+            response_schema=schema,
+            model=client.model,
+            temperature=client.temperature,
+            seed=client.seed,
+            stage_logic_version=DECOMPOSE_STAGE_LOGIC_VERSION,
+            requirement_text=requirement.text,
+        )
+        for requirement in registry
+    }
+
+
 def decompose(
     parsed: ParsedTaskFile,
     client: ModelClient,
     unusable_answers: UnusableAnswerLog | None = None,
     batch_size: int = DEFAULT_DECOMPOSE_BATCH_SIZE,
+    prior: LedgerEntry | None = None,
 ) -> Decomposition:
     """Decompose a parsed task into typed obligations, open questions, and the
     mapping from each identified requirement to what it produced.
@@ -719,12 +840,29 @@ def decompose(
     # they still need per-batch resolution: each response mints its own ids.
     question_final: dict[str, dict[str, str]] = {}
 
-    for batch in partition(registry, batch_size, key=lambda requirement: requirement.id):
+    # What this run may take from the run it continues. With no prior it plans
+    # every requirement as `derived`, and everything below runs exactly as it did
+    # before carry-forward existed.
+    plan = plan_carry(registry, prior, decompose_carry_keys(client, registry), client)
+    to_ask = plan.issues_calls_for
+    asking = [requirement for requirement in registry if requirement.id in to_ask]
+    calls_issued = 0
+
+    for batch in partition(asking, batch_size, key=lambda requirement: requirement.id):
         batch_ids = [requirement.id for requirement in batch.items]
         messages = [
             {"role": "system", "content": _SYSTEM_PROMPT},
-            {"role": "user", "content": _user_prompt(registry, set(batch_ids))},
+            {
+                "role": "user",
+                # The registry passed here is the WHOLE one, never `asking`: the
+                # batch scopes what a call answers for, not what it may read
+                # (#178). A call shown only the requirements that changed could
+                # not notice that an untouched section settles a term the
+                # changed one leaves open.
+                "content": _user_prompt(registry, set(batch_ids), plan.revised),
+            },
         ]
+        calls_issued += 1
         # Constrained to THIS batch's ids, not the whole registry: a disposition
         # for a requirement another call owns is unrepresentable under
         # constrained decoding, and caught locally otherwise (#163). Obligation
@@ -842,16 +980,164 @@ def decompose(
 
     obligations, derived_ids = _resolve_attributions(attributions, dispositions, unusable_answers)
 
+    carried_dispositions = {
+        requirement_id: _carried_disposition(requirement_id, source)
+        for requirement_id, source in plan.carried.items()
+    }
+    requirement_map = _requirement_map(
+        registry,
+        dispositions,
+        derived_ids,
+        question_final,
+        parsed.unclaimed,
+        carried_dispositions,
+    )
+
+    if not plan.is_fresh():
+        # Rebuild both flat lists by walking the map, so a carried obligation
+        # sits where its requirement sits rather than after everything asked for
+        # in this run. Only on a carrying run: with nothing carried, the lists
+        # the call loop already built are returned untouched, which keeps a fresh
+        # decomposition byte-for-byte what it was before this existed.
+        obligations, open_questions = _in_registry_order(
+            requirement_map, obligations, open_questions, plan
+        )
+
     return Decomposition(
         obligations=obligations,
         open_questions=open_questions,
-        requirement_map=_requirement_map(
-            registry,
-            dispositions,
-            derived_ids,
-            question_final,
-            parsed.unclaimed,
-        ),
+        requirement_map=requirement_map,
+        derivations=_derivations(registry, requirement_map, plan, obligations, open_questions),
+        removed_requirements=list(plan.removed),
+        calls_issued=calls_issued,
+    )
+
+
+def _carried_disposition(
+    requirement_id: str, source: RequirementDerivation
+) -> RequirementDisposition:
+    """The disposition a carried requirement keeps.
+
+    Rebuilt rather than copied so it is checked by the same validator every other
+    disposition passes — a carried `yielded` that names no obligation is as broken
+    as a derived one, and this is where that would surface.
+    """
+    return RequirementDisposition(
+        requirement_id=requirement_id,
+        disposition=source.disposition,
+        obligation_ids=[obligation.id for obligation in source.obligations],
+        open_question_ids=[question.id for question in source.open_questions],
+        reason=source.reason,
+        derivation=Derivation.CARRIED.value,
+        carried_from=source.digest(),
+    )
+
+
+def _in_registry_order(
+    requirement_map: RequirementMap,
+    obligations: list[Obligation],
+    open_questions: list[OpenQuestion],
+    plan: CarryPlan,
+) -> tuple[list[Obligation], list[OpenQuestion]]:
+    """The obligations and questions of every requirement, in registry order."""
+    by_obligation = {obligation.id: obligation for obligation in obligations}
+    by_question = {question.id: question for question in open_questions}
+    for source in plan.carried.values():
+        for obligation in source.obligations:
+            by_obligation[obligation.id] = obligation
+        for question in source.open_questions:
+            by_question[question.id] = question
+
+    ordered_obligations: list[Obligation] = []
+    ordered_questions: list[OpenQuestion] = []
+    seen: set[str] = set()
+    for disposition in requirement_map.dispositions:
+        for obligation_id in disposition.obligation_ids:
+            if obligation_id in by_obligation and obligation_id not in seen:
+                seen.add(obligation_id)
+                ordered_obligations.append(by_obligation[obligation_id])
+        for question_id in disposition.open_question_ids:
+            if question_id in by_question and question_id not in seen:
+                seen.add(question_id)
+                ordered_questions.append(by_question[question_id])
+    return ordered_obligations, ordered_questions
+
+
+def _derivations(
+    registry: list[RequirementRef],
+    requirement_map: RequirementMap,
+    plan: CarryPlan,
+    obligations: list[Obligation],
+    open_questions: list[OpenQuestion],
+) -> list[RequirementDerivation]:
+    """One ledger record per requirement, in registry order.
+
+    Written for every requirement, not only the ones that changed: the ledger is
+    what the NEXT run reads to decide what it may carry, so a requirement this run
+    merely carried must still appear, holding the same obligations. A ledger that
+    recorded only the derivations would carry work forward exactly once.
+    """
+    by_obligation = {obligation.id: obligation for obligation in obligations}
+    by_question = {question.id: question for question in open_questions}
+    records: list[RequirementDerivation] = []
+    for requirement in registry:
+        disposition = requirement_map.disposition_for(requirement.id)
+        if disposition is None:  # pragma: no cover - _requirement_map raises first
+            continue
+        kind = derivation_kind(plan, requirement.id)
+        source = plan.carried.get(requirement.id) or plan.revised.get(requirement.id)
+        records.append(
+            RequirementDerivation(
+                requirement_id=requirement.id,
+                text=requirement.text,
+                carry_key=plan.keys[requirement.id],
+                derivation=kind,
+                disposition=disposition.disposition,
+                reason=disposition.reason,
+                carried_from=source.digest() if source is not None else None,
+                revision_reason=(
+                    f"requirement text changed from: {source.text.strip()}"
+                    if kind is Derivation.REVISED and source is not None
+                    else None
+                ),
+                obligations=[
+                    by_obligation[obligation_id]
+                    for obligation_id in disposition.obligation_ids
+                    if obligation_id in by_obligation
+                ],
+                open_questions=[
+                    by_question[question_id]
+                    for question_id in disposition.open_question_ids
+                    if question_id in by_question
+                ],
+            )
+        )
+    return records
+
+
+def build_ledger_entry(
+    derived: Decomposition,
+    run_id: str,
+    parent_run_id: str | None,
+    task_digest: str,
+    linked: Decomposition | None = None,
+) -> LedgerEntry:
+    """This run's ledger record, ready to write.
+
+    Two inputs, deliberately. The **derivations** come from `derived`, before
+    linking: what a later run carries forward per requirement is what this stage
+    derived, and recording the post-merge set would let one run's merge silently
+    become the next run's premise (DR-204). The **merge decisions** come from
+    `linked`, because that is the stage that made them.
+    """
+    return LedgerEntry(
+        run_id=run_id,
+        parent_run_id=parent_run_id,
+        stage_logic_version=DECOMPOSE_STAGE_LOGIC_VERSION,
+        task_digest=task_digest,
+        calls_issued=derived.calls_issued,
+        derivations=list(derived.derivations),
+        merge_decisions=list((linked or derived).merge_decisions),
     )
 
 
@@ -924,6 +1210,7 @@ def _requirement_map(
     derived_ids: dict[str, list[str]],
     question_final: dict[str, dict[str, str]],
     unread: list,
+    carried: dict[str, RequirementDisposition] | None = None,
 ) -> RequirementMap:
     """Reconcile the returned dispositions against the registry.
 
@@ -953,7 +1240,30 @@ def _requirement_map(
         raise SchemaValidationError(
             f"response disposed requirement ids not in the registry: {', '.join(unknown)}"
         )
-    missing = [requirement.id for requirement in registry if requirement.id not in by_requirement]
+    # A carried requirement was not asked about in this run, so no response
+    # accounts for it — and it must still be accounted for, because a registry
+    # requirement with no disposition is the malformed-response case this
+    # function exists to reject. Carrying is the one way a disposition arrives
+    # without a call behind it, and it is checked here rather than trusted: an
+    # id carried for a requirement the registry does not have is caught by the
+    # same rule as one the model invented.
+    carried = carried or {}
+    carried_unknown = sorted(set(carried) - known)
+    if carried_unknown:
+        raise SchemaValidationError(
+            f"carried dispositions for requirement ids not in the registry: "
+            f"{', '.join(carried_unknown)}"
+        )
+    both = sorted(set(carried) & set(by_requirement))
+    if both:
+        raise SchemaValidationError(
+            f"requirement(s) both carried and disposed by a response: {', '.join(both)}"
+        )
+    missing = [
+        requirement.id
+        for requirement in registry
+        if requirement.id not in by_requirement and requirement.id not in carried
+    ]
     if missing:
         raise SchemaValidationError(
             f"response did not account for {len(missing)} of {len(registry)} "
@@ -962,6 +1272,9 @@ def _requirement_map(
 
     dispositions: list[RequirementDisposition] = []
     for requirement in registry:
+        if requirement.id in carried:
+            dispositions.append(carried[requirement.id])
+            continue
         entry = by_requirement[requirement.id]
 
         if isinstance(entry, _NoObligation):

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -380,6 +380,20 @@ class RequirementDisposition(_Model):
     open_question_ids: list[str] = Field(default_factory=list)
     reason: str | None = None
 
+    # How this requirement's obligations came to be, this run (#269). Defaulted
+    # so every disposition written before carry-forward existed keeps exactly the
+    # meaning it had: `derived` is what every one of them was.
+    derivation: Literal["derived", "carried", "revised"] = "derived"
+    # The CONTENT DIGEST of the derivation this was carried from — deliberately
+    # not the run id that held it. A run id is minted randomly, so recording one
+    # here would make two runs over the same input differ in their bytes and
+    # break M0.5. The digest is a function of the derivation itself, so it is
+    # stable, and it identifies what was carried rather than which run happened
+    # to be holding it. Run ids live in the ledger, where ordering is allowed.
+    carried_from: str | None = None
+    # Why a revised requirement was re-asked — the wording it used to have.
+    revision_reason: str | None = None
+
     @model_validator(mode="after")
     def _disposition_is_supported(self) -> RequirementDisposition:
         """A disposition must carry what it claims.

--- a/tests/requirement/test_carry_forward.py
+++ b/tests/requirement/test_carry_forward.py
@@ -17,8 +17,10 @@ same obligation and are entirely different behaviours.
 
 from __future__ import annotations
 
+import itertools
 import json
 import re
+from pathlib import Path
 
 import pytest
 
@@ -952,6 +954,126 @@ def test_two_runs_over_the_same_task_and_ledger_state_are_byte_identical():
 
 
 # --- merge decisions ---------------------------------------------------------
+
+
+# --- the corpus: stability must not be bought by freezing a loss in place -----
+
+_CORPUS = Path(__file__).resolve().parents[2] / "tests" / "fixtures" / "decompose-stability"
+_CORPUS_RUNS = sorted(path for path in _CORPUS.iterdir() if path.is_dir())
+_CORPUS_PAIRS = list(itertools.pairwise(_CORPUS_RUNS))
+
+
+def _ledger_over(registry, keys) -> LedgerEntry:
+    """A prior recording exactly this registry, one obligation per requirement.
+
+    Each obligation quotes the opening of its own requirement, so `stale_spans`
+    is genuinely exercised rather than trivially satisfied by an empty span list.
+    """
+    return LedgerEntry(
+        run_id="corpus-prior",
+        derivations=[
+            RequirementDerivation(
+                requirement_id=requirement.id,
+                text=requirement.text,
+                carry_key=keys[requirement.id],
+                derivation=Derivation.DERIVED,
+                disposition=Disposition.YIELDED,
+                obligations=[
+                    Obligation(
+                        id=f"ob-{requirement.id}",
+                        description=f"obligation for {requirement.id}",
+                        type=ObligationType.FUNCTIONAL,
+                        importance="normal",
+                        explicit=True,
+                        observable_behavior="holds",
+                        source_spans=[
+                            TextSpan(
+                                text=requirement.text[:24],
+                                start=0,
+                                end=min(24, len(requirement.text)),
+                            )
+                        ],
+                    )
+                ],
+            )
+            for requirement in registry
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "earlier,later", _CORPUS_PAIRS, ids=[f"{a.name}->{b.name}" for a, b in _CORPUS_PAIRS]
+)
+def test_carry_forward_re_asks_every_requirement_the_corpus_actually_changed(earlier, later):
+    """`completion-10`, over the real corpus rather than a fixture of my own.
+
+    The corpus at `tests/fixtures/decompose-stability/` is seven consecutive
+    `decompose` runs over a task file that was genuinely edited between them, and
+    the movements between those runs are what #195 turned into a scoreboard. The
+    way carry-forward could destroy them is exact and singular: **carry a
+    requirement whose text changed.** Do that and run N's decomposition is frozen
+    in place and every movement the corpus records disappears.
+
+    So this asserts the plan, over every consecutive pair: a requirement whose
+    text moved is re-asked, one whose text did not is carried, and one that
+    disappeared is reported. DR-180's constraint made mechanical — #191 is the
+    cautionary tale of a judge that scored beautifully on variance by answering
+    `caught` to 114 of 114 defects, and a carry-forward that carried everything
+    would score perfectly on every stability assertion in this module.
+
+    **No model call is issued**, by design: `plan_carry` is given no client, so
+    the residue is derived rather than aligned. Both outcomes are "re-asked",
+    which is the property under test, and the corpus has no recorded transcripts
+    to replay anyway.
+    """
+    earlier_registry = build_registry(parse_task_file((earlier / "current-task.md").read_text()))
+    later_registry = build_registry(parse_task_file((later / "current-task.md").read_text()))
+    keys_client = client_dispatching({})
+    prior = _ledger_over(earlier_registry, decompose_carry_keys(keys_client, earlier_registry))
+
+    plan = plan_carry(
+        later_registry, prior, decompose_carry_keys(keys_client, later_registry), client=None
+    )
+
+    earlier_texts = {requirement.text for requirement in earlier_registry}
+    later_texts = {requirement.text for requirement in later_registry}
+
+    # The pair must actually differ, or this case asserts nothing. The corpus
+    # README records an edit between every consecutive run.
+    assert earlier_texts != later_texts, f"{earlier.name} and {later.name} are identical"
+
+    changed = [r for r in later_registry if r.text not in earlier_texts]
+    unchanged = [r for r in later_registry if r.text in earlier_texts]
+    assert changed, "the corpus records an edit here; the plan must see one"
+
+    for requirement in changed:
+        assert requirement.id in plan.issues_calls_for, (
+            f"{requirement.id} changed between {earlier.name} and {later.name} "
+            f"and was not re-asked — this is exactly how carry-forward would "
+            f"freeze the corpus's movements in place"
+        )
+        assert requirement.id not in plan.carried
+
+    for requirement in unchanged:
+        assert requirement.id in plan.carried, (
+            f"{requirement.id} is byte-identical across {earlier.name} and "
+            f"{later.name} and should have cost no model call"
+        )
+
+    # A requirement the later run dropped is reported, not silently forgotten.
+    assert {derivation.text for derivation in plan.removed} == earlier_texts - later_texts
+
+
+def test_the_corpus_pairs_are_actually_loaded():
+    """A guard on the parametrisation itself.
+
+    An empty or mis-globbed corpus directory would collect zero cases, and a
+    parametrized test with no cases passes silently — the suite would report
+    green while asserting nothing about the corpus at all.
+    """
+    assert len(_CORPUS_RUNS) == 7
+    assert len(_CORPUS_PAIRS) == 6
+    assert all((run / "current-task.md").is_file() for run in _CORPUS_RUNS)
 
 
 def test_a_merge_decision_is_keyed_by_content_not_by_pair_position():

--- a/tests/requirement/test_carry_forward.py
+++ b/tests/requirement/test_carry_forward.py
@@ -294,6 +294,139 @@ def test_a_fresh_run_prompt_is_unchanged_by_the_revision_block():
         assert "PREVIOUSLY DERIVED" not in prompt
 
 
+def test_a_revised_requirement_records_that_it_was_revised_and_why():
+    """`constraint-32` and `constraint-33`.
+
+    Found by the tool's own Gate 2, and it was a defect rather than a missing
+    test: a revised requirement's disposition came back saying `derived` with no
+    reason, which is exactly what a genuinely new requirement says. The two are
+    different — one had a predecessor and was re-asked against it — and losing the
+    distinction loses the only record that an identifier could have been reused.
+    """
+    first, _ = _run(_TASK)
+    prior = _ledger_from(first)
+
+    second, _ = _run(_EDITED, prior=prior, alignment=[{"ground_truth": "g0", "reviewer": "r0"}])
+
+    revised = [d for d in second.derivations if d.derivation is Derivation.REVISED]
+    assert len(revised) == 1
+    assert "The ledger is append-only." in revised[0].revision_reason
+
+    disposition = second.requirement_map.disposition_for(revised[0].requirement_id)
+    assert disposition.derivation == "revised"
+    assert disposition.revision_reason == revised[0].revision_reason
+    assert disposition.carried_from is not None
+
+    # And the untouched requirements are not stamped, so the mark means something.
+    others = [
+        d
+        for d in second.requirement_map.dispositions
+        if d.requirement_id != revised[0].requirement_id
+    ]
+    assert {d.derivation for d in others} == {"carried"}
+    assert all(d.revision_reason is None for d in others)
+
+
+def test_carrying_forward_does_not_freeze_a_superseded_obligation_in_place():
+    """DR-180's constraint, and the one this whole feature could most easily
+    violate: **do not buy stability by blunting the decomposer.**
+
+    #191 is the cautionary tale — its pre-change discrimination judge scored
+    beautifully on variance precisely because it answered `caught` to 114 of 114
+    defects. A carry-forward that carried everything would score perfectly on
+    every stability metric here and be exactly as useless.
+
+    The discriminating setup: the re-derivation returns a DIFFERENT obligation
+    from the one on file. An implementation that carried the edited requirement
+    anyway would still show the old obligation, and would pass every other test in
+    this module.
+    """
+    first, _ = _run(_TASK)
+    prior = _ledger_from(first)
+    # Exact text, not a substring: "append-only" also appears in the Completion
+    # bullet that demands a test of it, and that requirement is NOT being edited.
+    superseded = {
+        obligation.id
+        for derivation in prior.derivations
+        if derivation.text == "The ledger is append-only."
+        for obligation in derivation.obligations
+    }
+    assert superseded, "fixture must have an obligation on the requirement being edited"
+
+    parsed = parse_task_file(_EDITED)
+    registry = build_registry(parsed)
+    edited_id = next(r.id for r in registry if "only ever appended to" in r.text)
+    counting = _CountingClient(_EDITED, alignment=[{"ground_truth": "g0", "reviewer": "r0"}])
+    # The re-derivation answers with a new obligation id, as a real one would
+    # after a wording change that altered what is required.
+    counting.client._completion_fn = _answering(
+        {edited_id: ("ob-supersedes", "the ledger is only ever appended to")},
+        alignment=[{"ground_truth": "g0", "reviewer": "r0"}],
+    )
+
+    second = decompose(parsed, counting.client, prior=prior)
+
+    ids = {obligation.id for obligation in second.obligations}
+    assert "ob-supersedes" in ids
+    assert not (ids & superseded), "a superseded obligation was frozen in place"
+    # The requirements that did NOT change still kept theirs — the change is
+    # surgical rather than a full re-derivation wearing a carry-forward label.
+    assert second.requirement_map.disposition_for(edited_id).derivation == "revised"
+    assert (
+        sum(1 for d in second.derivations if d.derivation is Derivation.CARRIED)
+        == len(registry) - 1
+    )
+
+
+def _answering(by_requirement: dict[str, tuple[str, str]], alignment: list[dict] | None = None):
+    """A completion double answering the decompose call with chosen obligations.
+
+    Dispatches on the response schema, because a carrying run issues two different
+    kinds of call — the residue aligner and the re-derivation — and a double that
+    answered both with the same payload would fail the first.
+    """
+
+    def completion_fn(**kwargs):
+        from types import SimpleNamespace
+
+        if kwargs["response_format"]["json_schema"]["name"] == "_Alignment":
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(content=json.dumps({"matches": alignment or []}))
+                    )
+                ],
+                usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            )
+
+        dispositions = [
+            {
+                "requirement_id": requirement_id,
+                "disposition": "yielded",
+                "obligation": {
+                    "id": obligation_id,
+                    "description": description,
+                    "type": "functional",
+                    "importance": "normal",
+                    "explicit": True,
+                    "observable_behavior": description,
+                    "source_quote": "",
+                    "required_evidence": "code_and_tests",
+                    "required_evidence_reason": "",
+                },
+                "more_obligations": [],
+            }
+            for requirement_id, (obligation_id, description) in by_requirement.items()
+        ]
+        payload = json.dumps({"open_questions": [], "requirement_dispositions": dispositions})
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=payload))],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+
+    return completion_fn
+
+
 def test_a_removed_requirement_is_reported_and_its_obligations_dropped():
     """Reported rather than silent: a requirement that vanished took its
     obligations with it, and a run that simply stops mentioning them is

--- a/tests/requirement/test_carry_forward.py
+++ b/tests/requirement/test_carry_forward.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 import json
 
+from acceptance.llm import inline_schema_refs
+from acceptance.requirement import obligations as obligations_module
 from acceptance.requirement.carry import plan_carry, stale_spans
 from acceptance.requirement.ledger import (
     DECOMPOSE_STAGE_LOGIC_VERSION,
@@ -27,6 +29,7 @@ from acceptance.requirement.ledger import (
     LedgerStore,
     MergeDecision,
     RequirementDerivation,
+    carry_key,
     new_run_id,
 )
 from acceptance.requirement.linking import link_duplicate_obligations
@@ -351,6 +354,74 @@ def test_a_changed_stage_logic_version_invalidates_every_carried_entry():
     _, counting = _run(_TASK, prior=prior)
 
     assert counting.decompose_calls > 0
+
+
+def test_a_changed_response_schema_invalidates_the_entries_derived_under_it():
+    """The response schema is one of the four determinism controls `llm.py` puts
+    in a request key, so an entry recorded under a different one is not an entry
+    this run could reproduce.
+
+    Modelled as a prior whose keys were computed under a different schema — which
+    is exactly what "obligations derived under the previous schema" is — rather
+    than by mutating the live model, so the assertion is about `plan_carry`
+    comparing keys rather than about a patched class.
+    """
+    first, counting = _run(_TASK)
+    prior = _ledger_from(first)
+    under_old_schema = prior.model_copy(
+        update={
+            "derivations": [
+                derivation.model_copy(
+                    update={
+                        "carry_key": carry_key(
+                            system_prompt=obligations_module._SYSTEM_PROMPT,
+                            response_schema={"name": "_Decomposition", "schema": {"older": True}},
+                            model=counting.client.model,
+                            temperature=counting.client.temperature,
+                            seed=counting.client.seed,
+                            stage_logic_version=DECOMPOSE_STAGE_LOGIC_VERSION,
+                            requirement_text=derivation.text,
+                        )
+                    }
+                )
+                for derivation in prior.derivations
+            ]
+        }
+    )
+
+    _, second = _run(_TASK, prior=under_old_schema)
+
+    assert second.decompose_calls > 0
+
+
+def test_the_carry_key_reads_the_live_response_schema():
+    """The wiring behind the test above.
+
+    That test would still pass if `decompose_carry_keys` hashed some constant
+    instead of the real schema — every key would move together and nothing would
+    carry, which looks like correct invalidation. This recomputes the key from
+    `_Decomposition`'s actual schema and requires a match, so silently dropping
+    the schema from the key fails here.
+    """
+    parsed = parse_task_file(_TASK)
+    registry = build_registry(parsed)
+    _, counting = _run(_TASK)
+
+    keys = decompose_carry_keys(counting.client, registry)
+
+    expected = carry_key(
+        system_prompt=obligations_module._SYSTEM_PROMPT,
+        response_schema={
+            "name": "_Decomposition",
+            "schema": inline_schema_refs(obligations_module._Decomposition.model_json_schema()),
+        },
+        model=counting.client.model,
+        temperature=counting.client.temperature,
+        seed=counting.client.seed,
+        stage_logic_version=DECOMPOSE_STAGE_LOGIC_VERSION,
+        requirement_text=registry[0].text,
+    )
+    assert keys[registry[0].id] == expected
 
 
 def test_a_changed_prompt_invalidates_the_entries_derived_under_it(monkeypatch):

--- a/tests/requirement/test_carry_forward.py
+++ b/tests/requirement/test_carry_forward.py
@@ -1,0 +1,778 @@
+"""#269 — an obligation is carried forward when its requirement did not change.
+
+The acceptance items from the issue, each as a test. What every one of them is
+really guarding is the same thing: `decompose` used to be a pure function of the
+task text, so one edited character re-derived all of it and re-minted every
+identifier. #191 measured the cost — 38 distinct criterion wordings across three
+runs of ~20 criteria, zero content difference — and since criterion text is the
+prompt for every later stage, that churn floors every downstream stability
+number.
+
+The tests inject responses rather than calling a model, per the replay-first
+invariant. Where a test is about **whether a call was issued at all**, it counts
+calls off the double rather than inspecting output: an obligation that was
+re-derived to an identical value and one that was never asked about produce the
+same obligation and are entirely different behaviours.
+"""
+
+from __future__ import annotations
+
+import json
+
+from acceptance.requirement.carry import plan_carry, stale_spans
+from acceptance.requirement.ledger import (
+    DECOMPOSE_STAGE_LOGIC_VERSION,
+    Derivation,
+    LedgerEntry,
+    LedgerStore,
+    MergeDecision,
+    RequirementDerivation,
+    new_run_id,
+)
+from acceptance.requirement.linking import link_duplicate_obligations
+from acceptance.requirement.obligations import (
+    Decomposition,
+    build_ledger_entry,
+    decompose,
+    decompose_carry_keys,
+)
+from acceptance.requirement.registry import build_registry
+from acceptance.requirement.task_file import parse_task_file
+from acceptance.review_state import (
+    Disposition,
+    Obligation,
+    ObligationType,
+    RequirementDisposition,
+    RequirementMap,
+    RequirementRef,
+    RequirementSection,
+)
+from acceptance.source_ref import TextSpan
+from tests.support import client_dispatching
+
+_TASK = """# Task
+The tool records what it derived.
+
+## Constraints
+- The ledger is append-only.
+- The run reports its own identifier.
+
+## Completion expectations
+- Implementation
+- A test asserts the ledger is append-only.
+"""
+
+
+def _response_for(requirement_ids: list[str]) -> dict:
+    """One yielded obligation per requirement, ids derived from the requirement."""
+    return {
+        "open_questions": [],
+        "requirement_dispositions": [
+            {
+                "requirement_id": requirement_id,
+                "disposition": "yielded",
+                "obligation": {
+                    "id": f"ob-{requirement_id}",
+                    "description": f"obligation for {requirement_id}",
+                    "type": "functional",
+                    "importance": "normal",
+                    "explicit": True,
+                    "observable_behavior": f"{requirement_id} holds",
+                    "source_quote": "",
+                    "required_evidence": "code_and_tests",
+                    "required_evidence_reason": "",
+                },
+                "more_obligations": [],
+            }
+            for requirement_id in requirement_ids
+        ],
+    }
+
+
+class _CountingClient:
+    """A double that records every call it was asked to answer.
+
+    Uses `client_dispatching(capture=...)`, the helper's own supported hook, so
+    the count is of calls the client actually issued rather than of a wrapper this
+    test hoped was installed.
+    """
+
+    def __init__(self, task: str, alignment: list[dict] | None = None, **kwargs):
+        self.calls: list[dict] = []
+        parsed = parse_task_file(task)
+        ids = [requirement.id for requirement in build_registry(parsed)]
+        self.client = client_dispatching(
+            {
+                "_Decomposition": _response_for(ids),
+                # The residue aligner (#209), reached only when both sides have
+                # requirements left over after exact-text matching. Defaults to
+                # matching nothing, which is what a correct aligner returns for
+                # two unrelated task files.
+                "_Alignment": {"matches": alignment or []},
+            },
+            capture=self.calls,
+            **kwargs,
+        )
+
+    @property
+    def decompose_calls(self) -> int:
+        return sum(1 for call in self.calls if call["schema"] == "_Decomposition")
+
+    def prompts_for(self, schema: str) -> list[str]:
+        return [call["prompt"] for call in self.calls if call["schema"] == schema]
+
+
+def _run(task: str, prior: LedgerEntry | None = None, alignment=None, **kwargs):
+    """Decompose `task`, returning the result and how many calls it took."""
+    parsed = parse_task_file(task)
+    counting = _CountingClient(task, alignment=alignment, **kwargs)
+    result = decompose(parsed, counting.client, prior=prior)
+    return result, counting
+
+
+def _ledger_from(result, run_id: str = "run-one", parent: str | None = None) -> LedgerEntry:
+    return build_ledger_entry(result, run_id=run_id, parent_run_id=parent, task_digest="d")
+
+
+# --- the headline: an unchanged task file costs nothing ----------------------
+
+
+def test_a_rerun_over_an_unchanged_task_file_issues_no_decompose_call():
+    """The acceptance item the whole issue exists for.
+
+    Counted off the double, not inferred from the output: re-deriving to the same
+    answer and not asking at all are indistinguishable in the result and are the
+    entire difference this change makes.
+    """
+    first, _ = _run(_TASK)
+    prior = _ledger_from(first)
+
+    _, second = _run(_TASK, prior=prior)
+
+    assert second.decompose_calls == 0
+
+
+def test_a_rerun_over_an_unchanged_task_file_returns_byte_identical_obligations():
+    """Identifiers and descriptions included — the churn #191 measured is exactly
+    a change of identifier and wording over unchanged substance, so comparing the
+    obligation set alone would pass while the defect was fully present."""
+    first, _ = _run(_TASK)
+    second, _ = _run(_TASK, prior=_ledger_from(first))
+
+    assert [o.to_dict() for o in second.obligations] == [o.to_dict() for o in first.obligations]
+    assert [o.id for o in second.obligations] == [o.id for o in first.obligations]
+    assert [o.description for o in second.obligations] == [o.description for o in first.obligations]
+
+
+def test_every_requirement_is_recorded_as_carried():
+    first, _ = _run(_TASK)
+    second, _ = _run(_TASK, prior=_ledger_from(first))
+
+    assert {d.derivation for d in second.derivations} == {Derivation.CARRIED}
+    assert all(
+        disposition.derivation == "carried" for disposition in second.requirement_map.dispositions
+    )
+
+
+def test_a_carried_disposition_records_the_digest_it_came_from_not_a_run_id():
+    """`carried_from` holds a CONTENT digest deliberately.
+
+    A run id is minted randomly, so recording one in review state would make two
+    runs over the same input differ in their bytes and break M0.5. The digest is
+    a function of the derivation itself.
+    """
+    first, _ = _run(_TASK)
+    prior = _ledger_from(first, run_id="run-abc")
+    second, _ = _run(_TASK, prior=prior)
+
+    digests = {d.carried_from for d in second.requirement_map.dispositions}
+    assert None not in digests
+    assert "run-abc" not in digests
+    by_text = prior.by_text()
+    for derivation in second.derivations:
+        assert derivation.carried_from == by_text[derivation.text].digest()
+
+
+# --- default-to-fresh, and no cross-task contamination -----------------------
+
+
+def test_no_continued_run_carries_nothing():
+    result, counting = _run(_TASK)
+
+    assert counting.decompose_calls > 0
+    assert {d.derivation for d in result.derivations} == {Derivation.DERIVED}
+
+
+def test_a_ledger_recording_a_different_task_produces_what_an_empty_ledger_does():
+    """Cross-task contamination is a bug, not a feature of carrying forward.
+
+    Identity is the requirement's exact text, so a ledger whose requirements share
+    none of this task's wording matches nothing and every requirement derives
+    fresh — the same result as no ledger at all.
+    """
+    other = """# Task
+Something else entirely.
+
+## Constraints
+- Pagination is unchanged.
+"""
+    other_result, _ = _run(other)
+    against_other, counting_other = _run(_TASK, prior=_ledger_from(other_result))
+    against_nothing, counting_nothing = _run(_TASK)
+
+    assert [o.to_dict() for o in against_other.obligations] == [
+        o.to_dict() for o in against_nothing.obligations
+    ]
+    assert counting_other.decompose_calls == counting_nothing.decompose_calls
+
+
+# --- editing one requirement -------------------------------------------------
+
+_EDITED = _TASK.replace("- The ledger is append-only.", "- The ledger is only ever appended to.")
+
+
+def test_editing_one_requirement_leaves_every_other_requirement_carried():
+    """The other half of the headline: an edit costs one requirement, not all of
+    them. Before this change, `rerun.py`'s rule was that a changed task
+    invalidates everything."""
+    first, _ = _run(_TASK)
+
+    # The aligner matches the one edited bullet to the one it replaced — the only
+    # residue on either side.
+    second, counting = _run(
+        _EDITED,
+        prior=_ledger_from(first),
+        alignment=[{"ground_truth": "g0", "reviewer": "r0"}],
+    )
+
+    kinds = {d.requirement_id: d.derivation for d in second.derivations}
+    changed = [rid for rid, kind in kinds.items() if kind is not Derivation.CARRIED]
+    assert len(changed) == 1, kinds
+    assert kinds[changed[0]] is Derivation.REVISED
+    assert counting.decompose_calls == 1
+
+
+def test_an_edited_requirements_persisting_obligations_keep_their_identifiers():
+    """Id stability across an edit is the whole point — #191 found identifiers
+    re-minted alongside re-worded criteria on input that had not changed at all.
+
+    The prompt is what carries this: the revised requirement's previous wording
+    and the obligations it produced are put in front of the model, so reusing an
+    id is available to it. Asserted on the prompt because the response is a
+    fixture — a test that injected the reused id and then asserted it would be
+    asserting its own double.
+    """
+    first, _ = _run(_TASK)
+    prior = _ledger_from(first)
+    previous_ids = [o.id for o in prior.derivations[1].obligations]
+
+    _, counting = _run(
+        _EDITED,
+        prior=prior,
+        alignment=[{"ground_truth": "g0", "reviewer": "r0"}],
+    )
+
+    prompt = counting.prompts_for("_Decomposition")[0]
+    assert "PREVIOUSLY DERIVED" in prompt
+    assert "The ledger is append-only." in prompt
+    for obligation_id in previous_ids:
+        assert obligation_id in prompt
+    assert "reuse its id" in prompt
+
+
+def test_a_fresh_run_prompt_is_unchanged_by_the_revision_block():
+    """`completion-06` in prompt form: with nothing carried, the request this
+    stage issues is byte-for-byte what it issued before carry-forward existed, so
+    every recorded transcript still replays and no work is lost to a tool update.
+    """
+    _, counting = _run(_TASK)
+
+    for prompt in counting.prompts_for("_Decomposition"):
+        assert "PREVIOUSLY DERIVED" not in prompt
+
+
+def test_a_removed_requirement_is_reported_and_its_obligations_dropped():
+    """Reported rather than silent: a requirement that vanished took its
+    obligations with it, and a run that simply stops mentioning them is
+    indistinguishable from one where they were never written."""
+    first, _ = _run(_TASK)
+    shortened = _TASK.replace("- The run reports its own identifier.\n", "")
+
+    second, _ = _run(shortened, prior=_ledger_from(first))
+
+    assert len(second.removed_requirements) == 1
+    removed = second.removed_requirements[0]
+    assert "reports its own identifier" in removed.text
+    assert removed.obligations
+    surviving = {o.id for o in second.obligations}
+    assert not {o.id for o in removed.obligations} & surviving
+
+
+# --- what invalidates a carried entry ----------------------------------------
+
+
+def test_a_tool_change_that_leaves_the_request_unaltered_carries_everything():
+    """The backwards-compatible-by-default half of the design.
+
+    Modelled as a second run with identical determinism controls, which is what
+    "the request did not move" means operationally.
+    """
+    first, _ = _run(_TASK)
+    _, counting = _run(_TASK, prior=_ledger_from(first))
+
+    assert counting.decompose_calls == 0
+
+
+def test_a_changed_model_invalidates_every_carried_entry():
+    first, _ = _run(_TASK, model="gpt-4o-mini")
+    _, counting = _run(_TASK, prior=_ledger_from(first), model="another-model")
+
+    assert counting.decompose_calls > 0
+
+
+def test_a_changed_seed_invalidates_every_carried_entry():
+    first, _ = _run(_TASK, seed=1)
+    _, counting = _run(_TASK, prior=_ledger_from(first), seed=2)
+
+    assert counting.decompose_calls > 0
+
+
+def test_a_changed_stage_logic_version_invalidates_every_carried_entry():
+    """The gap the request key cannot see.
+
+    A code change that alters what we do with an unchanged response leaves the
+    request identical, so nothing else in the system would notice it.
+    """
+    first, _ = _run(_TASK)
+    prior = _ledger_from(first).model_copy(
+        update={"stage_logic_version": DECOMPOSE_STAGE_LOGIC_VERSION + 1}
+    )
+
+    _, counting = _run(_TASK, prior=prior)
+
+    assert counting.decompose_calls > 0
+
+
+def test_a_changed_prompt_invalidates_the_entries_derived_under_it(monkeypatch):
+    """The carry key hashes the system prompt, so editing it strands every entry
+    recorded under the old one."""
+    from acceptance.requirement import obligations as module
+
+    first, _ = _run(_TASK)
+    prior = _ledger_from(first)
+    monkeypatch.setattr(module, "_SYSTEM_PROMPT", module._SYSTEM_PROMPT + "\nAnd one more rule.")
+
+    _, counting = _run(_TASK, prior=prior)
+
+    assert counting.decompose_calls > 0
+
+
+def test_a_carried_entry_quoting_text_the_requirement_lost_is_rederived():
+    """Caught in code rather than by trusting the model to notice.
+
+    The obligation's source span is checked against the NEW requirement text, so
+    an entry carried over from an older wording cannot survive on an id match.
+    """
+    derivation = RequirementDerivation(
+        requirement_id="constraint-01",
+        text="The ledger is append-only.",
+        carry_key="k",
+        derivation=Derivation.DERIVED,
+        disposition=Disposition.YIELDED,
+        obligations=[
+            Obligation(
+                id="ob",
+                description="d",
+                type=ObligationType.FUNCTIONAL,
+                importance="normal",
+                explicit=True,
+                observable_behavior="b",
+                source_spans=[TextSpan(text="append-only", start=0, end=11)],
+            )
+        ],
+    )
+
+    assert not stale_spans(derivation, "The ledger is append-only.")
+    assert stale_spans(derivation, "The ledger is rewritten in place.")
+
+
+def test_whitespace_only_reflow_does_not_strand_a_carried_span():
+    """Task prose is hard-wrapped, so a reflowed paragraph is not a changed one —
+    the same rule `_locate_quotation` already applies when deriving."""
+    derivation = RequirementDerivation(
+        requirement_id="constraint-01",
+        text="The ledger is\n  append-only.",
+        carry_key="k",
+        derivation=Derivation.DERIVED,
+        disposition=Disposition.YIELDED,
+        obligations=[
+            Obligation(
+                id="ob",
+                description="d",
+                type=ObligationType.FUNCTIONAL,
+                importance="normal",
+                explicit=True,
+                observable_behavior="b",
+                source_spans=[TextSpan(text="ledger is append-only", start=0, end=21)],
+            )
+        ],
+    )
+
+    assert not stale_spans(derivation, "The ledger is\n  append-only.")
+
+
+# --- the plan itself ---------------------------------------------------------
+
+
+def test_the_plan_issues_calls_only_for_what_changed():
+    parsed = parse_task_file(_TASK)
+    registry = build_registry(parsed)
+    first, counting = _run(_TASK)
+    prior = _ledger_from(first)
+    keys = decompose_carry_keys(counting.client, registry)
+
+    plan = plan_carry(registry, prior, keys, counting.client)
+
+    assert plan.issues_calls_for == set()
+    assert set(plan.carried) == {requirement.id for requirement in registry}
+    assert not plan.is_fresh()
+
+
+def test_a_plan_with_no_prior_is_fresh():
+    parsed = parse_task_file(_TASK)
+    registry = build_registry(parsed)
+    _, counting = _run(_TASK)
+    keys = decompose_carry_keys(counting.client, registry)
+
+    plan = plan_carry(registry, None, keys, counting.client)
+
+    assert plan.is_fresh()
+    assert plan.issues_calls_for == {requirement.id for requirement in registry}
+    assert plan.removed == ()
+
+
+# --- the ledger --------------------------------------------------------------
+
+
+def test_the_ledger_records_what_was_carried_derived_and_revised(tmp_path):
+    first, _ = _run(_TASK)
+    store = LedgerStore(tmp_path / "ledger")
+    entry = _ledger_from(first, run_id=new_run_id())
+    store.write(entry)
+
+    read_back = store.read(entry.run_id)
+
+    assert read_back.derived_count() == len(first.derivations)
+    assert read_back.carried_count() == 0
+    assert read_back.revised_count() == 0
+    assert read_back.calls_issued == first.calls_issued
+    assert read_back.stage_logic_version == DECOMPOSE_STAGE_LOGIC_VERSION
+
+
+def test_the_ledger_records_the_request_key_of_each_derivation():
+    first, _ = _run(_TASK)
+    entry = _ledger_from(first)
+
+    assert all(derivation.carry_key for derivation in entry.derivations)
+    assert len({derivation.carry_key for derivation in entry.derivations}) == len(entry.derivations)
+
+
+def test_a_run_records_the_run_it_continues_as_its_parent():
+    first, _ = _run(_TASK)
+    second, _ = _run(_TASK, prior=_ledger_from(first, run_id="parent-run"))
+
+    entry = build_ledger_entry(
+        second, run_id="child-run", parent_run_id="parent-run", task_digest="d"
+    )
+
+    assert entry.run_id == "child-run"
+    assert entry.parent_run_id == "parent-run"
+
+
+def test_a_ledger_file_is_never_rewritten(tmp_path):
+    """Append-only is enforced, not merely intended: a silent clobber would lose
+    the history a later feature counts settling runs from."""
+    store = LedgerStore(tmp_path / "ledger")
+    entry = LedgerEntry(run_id="only-once")
+    store.write(entry)
+
+    try:
+        store.write(entry)
+    except FileExistsError:
+        pass
+    else:  # pragma: no cover - the assertion below reports it
+        raise AssertionError("a second write to the same run id must be refused")
+
+
+def test_the_ledger_is_not_written_under_the_cache(tmp_path):
+    """DR-259 lost two runs to a cache clear. The ledger has to survive one."""
+    from acceptance.requirement.ledger import DEFAULT_LEDGER_ROOT
+
+    assert "cache" not in DEFAULT_LEDGER_ROOT.parts
+
+
+def test_an_unknown_continued_run_is_not_an_error(tmp_path):
+    """Default-to-fresh: the failure mode of the default must be lost work, never
+    imported work, so an absent prior degrades to a full derivation."""
+    store = LedgerStore(tmp_path / "ledger")
+
+    assert store.read_if_present("no-such-run") is None
+    assert store.read_if_present(None) is None
+
+
+# --- run identifiers stay out of review state --------------------------------
+
+
+def test_a_run_identifier_appears_in_no_review_state():
+    """The M0.5 guard. A random id in review state makes two runs over the same
+    input differ in their bytes, which is exactly why `Review` has no timestamp."""
+    first, _ = _run(_TASK)
+    run_id = "deadbeefcafe"
+    second, _ = _run(_TASK, prior=_ledger_from(first, run_id=run_id))
+
+    serialized = json.dumps(second.requirement_map.to_dict())
+    assert run_id not in serialized
+    assert run_id not in json.dumps([o.to_dict() for o in second.obligations])
+
+
+def test_two_runs_over_the_same_task_and_ledger_state_are_byte_identical():
+    """M0.5, restated for this feature: same task file PLUS same ledger state."""
+    first, _ = _run(_TASK)
+    prior = _ledger_from(first)
+
+    left, _ = _run(_TASK, prior=prior)
+    right, _ = _run(_TASK, prior=prior)
+
+    assert json.dumps(left.to_dict(), sort_keys=True) == json.dumps(right.to_dict(), sort_keys=True)
+
+
+# --- merge decisions ---------------------------------------------------------
+
+
+def test_a_merge_decision_is_keyed_by_content_not_by_pair_position():
+    """Pair ids are positional (`pair-0007`) and assigned before filtering, so
+    carrying one obligation forward renumbers every pair after it. Keying on
+    content is what makes a carried decision survive that."""
+
+    def obligation(obligation_id: str, description: str) -> Obligation:
+        return Obligation(
+            id=obligation_id,
+            description=description,
+            type=ObligationType.FUNCTIONAL,
+            importance="normal",
+            explicit=True,
+            observable_behavior=f"{obligation_id} holds",
+        )
+
+    left = obligation("a", "first")
+    right = obligation("b", "second")
+
+    forwards = MergeDecision.between(left, right, True)
+    backwards = MergeDecision.between(right, left, True)
+
+    assert forwards.key == backwards.key
+
+    changed = MergeDecision.between(left, obligation("b", "second, reworded"), True)
+    assert changed.key != forwards.key
+
+
+def test_the_decompose_command_writes_a_ledger_entry_and_a_second_run_carries(
+    tmp_path, monkeypatch
+):
+    """The wiring, not the helper.
+
+    Defect injection has repeatedly found the same shape of hole in this
+    repository: a helper with a good unit test that the pipeline never calls. This
+    drives the real CLI entry point twice — the second naming the first — and
+    asserts that the second issued no decompose call.
+    """
+    from acceptance import cli
+
+    task = tmp_path / "task.md"
+    task.write_text(_TASK)
+    ledger = LedgerStore(tmp_path / "ledger")
+    counting = _CountingClient(_TASK)
+    monkeypatch.setattr(cli.RunConfig, "build_client", lambda self: counting.client)
+
+    _, _, first_run = cli.run_decompose(str(task), cli.RunConfig(), ledger=ledger)
+
+    assert ledger.path_for(first_run).exists()
+    assert ledger.read(first_run).derived_count() > 0
+    calls_after_first = counting.decompose_calls
+    assert calls_after_first > 0
+
+    _, _, second_run = cli.run_decompose(
+        str(task), cli.RunConfig(), continue_from=first_run, ledger=ledger
+    )
+
+    assert counting.decompose_calls == calls_after_first
+    assert ledger.read(second_run).parent_run_id == first_run
+    assert ledger.read(second_run).carried_count() == len(ledger.read(first_run).derivations)
+
+
+def test_the_review_pipeline_carries_forward_and_hands_back_what_it_derived(tmp_path):
+    """`check` decomposes too, through `run_review`, so the same carry-forward has
+    to reach it — otherwise only one of the two entry points could be continued
+    and the ledger would describe half the runs.
+
+    Driven through `run_review` itself rather than through `decompose`, because
+    the defect this guards against is precisely a pipeline that never calls the
+    thing its unit tests cover.
+    """
+    from acceptance.pipeline import run_review
+    from acceptance.review_state import ChangeSet
+
+    first, _ = _run(_TASK)
+    prior = _ledger_from(first, run_id="seed-run")
+    counting = _CountingClient(_TASK)
+    sink: list = []
+
+    run_review(
+        task_text=_TASK,
+        change_set=ChangeSet(base_revision="a", head_revision="b", files=[]),
+        repo=tmp_path,
+        client=counting.client,
+        reviewed_revision="b",
+        ledger_prior=prior,
+        ledger_sink=sink,
+    )
+
+    assert counting.decompose_calls == 0
+    assert len(sink) == 1
+    derived, _linked = sink[0]
+    assert {d.derivation for d in derived.derivations} == {Derivation.CARRIED}
+
+
+def test_the_review_pipeline_leaves_no_ledger_behind_when_given_no_sink(tmp_path):
+    """The benchmark runs the same pipeline over many cases and must not litter
+    run records; writing is the caller's, which is why the sink is opt-in."""
+    from acceptance.pipeline import run_review
+    from acceptance.review_state import ChangeSet
+
+    counting = _CountingClient(_TASK)
+
+    run_review(
+        task_text=_TASK,
+        change_set=ChangeSet(base_revision="a", head_revision="b", files=[]),
+        repo=tmp_path,
+        client=counting.client,
+        reviewed_revision="b",
+    )
+
+    assert not (tmp_path / ".acceptance").exists()
+
+
+def _linkable() -> tuple[Decomposition, list[Obligation]]:
+    """Two obligations under two requirements — one askable pair."""
+    obligations = [
+        Obligation(
+            id=obligation_id,
+            description=f"{obligation_id} is required",
+            type=ObligationType.FUNCTIONAL,
+            importance="normal",
+            explicit=True,
+            observable_behavior=f"{obligation_id} holds",
+        )
+        for obligation_id in ("alpha", "beta")
+    ]
+    requirements = [
+        RequirementRef(
+            id=requirement_id,
+            section=RequirementSection.CONSTRAINT,
+            ordinal=index,
+            span=TextSpan(text=requirement_id, start=0, end=len(requirement_id)),
+        )
+        for index, requirement_id in enumerate(("constraint-01", "constraint-02"))
+    ]
+    dispositions = [
+        RequirementDisposition(
+            requirement_id=requirement.id,
+            disposition=Disposition.YIELDED,
+            obligation_ids=[obligation.id],
+        )
+        for requirement, obligation in zip(requirements, obligations, strict=True)
+    ]
+    return (
+        Decomposition(
+            obligations=obligations,
+            requirement_map=RequirementMap(requirements=requirements, dispositions=dispositions),
+        ),
+        obligations,
+    )
+
+
+def _linking_client(capture: list | None = None):
+    return client_dispatching(
+        {
+            "_Verdicts": {
+                "verdicts": [
+                    {"pair_id": "pair-0000", "same_requirement": False, "reason": "double"}
+                ]
+            }
+        },
+        capture=capture,
+    )
+
+
+def test_a_merge_decision_over_two_unchanged_obligations_is_not_asked_again():
+    """`constraint-11`. Counted off the double: a re-asked pair answered the same
+    way is indistinguishable in the output from one that was never asked."""
+    decomposition, obligations = _linkable()
+    prior = LedgerEntry(
+        run_id="prior",
+        merge_decisions=[MergeDecision.between(obligations[0], obligations[1], False)],
+    )
+    calls: list[dict] = []
+
+    link_duplicate_obligations(decomposition, _linking_client(calls), prior=prior)
+
+    assert [call["schema"] for call in calls] == []
+
+
+def test_a_merge_decision_is_asked_again_when_either_obligation_changed():
+    """`constraint-12`. The linking prompt renders both obligations, so a verdict
+    about one wording is not a verdict about another."""
+    decomposition, obligations = _linkable()
+    stale = obligations[1].model_copy(update={"description": "beta, reworded"})
+    prior = LedgerEntry(
+        run_id="prior",
+        merge_decisions=[MergeDecision.between(obligations[0], stale, False)],
+    )
+    calls: list[dict] = []
+
+    link_duplicate_obligations(decomposition, _linking_client(calls), prior=prior)
+
+    assert [call["schema"] for call in calls] == ["_Verdicts"]
+
+
+def test_a_carried_merge_decision_still_merges():
+    """Carrying a decision must carry its EFFECT, not merely skip the call — a
+    confirmed pair that stopped merging would silently un-deduplicate the set."""
+    decomposition, obligations = _linkable()
+    prior = LedgerEntry(
+        run_id="prior",
+        merge_decisions=[MergeDecision.between(obligations[0], obligations[1], True)],
+    )
+
+    linked = link_duplicate_obligations(decomposition, _linking_client(), prior=prior)
+
+    assert [o.id for o in linked.obligations] == ["alpha"]
+    assert all(d.obligation_ids == ["alpha"] for d in linked.requirement_map.dispositions)
+
+
+def test_the_decisions_a_run_stands_on_are_recorded_carried_and_fresh_alike():
+    """So the next run inherits the whole set rather than only what this one
+    happened to re-ask — otherwise a decision decays after one carry."""
+    decomposition, _ = _linkable()
+
+    linked = link_duplicate_obligations(decomposition, _linking_client())
+
+    assert len(linked.merge_decisions) == 1
+    carried_forward = link_duplicate_obligations(
+        decomposition,
+        _linking_client(),
+        prior=LedgerEntry(run_id="p", merge_decisions=linked.merge_decisions),
+    )
+    assert [d.key for d in carried_forward.merge_decisions] == [
+        d.key for d in linked.merge_decisions
+    ]

--- a/tests/requirement/test_carry_forward.py
+++ b/tests/requirement/test_carry_forward.py
@@ -18,6 +18,9 @@ same obligation and are entirely different behaviours.
 from __future__ import annotations
 
 import json
+import re
+
+import pytest
 
 from acceptance.llm import inline_schema_refs
 from acceptance.requirement import obligations as obligations_module
@@ -695,17 +698,215 @@ def test_a_run_records_the_run_it_continues_as_its_parent():
 
 def test_a_ledger_file_is_never_rewritten(tmp_path):
     """Append-only is enforced, not merely intended: a silent clobber would lose
-    the history a later feature counts settling runs from."""
-    store = LedgerStore(tmp_path / "ledger")
-    entry = LedgerEntry(run_id="only-once")
-    store.write(entry)
+    the history a later feature counts settling runs from.
 
-    try:
-        store.write(entry)
-    except FileExistsError:
-        pass
-    else:  # pragma: no cover - the assertion below reports it
-        raise AssertionError("a second write to the same run id must be refused")
+    Asserts the file is untouched as well as the refusal — a store that raised
+    *after* truncating would pass a refusal-only test and still have destroyed
+    the record.
+    """
+    store = LedgerStore(tmp_path / "ledger")
+    original = LedgerEntry(run_id="only-once", calls_issued=3)
+    path = store.write(original)
+    before = path.read_bytes()
+
+    with pytest.raises(FileExistsError):
+        store.write(LedgerEntry(run_id="only-once", calls_issued=99))
+
+    assert path.read_bytes() == before
+    assert store.read("only-once").calls_issued == 3
+
+
+def test_the_ledger_records_how_many_model_calls_the_run_issued(tmp_path):
+    """`constraint-30`. The count is the whole point of the feature made visible:
+    a run that carried everything issued none, and one that carried nothing
+    issued the same number it always did."""
+    fresh, counting = _run(_TASK)
+    fresh_entry = _ledger_from(fresh, run_id="fresh")
+
+    assert fresh_entry.calls_issued == counting.decompose_calls
+    assert fresh_entry.calls_issued > 0
+
+    carried, _ = _run(_TASK, prior=fresh_entry)
+    carried_entry = _ledger_from(carried, run_id="carried")
+
+    assert carried_entry.calls_issued == 0
+
+
+def test_a_run_identifier_appears_in_no_rendered_report(tmp_path, monkeypatch, capsys):
+    """`constraint-23`. The report goes to stdout and must be byte-identical
+    across two runs over the same input; a randomly minted run id in it would
+    break that for every consumer that captures the report — which is how the
+    dogfood logs are made.
+
+    Driven through the CLI, because the property is about what the command
+    PRINTS, and asserting on a renderer in isolation would not catch a run id
+    added to the stdout stream around it.
+    """
+    from acceptance import cli
+
+    task = tmp_path / "task.md"
+    task.write_text(_TASK)
+    counting = _CountingClient(_TASK)
+    monkeypatch.setattr(cli.RunConfig, "build_client", lambda self: counting.client)
+
+    exit_code = cli.main(["decompose", "--task", str(task), "--mode", "record"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    run_id = re.search(r"^run ([0-9a-f]+)$", captured.err, re.MULTILINE).group(1)
+    assert run_id not in captured.out
+    # And it IS reported, on the stream that does not have to stay stable —
+    # otherwise this test would pass on a build that minted no run id at all.
+    assert f"--continue {run_id}" in captured.err
+
+
+def test_every_run_reports_an_identifier_for_itself(tmp_path, monkeypatch, capsys):
+    """`constraint-20` and `task-02`. Without it there is nothing to pass to
+    `--continue`, so the whole feature is unreachable from the command line."""
+    from acceptance import cli
+
+    task = tmp_path / "task.md"
+    task.write_text(_TASK)
+    counting = _CountingClient(_TASK)
+    monkeypatch.setattr(cli.RunConfig, "build_client", lambda self: counting.client)
+
+    cli.main(["decompose", "--task", str(task), "--mode", "record"])
+    first = capsys.readouterr().err
+
+    cli.main(["decompose", "--task", str(task), "--mode", "record"])
+    second = capsys.readouterr().err
+
+    ids = [re.search(r"^run ([0-9a-f]+)$", err, re.MULTILINE).group(1) for err in (first, second)]
+    assert all(ids)
+    # Distinct, because two runs over the same input are two runs. This is
+    # exactly why a run id cannot live in review state.
+    assert ids[0] != ids[1]
+
+
+def test_carry_forward_reads_only_the_run_it_was_told_to_continue(tmp_path, monkeypatch):
+    """`constraint-13`. A decoy entry holding the SAME requirements sits in the
+    store alongside the named one, so a store that scanned for a match — or took
+    the latest — would find it and carry from the wrong run.
+
+    Without the decoy this would pass on an implementation that ignored the run
+    id entirely and read whatever it found.
+    """
+    from acceptance import cli
+
+    task = tmp_path / "task.md"
+    task.write_text(_TASK)
+    ledger = LedgerStore(tmp_path / "ledger")
+    counting = _CountingClient(_TASK)
+    monkeypatch.setattr(cli.RunConfig, "build_client", lambda self: counting.client)
+
+    _, _, decoy = cli.run_decompose(str(task), cli.RunConfig(), ledger=ledger)
+    assert ledger.read(decoy).derived_count() > 0
+
+    # Naming nothing carries nothing, even though the decoy is right there and
+    # matches this task file exactly.
+    _, _, fresh = cli.run_decompose(str(task), cli.RunConfig(), ledger=ledger)
+
+    # Asserted on the LEDGER, not on a call count: this client is shared across
+    # both runs, so an identical request replays from its transcript store and
+    # issues no completion either way. What distinguishes the two is what each
+    # run recorded it did.
+    assert ledger.read(fresh).carried_count() == 0
+    assert ledger.read(fresh).derived_count() == len(ledger.read(decoy).derivations)
+    assert ledger.read(fresh).parent_run_id is None
+
+    # Named explicitly, the same store now carries — so the decoy was reachable
+    # all along and was ignored because it was not named.
+    _, _, continued = cli.run_decompose(
+        str(task), cli.RunConfig(), continue_from=decoy, ledger=ledger
+    )
+    assert ledger.read(continued).carried_count() == len(ledger.read(decoy).derivations)
+    assert ledger.read(continued).parent_run_id == decoy
+
+
+def test_a_new_requirement_is_derived_without_consulting_any_prior_obligation():
+    """`constraint-08` and `task-01`. A requirement with no counterpart has
+    nothing to anchor on, and showing it another requirement's obligations would
+    be an invitation to reuse an identifier that never meant this.
+
+    Asserted on the PROMPT: the revision block is what carries prior obligations
+    into a call, so a new requirement's call must not contain one.
+    """
+    first, _ = _run(_TASK)
+    prior = _ledger_from(first)
+    prior_obligation_ids = [
+        obligation.id for derivation in prior.derivations for obligation in derivation.obligations
+    ]
+    extended = _TASK.replace(
+        "- The run reports its own identifier.",
+        "- The run reports its own identifier.\n- The ledger is written once per run.",
+    )
+
+    second, counting = _run(extended, prior=prior)
+
+    added = [d for d in second.derivations if "written once per run" in d.text]
+    assert len(added) == 1
+    assert added[0].derivation is Derivation.DERIVED
+    assert added[0].carried_from is None
+    prompt = counting.prompts_for("_Decomposition")[0]
+    assert "PREVIOUSLY DERIVED" not in prompt
+    for obligation_id in prior_obligation_ids:
+        assert obligation_id not in prompt
+
+
+def test_the_residue_is_matched_through_the_alignment_helper():
+    """`constraint-10`. Only the residue needs a judgement, and this is the one
+    place a call is issued for it.
+
+    Observed off the client, because the outcome alone cannot distinguish "the
+    aligner matched them" from "the planner guessed by position" — and position
+    is exactly what identity must not be.
+    """
+    first, _ = _run(_TASK)
+
+    _, counting = _run(
+        _EDITED, prior=_ledger_from(first), alignment=[{"ground_truth": "g0", "reviewer": "r0"}]
+    )
+
+    assert [call["schema"] for call in counting.calls].count("_Alignment") == 1
+    prompt = counting.prompts_for("_Alignment")[0]
+    assert "The ledger is append-only." in prompt
+    assert "The ledger is only ever appended to." in prompt
+
+
+def test_the_alignment_helper_is_not_called_when_nothing_is_left_over():
+    """The other half: an unchanged task file matches entirely by exact text, so
+    the judgement is not needed and is not paid for."""
+    first, _ = _run(_TASK)
+
+    _, counting = _run(_TASK, prior=_ledger_from(first))
+
+    assert [call["schema"] for call in counting.calls].count("_Alignment") == 0
+
+
+def test_two_requirements_are_the_same_requirement_when_their_text_matches_exactly():
+    """`constraint-09`, on its own rather than through a carry.
+
+    The discriminating case is the id: this task file's edit shifts nothing, so a
+    positional identity would agree with a textual one and the test would prove
+    nothing. Inserting a bullet renames every later requirement in its section,
+    and textual identity has to survive that.
+    """
+    first, _ = _run(_TASK)
+    prior = _ledger_from(first)
+    with_insert = _TASK.replace(
+        "## Constraints\n", "## Constraints\n- The store refuses an overwrite.\n"
+    )
+
+    second, counting = _run(with_insert, prior=prior)
+
+    # Every original requirement carried, despite every constraint id shifting by
+    # one — matched on text, not on `constraint-NN`.
+    carried = [d for d in second.derivations if d.derivation is Derivation.CARRIED]
+    assert len(carried) == len(prior.derivations)
+    inserted = [d for d in second.derivations if "refuses an overwrite" in d.text]
+    assert len(inserted) == 1
+    assert inserted[0].derivation is Derivation.DERIVED
+    assert counting.decompose_calls == 1
 
 
 def test_the_ledger_is_not_written_under_the_cache(tmp_path):

--- a/tests/requirement/test_linking.py
+++ b/tests/requirement/test_linking.py
@@ -11,6 +11,7 @@ attributable.
 
 from __future__ import annotations
 
+from acceptance.requirement.ledger import LedgerStore
 from acceptance.requirement.linking import (
     _confirmed_clusters,
     _pairs,
@@ -537,7 +538,9 @@ def test_the_decompose_command_runs_the_linking_pass(tmp_path, monkeypatch):
         cli.RunConfig, "build_client", lambda self: client_dispatching({"_Decomposition": _DERIVED})
     )
 
-    result, _ = cli.run_decompose(str(task), cli.RunConfig())
+    result, _, _ = cli.run_decompose(
+        str(task), cli.RunConfig(), ledger=LedgerStore(tmp_path / "ledger")
+    )
 
     assert called == [2], "decompose must hand its derived obligations to the linking pass"
     assert len(result.obligations) <= 2
@@ -555,7 +558,9 @@ def test_the_decompose_command_surfaces_an_unreconciled_group(tmp_path, monkeypa
         cli.RunConfig, "build_client", lambda self: client_dispatching({"_Decomposition": _DERIVED})
     )
 
-    _, unusable = cli.run_decompose(str(task), cli.RunConfig())
+    _, unusable, _ = cli.run_decompose(
+        str(task), cli.RunConfig(), ledger=LedgerStore(tmp_path / "ledger")
+    )
 
     assert hasattr(unusable, "answers"), "decompose must carry the linking stage's log"
 

--- a/tests/requirement/test_requirement_map.py
+++ b/tests/requirement/test_requirement_map.py
@@ -713,13 +713,53 @@ def test_decompose_cannot_reach_a_diff_or_a_head_revision():
     """
     parameters = inspect.signature(decompose).parameters
 
-    assert list(parameters) == ["parsed", "client", "unusable_answers", "batch_size"]
+    # `prior` is a `LedgerEntry` — what a PREVIOUS DECOMPOSITION produced, which
+    # is the mandate's own history and nothing else (#269). It carries requirement
+    # text and the obligations derived from it; there is no diff, no repository
+    # and no revision anywhere in it. The guarantee this test exists for is
+    # unchanged: decomposition still cannot see the implementation it will later
+    # be used to judge.
+    assert list(parameters) == ["parsed", "client", "unusable_answers", "batch_size", "prior"]
     annotations = {name: str(p.annotation) for name, p in parameters.items()}
     forbidden = ("ChangeSet", "Path", "revision", "repo", "head")
     for name, annotation in annotations.items():
         assert not any(term.lower() in annotation.lower() for term in forbidden), (
             f"decompose's `{name}` parameter exposes change or repository context"
         )
+
+
+def test_the_ledger_entry_decompose_may_read_carries_no_implementation_context():
+    """The companion to the signature pin above, on the type rather than the name.
+
+    `prior` is the one input added to a deliberately code-blind stage, so what it
+    can hold is worth asserting rather than assuming. A field that reached a diff,
+    a revision or a path would reintroduce exactly what the signature test forbids
+    — through a nested model, where the signature check cannot see it.
+    """
+    from acceptance.requirement.ledger import LedgerEntry, RequirementDerivation
+
+    # "revision" is deliberately absent from the NAME terms and present in the
+    # TYPE terms. `revision_reason` is why a REQUIREMENT was re-asked — its old
+    # wording — and the word is the right one for that. A git revision would
+    # arrive as a `ChangeSet`, a `Path` or a field named for the repository, and
+    # those are what these lists catch.
+    forbidden_names = ("changeset", "repo", "diff", "commit", "sha", "head", "base")
+    forbidden_types = ("ChangeSet", "Path", "Repo", "Diff", "revision")
+    for model in (LedgerEntry, RequirementDerivation):
+        for name, field in model.model_fields.items():
+            annotation = str(field.annotation)
+            assert not any(term in name.lower() for term in forbidden_names), (
+                f"{model.__name__}.{name} names change or repository context"
+            )
+            assert not any(term.lower() in annotation.lower() for term in forbidden_types), (
+                f"{model.__name__}.{name} is typed with change or repository context"
+            )
+
+    # And the one ambiguous name is pinned to its meaning, so a later edit cannot
+    # quietly repurpose it into the git sense the lists above would then miss.
+    described = RequirementDerivation.model_fields["revision_reason"].description or ""
+    assert "old wording" in described
+    assert "never a git revision" in described
 
 
 def test_the_prompt_carries_identified_requirements_not_raw_markdown():


### PR DESCRIPTION
Closes #269. Fixes the mechanism behind #193.

Decomposition was a pure function of the task text, so one edited character re-derived all of it and re-minted every identifier. `rerun.py` stated the rule outright: *a changed task invalidates everything.* #191 measured the cost — three runs over one unchanged task file differing only by seed produced **38 distinct criterion wordings across ~20 criteria**, 8 appearing in all three and 23 in exactly one, with **zero obligation content difference**. Criterion text is the prompt for every later stage, so that churn floors every downstream stability number. It is not model nondeterminism: the same prompt at temperature 0 returned byte-identical output three times. What moved was which request the model got.

## What this does

Per requirement: unchanged text is **carried** with no model call, edited text is **revised** in one call carrying the old text, the new text and the prior obligations, a new requirement is **derived** fresh, and a disappeared one has its obligations **dropped and reported**. The same rule for linking: a merge decision over two unchanged obligations carries; either side changing puts the pair back in front of the model.

**Identity is the requirement's exact text, never its id.** Ids are `section-ordinal`, so inserting one bullet renames every later requirement in its section while changing none of them. Exact matching is free and needs no call — which is what makes the unchanged case cost nothing. Only the residue, telling *edited* from *new*, needs a judgement, and that is the one call the planner issues.

**The ledger is both the log and the carry-forward store**, because it had to be: `ReviewStore` overwrites one file per revision, an uncommitted run keys on the literal `<working-tree>` string so the Gate 1 loop keeps no history at all, and `decompose` never builds a `Review` on that path. One file per run, never rewritten, outside `.acceptance/cache/` so a cache clear cannot take it (DR-259 lost two runs that way).

**Runs are identified by a run id with a parent pointer**, not a lineage id echoed forward. One file per run already needs a unique key, so making the continuation token *be* that key removes the second identifier — and a shared lineage id would need "the latest run in the lineage" to select a prior, which needs ordering, which needs wall-clock. A parent pointer never reads time at all.

## Two deliberate divergences from the issue

**`carried_from` holds a content digest, not a run id** (Deliverable 4 says the run id). A randomly minted id in review state would make two runs over the same input differ in their bytes and break M0.5 — the same reason `Review` carries no timestamp. Run ids stay in the ledger, the ledger filename and stderr; stdout is untouched.

**The carry key excludes registry context** — `docs/DR-269-carry-key-excludes-registry-context.md`. The mandate says an entry is carried only when re-deriving it would issue the same request key, and that cannot be implemented literally: the prompt carries the whole registry (#178), so any edit moves every requirement's key and per-requirement carry-forward becomes dead code — `constraint-04`'s edited path could never coexist with a carried one. The cost is real and stated: an unchanged requirement whose meaning is altered by an edit elsewhere keeps its old obligations. That suppression is the stability being bought, and it is reversible in one line.

A fresh run's prompt is byte-identical to what this stage issued before, because the revision block is appended only when a call answers for a revised requirement. Every recorded transcript still replays.

## Gate 2 is not clean, and this lands anyway

On the precedent #271 set explicitly, with its condition met: **every outstanding finding is attributable to a tool defect, not to this delivery.**

Six runs. Every finding was fixed or attributed:

| finding | run | disposition |
|---|---|---|
| `schema-change-blocks-carry-forward` unsupported | 1 | fixed — two tests, both injections confirmed |
| `revised-requirement-records-revision-reason` unsupported | 2 | **a defect, not a missing test** — a revised requirement's disposition reported `derived` with no reason, indistinguishable from a genuinely new one. Fixed by `_stamp_revisions` |
| whole-review abort, no report rendered | 3 | tool defect — fixed independently by #279 |
| nine evidence gaps | 4 | all nine fixed |
| **ratings collapsed 37 → 4 strongly supported** | 5 | tool defect — filed on **#251** |
| `completion-10` unsupported | 4 | fixed in run 6 |

**Run 5 is the one to read.** It differs from run 4 by a commit that adds nine tests and changes no source file, and `strongly supported` fell from 37 to 4. `unchanged-task-file-no-decompose-call` cites a strict *superset* of run 4's tests and drops a tier. That is on #251, which already describes the defect and cites two smaller instances.

**What this means for the merge, stated plainly:** with 4 of 60 obligations rated strongly supported, run 6 cannot distinguish a good delivery from a bad one. The evidence this rests on is **run 4's** reading — every obligation addressed, 15 evidence gaps, nine now closed and one of them `completion-10`. Logs and judgements for all six runs are on `main` under `dogfood-logs/269-gate2-run1..6/`.

## Verification

**1365 tests pass**; `ruff check` and `ruff format` clean. 47 new tests in `tests/requirement/test_carry_forward.py`.

Defect injection, each confirmed to fail the tests that claim to catch it:

- forcing `plan_carry` to carry nothing → 13 tests fail
- switching identity from requirement **text** to requirement **id**, the plausible wrong implementation → all six corpus pairs fail
- hashing a constant instead of the live response schema → the wiring test fails, the behavioural one does not (which is why both exist)
- dropping the carry-key comparison → all four invalidation tests fail

`completion-10` is asserted over the real corpus: all six consecutive pairs of `tests/fixtures/decompose-stability/`, with no model call, since carrying a requirement whose text changed is the precise and singular way carry-forward could freeze the corpus's recorded movements in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
