### PR TITLE
Record how a change could fail a criterion, before any test is looked at

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,64 +1,63 @@
 # Task
-Every requirement of a mandate is accounted for on its own, and an obligation
-quotes the requirement it came from. The mandate's opening summary is accounted
-for last, against the obligations the rest of the mandate already produced, so
-that a property the rest of the mandate states does not become a second
-obligation and a property only the summary states is not lost.
+Before any test is looked at, the review records — for each criterion it derived
+from the mandate — the concrete ways the delivered code could plausibly fail that
+criterion.
 
 ## Constraints
-- A requirement other than the opening summary is accounted for by a step asked
-  about that requirement alone, and that step returns exactly one account of it.
-- The quotation an obligation carries is chosen from the text of the requirement
-  its step was asked about, so a quotation belonging to a different requirement
-  cannot be given.
-- No step that accounts for a requirement other than the opening summary is
-  asked to account for the opening summary.
-- The opening summary is accounted for by a step that first divides it into
-  stretches of its own words and then decides, for each stretch, whether the
-  obligations already derived from the rest of the mandate require the same
-  thing.
-- Every stretch is a substring of the opening summary, and every stretch is
-  decided exactly once.
-- A stretch the already-derived obligations require yields no obligation.
-- A stretch they do not require yields obligations, derived by a step asked
-  about that stretch alone.
-- The step that decides whether a stretch is already required yields no
-  obligations itself.
-- An obligation derived from a stretch carries that stretch as its quotation,
-  taken from the mandate rather than from the answer that named it.
-- A step may name the model it runs on; a step that names none uses the run's
-  own model.
-- A completed run says which model each step used.
-- Where a step tells the answering party what order its request presents its
-  parts in, that statement is true of the request as sent.
+- Each recorded way of failing carries an identifier unique within the review,
+  the criterion it belongs to, a classification, a free-text description, and the
+  regions of changed source it implicates.
+- Every other part of the review that names a recorded way of failing names it by
+  that identifier, and does not restate its content.
+- A classification is either a value from a fixed vocabulary or a single escape
+  value meaning the vocabulary has no value for this way of failing.
+- The recorded ways of failing persist with the rest of the review's state, and a
+  review reloaded from storage carries them unchanged.
+- The step that produces them is given the criterion and the changed source, and
+  is given no test.
+- That step is guided by a checklist of ways to fail chosen by the criterion's
+  type, and may still record a way of failing that no entry on that checklist
+  names.
+- Recording no way of failing for a criterion is a valid result for that
+  criterion, and carries the reason the set is empty.
+- A criterion's set of records is reused rather than produced again exactly while
+  both that criterion's text and the contents of the source regions its records
+  implicate are unchanged.
+- A criterion whose text changed has its entire set produced again, and keeps no
+  part of the set recorded for it before.
+- A run continuing an earlier run reuses every set it is entitled to reuse.
+- A run continuing an earlier run produces again only the sets it is not
+  entitled to reuse.
+- Where a set was reused rather than produced again, the review says so.
+- The review reports the recorded ways of failing.
+- Whether the review reports the work complete, and every rating it gives a
+  criterion, are what they would be if no way of failing had been recorded at
+  all.
 
 ## Scope exclusions
-- Which text in the mandate counts as a requirement, and how many requirements
-  are found.
-- Whether the obligations derived for a requirement are the right ones for it.
-- What the review does with an answer it cannot read at all.
-- Combining obligations that state the same thing as one another.
-- Which model is the right one for any step, and what any step costs.
-- Comparing figures recorded before this change with figures recorded after it.
+- Judging whether any test would fail if the delivered code contained a recorded
+  way of failing.
+- Deriving any rating, classification or conclusion about a criterion from its
+  recorded ways of failing.
+- Which criteria the review derives from the mandate, and how it derives them.
+- How the review gathers, judges or rates test evidence today.
+- Running the delivered code, and altering it to produce a failure.
+- Comparing a recorded set against an expected set supplied from outside the
+  review.
 
 ## Completion expectations
 - Implementation.
-- A test fails when a step accounting for a requirement other than the opening
-  summary is asked about more than that one requirement.
-- A test fails when an obligation carries a quotation belonging to a requirement
-  its step was not asked about.
-- A test fails when a step that accounts for a requirement other than the
-  opening summary is asked to account for the opening summary.
-- A test fails when a stretch of the opening summary is decided more than once,
-  or is left undecided, or is not a substring of the opening summary.
-- A test fails when a stretch the already-derived obligations require yields an
-  obligation.
-- A test fails when a stretch they do not require yields none.
-- A test fails when an obligation derived from a stretch carries a quotation
-  other than that stretch.
-- A test fails when a step naming its own model is run on the run's model
-  instead.
-- A test exercises the whole path from the mandate through to the obligations
-  produced, not any one step alone.
+- A test asserts that the step that records ways of failing is given no test.
+- A test fails when a criterion with no plausible way of failing is given an
+  invented one instead of an empty set carrying its reason.
+- A test fails when a set is produced again across two continued runs although
+  the criterion's text and the contents of its implicated source regions are both
+  unchanged.
+- A test fails when a criterion whose text changed keeps any part of the set
+  recorded for it before.
+- A test asserts that changing one criterion's text leaves every other
+  criterion's set reused rather than produced again.
+- A test fails when recording ways of failing changes the review's completion
+  conclusion or any criterion's rating.
 - Two recorded runs over the same input produce byte-identical review state and
   byte-identical report output.

--- a/src/acceptance/benchmark/alignment.py
+++ b/src/acceptance/benchmark/alignment.py
@@ -16,6 +16,13 @@ unmatched and correctly costs precision.
 
 This is benchmark *measurement* infrastructure — it runs against known ground
 truth, not in the product's own review path.
+
+One exception, and it is why `stage` is a parameter rather than a constant here:
+`requirement/carry.py` reuses this function to match a reworded requirement to
+the prior run's wording. That call is part of a review, so its spend has to be
+attributed like any other (#264), and only the caller knows which stage it
+belongs to. A benchmark caller passes nothing and stays out of the review's
+per-stage footer, which is where it belongs.
 """
 
 from __future__ import annotations
@@ -61,6 +68,7 @@ def align_obligations(
     ground_truth_descriptions: list[str],
     reviewer_descriptions: list[str],
     client: ModelClient,
+    stage: str | None = None,
 ) -> dict[str, str]:
     """Return a `reviewer_description -> ground_truth_description` map for
     semantically-equivalent criteria (a bijection over the matched subset)."""
@@ -74,7 +82,7 @@ def align_obligations(
         {"role": "system", "content": _SYSTEM_PROMPT},
         {"role": "user", "content": _render_prompt(gt_labels, rv_labels)},
     ]
-    result = client.complete(messages, _Alignment)
+    result = client.complete(messages, _Alignment, stage=stage)
 
     alignment: dict[str, str] = {}
     used_gt: set[str] = set()

--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -205,7 +205,7 @@ def run_check(
     )
     store.write(review)
     if ledger is not None and sink:
-        derived, linked = sink[0]
+        derived, linked, defect_sets = sink[0]
         ledger.write(
             build_ledger_entry(
                 derived,
@@ -213,6 +213,7 @@ def run_check(
                 parent_run_id=continue_from,
                 task_digest=task_digest(task_text),
                 linked=linked,
+                defect_sets=defect_sets,
             )
         )
     return review

--- a/src/acceptance/defects/__init__.py
+++ b/src/acceptance/defects/__init__.py
@@ -1,0 +1,16 @@
+"""Defect enumeration: the ways a change could plausibly fail an obligation.
+
+The first stage of the defect-first evidence shape (#312, #313). It runs before
+any test is looked at and produces a set of typed, identified `Defect` records
+per obligation — the denominator a later stage maps tests onto.
+
+Advisory in this milestone: nothing here changes a verdict or an obligation's
+rating. That is deliberate (DR-312 decision 5). Landing enumeration alongside
+the existing mapping/discrimination/strength chain rather than in place of it is
+what makes a rating movement attributable to one cause instead of three.
+"""
+
+from acceptance.defects.enumeration import enumerate_defects
+from acceptance.defects.taxonomy import CHECKLIST, checklist_for, enumerable
+
+__all__ = ["CHECKLIST", "checklist_for", "enumerable", "enumerate_defects"]

--- a/src/acceptance/defects/enumeration.py
+++ b/src/acceptance/defects/enumeration.py
@@ -1,0 +1,428 @@
+"""Enumerate the ways the changed code could plausibly fail each obligation.
+
+The first stage of the defect-first shape (#312, #313), and the one place the
+whole design's premise is enforced: **this stage is never shown a test.**
+
+That is the mitigation for #252. A denominator chosen by something that can see
+what is already covered drifts toward it — enumerate the defects the tests
+already catch, and a thin enumeration earns a strong rating. So the change set
+this stage renders is filtered to non-test files before it reaches the prompt,
+in code, rather than by asking the model not to look.
+
+One call per obligation. Batching would put the checklist for one obligation
+type in front of an obligation of another, and #317 measured what happens when a
+call is shown several units and asked about one: it answers for the others. A
+per-obligation call also makes the carry unit and the request unit the same
+thing, so a reworded obligation re-enumerates exactly itself.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from acceptance.carry import carry_key, decide
+from acceptance.coverage.prompt import diff_block, hunk_label, hunk_labels
+from acceptance.defects.taxonomy import DESCRIPTIONS, checklist_for, enumerable
+from acceptance.llm import ModelClient, StrictResponseModel
+from acceptance.partition import partition
+from acceptance.request_blocks import Block, BlockKind, assemble
+from acceptance.review_state import (
+    ChangeSet,
+    Defect,
+    DefectSet,
+    DefectType,
+    Obligation,
+)
+from acceptance.serialization import canonical_json
+from acceptance.supplied_ids import UnusableAnswerLog, constrain, scan
+
+__all__ = [
+    "DEFECT_STAGE_LOGIC_VERSION",
+    "ONE_OBLIGATION_PER_CALL",
+    "enumerate_defects",
+    "non_test_changes",
+    "region_digests_for",
+]
+
+_STAGE = "defect enumeration"
+
+# Bumped when the code that turns a response into a `DefectSet` changes in a way
+# the request key cannot see — a different id scheme, a changed empty-set rule.
+# The request key covers the prompt and the schema; this covers everything after
+# the response comes back (`acceptance.carry`, check 3).
+DEFECT_STAGE_LOGIC_VERSION = 1
+
+# One obligation per call. Stated as a partition size rather than a bare loop so
+# the size lands in the request key: a recording made under batching must not
+# replay as though nothing had moved (#154).
+ONE_OBLIGATION_PER_CALL = 1
+
+_SYSTEM_PROMPT = """\
+You are given ONE acceptance criterion and the changed production code of a
+proposed implementation. Enumerate the concrete ways that code could plausibly
+FAIL that criterion.
+
+You are enumerating candidate defects, not judging whether any of them is
+present. Each one is a specific, checkable claim about what could be wrong —
+something a reader could go and look for in the code you were shown.
+
+Walk the checklist you are given, in order, and ask of each entry: could the
+delivered code fail this criterion in that way? Record one defect for each way
+that is genuinely plausible given the code in front of you. The checklist is a
+prompt for your attention, not a quota: skip an entry that does not apply.
+
+Where a plausible way of failing fits no entry on the checklist, record it with
+type `other` and say what it is in the description. Do not force a defect into
+the nearest entry.
+
+DESCRIPTIONS
+
+Write each description as the failure, not as the requirement. "The rate is
+computed from a 30-day month, so February is wrong" — not "the rate must be
+computed correctly". A reader must be able to tell what to go and check.
+
+Give each defect a short `slug`: lowercase words joined by hyphens, naming the
+specific failure. It is a label, not a sentence.
+
+CODE REFERENCES
+
+`code_refs` are the labels (like `path#0`) of the changed regions the defect
+would live in. Cite the regions a reader would have to inspect to tell whether
+the defect is present. Leave it empty only when the defect is about code that is
+ABSENT from the change — a case the criterion covers and the diff never touches.
+
+AN EMPTY SET IS A REAL ANSWER
+
+Some criteria have no plausible static defect. A criterion satisfied by
+construction — one the delivered shape makes true, so that no code path could
+violate it — earns no defect, and saying so is the correct answer.
+
+When you return no defects, `reason` MUST say why the set is empty, specifically
+enough that a reader can disagree with it. When you return defects, leave
+`reason` empty.
+
+Never invent a defect to avoid returning an empty set. A made-up defect is worse
+than an empty one: it will be counted in a denominator, and the criterion will
+look better tested than it is."""
+
+
+class _Defect(StrictResponseModel):
+    slug: str
+    # `str`, not `DefectType`, so `constrain` can narrow it to this obligation's
+    # own checklist. Declaring the enum here would offer every defect type to
+    # every obligation and leave the checklist as advice in the prompt; narrowing
+    # a string field to exactly the permitted values is what makes an off-
+    # checklist type unrepresentable. Converted back to `DefectType` in
+    # `_defects_from`, which is where an unconvertible value is reported.
+    type: str
+    description: str
+    code_refs: list[str]
+
+
+class _Enumeration(StrictResponseModel):
+    obligation_id: str
+    defects: list[_Defect]
+    reason: str
+
+
+def non_test_changes(change_set: ChangeSet) -> ChangeSet:
+    """`change_set` with every test-category file removed.
+
+    The enumerator's test-blindness, enforced where it cannot be talked out of:
+    a filtered change set has nothing to leak. Asking the prompt to ignore the
+    tests would leave the tests in the request, one instruction away from being
+    read — and #252 is about a denominator that drifts, which is exactly the
+    failure an instruction cannot rule out.
+
+    `ignored_paths` is carried through unchanged. It records what the reviewed
+    repo's own ignore rules excluded, which is a fact about the change set
+    rather than about this stage's view of it.
+    """
+    return change_set.model_copy(
+        update={"files": [file for file in change_set.files if file.category != "test"]}
+    )
+
+
+def region_digests_for(change_set: ChangeSet, labels: list[str]) -> dict[str, str]:
+    """Content digest of each named `path#hunk` region of `change_set`.
+
+    A label naming no region in this change set is omitted rather than recorded
+    as absent, and that is the conservative direction: an omitted region makes
+    the recomputed key differ from the stored one, so the set re-enumerates. The
+    alternative — a sentinel for "gone" — would let a set whose implicated code
+    was DELETED compare equal and carry forward over nothing.
+    """
+    by_label = {}
+    for file_change in change_set.files:
+        for index, hunk in enumerate(file_change.hunks):
+            by_label[hunk_label(file_change.path, index)] = hunk.content
+    return {
+        label: hashlib.sha256(by_label[label].encode("utf-8")).hexdigest()
+        for label in sorted(set(labels))
+        if label in by_label
+    }
+
+
+def _key(
+    client: ModelClient,
+    obligation: Obligation,
+    text: str,
+    region_digests: dict[str, str],
+) -> str:
+    """What a stored defect set is valid under.
+
+    The criterion's text and the CONTENTS of the regions its defects implicate —
+    the mandate's rule stated exactly: a set is reused while both are unchanged.
+    Not which files were touched: #293 deleted that comparison because it fires
+    when a byte-identical region moves within a file.
+
+    **The UNCONSTRAINED schema, deliberately.** The schema this stage actually
+    sends carries two per-call enum sets — the criterion's own id, and every
+    hunk label in the change set — and folding either into this key would break
+    the rule above. The id would re-enumerate a criterion that was only renamed,
+    which is exactly what carrying on text exists to avoid; the hunk labels
+    would re-enumerate every criterion whenever any unrelated file gained a
+    hunk. What the key needs from the schema is its SHAPE, which is what moves
+    when the response model changes.
+
+    The checklist is named instead, because it is what the per-call `type` enum
+    would otherwise have contributed: a criterion whose checklist changed must
+    re-enumerate, and nothing else in this key would notice.
+    """
+    return carry_key(
+        system_prompt=_SYSTEM_PROMPT,
+        response_schema=_Enumeration.model_json_schema(),
+        model=client.model_for(_STAGE),
+        temperature=client.temperature,
+        seed=client.seed,
+        stage_logic_version=DEFECT_STAGE_LOGIC_VERSION,
+        inputs={
+            "obligation_text": text,
+            "checklist": [t.value for t in checklist_for(obligation.type)],
+            "region_digests": region_digests,
+        },
+    )
+
+
+def obligation_text(obligation: Obligation) -> str:
+    """The identity a defect set is carried on.
+
+    Both fields the enumerator is shown, and only those. Adding a field the
+    prompt never renders would re-enumerate on a change that could not have
+    altered the answer; leaving one out would carry a set across a change that
+    could.
+    """
+    return canonical_json(
+        {
+            "description": obligation.description,
+            "observable_behavior": obligation.observable_behavior,
+        }
+    )
+
+
+def _subject(obligation: Obligation) -> str:
+    """The one call's own content: the criterion, and its checklist."""
+    lines = [
+        "## Criterion",
+        "",
+        f"id={obligation.id} [{obligation.type.value}]",
+        f"description: {obligation.description}",
+        f"observable behaviour: {obligation.observable_behavior}",
+        "",
+        "## Checklist",
+        "",
+    ]
+    for defect_type in checklist_for(obligation.type):
+        lines.append(f"- {defect_type.value}: {DESCRIPTIONS[defect_type]}")
+    lines.append("- other: a plausible way of failing that no entry above names")
+    return "\n".join(lines)
+
+
+def _defects_from(
+    result: _Enumeration, obligation: Obligation, label_to_ref: dict[str, object]
+) -> list[Defect]:
+    """Turn one answer into identified `Defect` records.
+
+    Ids are composed here rather than taken from the answer. The mandate wants
+    an identifier unique within the review, and a model-chosen slug cannot carry
+    that guarantee across obligations — two criteria about the same code invite
+    the same slug. Prefixing with the obligation id makes uniqueness structural,
+    and the numeric suffix settles a collision inside one answer.
+    """
+    defects: list[Defect] = []
+    seen: set[str] = set()
+    for entry in result.defects:
+        base = f"{obligation.id}/{entry.slug}"
+        defect_id = base
+        suffix = 2
+        while defect_id in seen:
+            defect_id = f"{base}-{suffix}"
+            suffix += 1
+        seen.add(defect_id)
+        defects.append(
+            Defect(
+                id=defect_id,
+                obligation_id=obligation.id,
+                type=_defect_type(entry.type),
+                description=entry.description,
+                code_refs=[ref for ref in entry.code_refs if ref in label_to_ref],
+            )
+        )
+    return defects
+
+
+def _defect_type(value: str) -> DefectType:
+    """The returned type, or the escape when it is not one this vocabulary has.
+
+    Unreachable through the schema, which offers only the checklist's own values
+    plus `other`. Kept because the defect is still worth having if it happens:
+    `scan` records the off-list value in the unusable-answer log, which surfaces
+    as a finding, so the event is visible rather than silent — while dropping the
+    defect entirely, or raising, would lose a real observation over a label.
+    """
+    try:
+        return DefectType(value)
+    except ValueError:
+        return DefectType.OTHER
+
+
+def enumerate_defects(
+    obligations: list[Obligation],
+    change_set: ChangeSet,
+    client: ModelClient,
+    unusable: UnusableAnswerLog | None = None,
+    prior: list[DefectSet] | None = None,
+) -> list[DefectSet]:
+    """One `DefectSet` per enumerable obligation, in the order given.
+
+    An obligation whose type is not enumerable gets **no entry at all** — not an
+    empty one. `test_demand` and `human_review` are excluded by DR-313 decision
+    2, and an empty set means "looked, found nothing plausible, here is why".
+    Recording that about an obligation this stage never examined would be a
+    false negative wearing a reason.
+
+    With `prior`, a set whose obligation text and implicated region contents are
+    both unchanged is reused and no call is issued for it.
+    """
+    visible = non_test_changes(change_set)
+    label_to_ref = hunk_labels(visible)
+    prior_by_text = {entry.obligation_text: entry for entry in (prior or [])}
+    asking = [o for o in obligations if enumerable(o.type)]
+    order = {o.id: index for index, o in enumerate(asking)}
+
+    sets: list[DefectSet] = []
+    for obligation in asking:
+        text = obligation_text(obligation)
+        candidate = prior_by_text.get(text)
+        constrained = constrain(_Enumeration, _allowed(obligation, label_to_ref))
+        # Against the regions the STORED set implicates, because the question is
+        # whether that set is still valid. Computing it over this run's regions
+        # would be circular: they are not known until the call this check exists
+        # to avoid has already been made.
+        current = _key(client, obligation, text, region_digests_for(visible, _labels(candidate)))
+        decision = decide(
+            obligation.id,
+            prior=candidate,
+            prior_key=candidate.carry_key if candidate else None,
+            current_key=current,
+        )
+        if decision.carried:
+            # Re-identified onto this run's obligation id, which may differ from
+            # the one the set was recorded under: the carry matched on text.
+            # Everything else is the stored answer, untouched.
+            carried = candidate.model_copy(
+                update={
+                    "obligation_id": obligation.id,
+                    "defects": [
+                        defect.model_copy(update={"obligation_id": obligation.id})
+                        for defect in candidate.defects
+                    ],
+                    "carried_from": candidate.carry_key,
+                }
+            )
+            sets.append(carried)
+            continue
+        sets.append(
+            _ask_about(obligation, visible, label_to_ref, constrained, client, unusable, text)
+        )
+
+    return sorted(sets, key=lambda entry: order[entry.obligation_id])
+
+
+def _allowed(obligation: Obligation, label_to_ref: dict) -> dict[str, list[str]]:
+    """What this call's answer may say, as the enum sets folded into its schema.
+
+    `type` is the one that carries the guarantee. Restricted to this obligation
+    type's own checklist plus the escape, a defect typed against a different
+    obligation type's checklist is unrepresentable rather than filtered
+    afterwards — the standard DR-163 set, and what #317 showed is worth more
+    than a check applied to the answer.
+    """
+    return {
+        "obligation_id": [obligation.id],
+        "type": [t.value for t in checklist_for(obligation.type)] + [DefectType.OTHER.value],
+        "code_refs": list(label_to_ref),
+    }
+
+
+def _labels(candidate: DefectSet | None) -> list[str]:
+    """The regions a stored set implicates, which is what its key was built over.
+
+    Read off the stored `region_digests` rather than off its defects' `code_refs`
+    so that a stored set and the key recomputed against it always cover the same
+    regions, even if the two ever disagree.
+    """
+    return list(candidate.region_digests) if candidate else []
+
+
+def _ask_about(
+    obligation: Obligation,
+    visible: ChangeSet,
+    label_to_ref: dict,
+    constrained: type[_Enumeration],
+    client: ModelClient,
+    unusable: UnusableAnswerLog | None,
+    text: str,
+) -> DefectSet:
+    """One call, about `obligation` alone, over the test-free change set.
+
+    `constrained` is passed in rather than rebuilt: the carry check above needs
+    the same schema to compute the same key, and two constructions of it are two
+    things that can drift apart.
+    """
+    messages = assemble(
+        [
+            diff_block(visible),
+            Block(BlockKind.INSTRUCTIONS, _SYSTEM_PROMPT),
+            Block(BlockKind.SUBJECT, _subject(obligation)),
+        ]
+    )
+    allowed = _allowed(obligation, label_to_ref)
+    batch = partition([obligation], ONE_OBLIGATION_PER_CALL, key=lambda o: o.id)[0]
+    result = client.complete(
+        messages,
+        constrained,
+        batch.request_partition(),
+        parse_as=_Enumeration,
+        stage=_STAGE,
+    )
+    if unusable is not None:
+        unusable.record(scan(result, allowed, _STAGE))
+
+    defects = _defects_from(result, obligation, label_to_ref)
+    # An answer with neither defects nor a reason is not an empty set, it is a
+    # non-answer. Saying so keeps "no plausible static defect, and here is why"
+    # distinguishable from a stage that returned nothing (#275's shape).
+    reason = result.reason.strip()
+    if not defects and not reason:
+        reason = "The enumeration returned no defects and gave no reason for the empty set."
+    implicated = [ref for defect in defects for ref in defect.code_refs]
+    digests = region_digests_for(visible, implicated)
+    return DefectSet(
+        obligation_id=obligation.id,
+        defects=defects,
+        reason="" if defects else reason,
+        obligation_text=text,
+        carry_key=_key(client, obligation, text, digests),
+        region_digests=digests,
+    )

--- a/src/acceptance/defects/taxonomy.py
+++ b/src/acceptance/defects/taxonomy.py
@@ -1,0 +1,144 @@
+"""Which defect types the enumerator is walked through, per obligation type.
+
+The contents are `docs/DR-313-defect-taxonomy.md`; the reasoning for the shape
+is DR-312's resolved question 4. Two things about it are load-bearing and easy
+to undo by accident:
+
+**The list is short on purpose.** Six entries per obligation plus the `other`
+escape. A checklist earns its keep by driving recall, and a twenty-item list
+walked for every obligation dilutes the prompt and invites odd defects being
+forced into the nearest slot — the failure mode DR-312 names.
+
+**Two obligation types get no checklist, and that is not the same as an empty
+one.** `HUMAN_REVIEW` exists because a machine cannot settle the question, and
+`TEST_DEMAND` because DR-313 decision 2 excludes it: the enumerator may never
+see the tests (the #252 mitigation), and a `test_demand` obligation is *about*
+a test. `enumerable` is the predicate; an obligation it rejects gets no defect
+set at all, which downstream must keep distinct from an empty set.
+"""
+
+from __future__ import annotations
+
+from acceptance.review_state import DefectType, ObligationType
+
+__all__ = ["CHECKLIST", "CORE", "DESCRIPTIONS", "checklist_for", "enumerable"]
+
+# Walked for every enumerable obligation type, whatever it is.
+CORE: tuple[DefectType, ...] = (
+    DefectType.QUALIFIER_IGNORED,
+    DefectType.CONDITION_INVERTED,
+    DefectType.SCOPE_TOO_NARROW,
+    DefectType.NOT_WIRED,
+)
+
+# Added to CORE for the obligation type that names them. An obligation type
+# absent from this mapping is one `enumerable` rejects.
+_BY_TYPE: dict[ObligationType, tuple[DefectType, ...]] = {
+    ObligationType.FUNCTIONAL: (
+        DefectType.WRONG_OUTPUT_SHAPE,
+        DefectType.MISSING_CASE,
+    ),
+    ObligationType.BOUNDARY: (
+        DefectType.BOUNDARY_WRONG_SIDE,
+        DefectType.BOUNDARY_UNHANDLED,
+    ),
+    ObligationType.ERROR_HANDLING: (
+        DefectType.ERROR_SWALLOWED,
+        DefectType.WRONG_ERROR_SURFACED,
+    ),
+    ObligationType.INVARIANT: (
+        DefectType.ESTABLISHED_NOT_MAINTAINED,
+        DefectType.UNENFORCED_ON_ONE_PATH,
+    ),
+    ObligationType.REGRESSION: (
+        DefectType.PRIOR_BEHAVIOR_ALTERED,
+        DefectType.PRIOR_BEHAVIOR_REMOVED,
+    ),
+    ObligationType.COMPATIBILITY: (
+        DefectType.OLD_INPUT_REJECTED,
+        DefectType.STORED_FORM_UNREADABLE,
+    ),
+    ObligationType.EXPLANATION_OBSERVABILITY: (
+        DefectType.EXPLANATION_ABSENT,
+        DefectType.EXPLANATION_STATES_WRONG_CAUSE,
+    ),
+    ObligationType.DOCS_CONFIG: (
+        DefectType.DOCUMENTED_NOT_IMPLEMENTED,
+        DefectType.DEFAULT_DISAGREES_WITH_DOCS,
+    ),
+}
+
+# What each type means, rendered into the enumerator's prompt. A checklist of
+# bare slugs is a list of words to pattern-match; a checklist of sentences is
+# something to walk. `OTHER` is described where the prompt introduces it, since
+# what it means is "none of the above" rather than a failure of its own.
+DESCRIPTIONS: dict[DefectType, str] = {
+    DefectType.QUALIFIER_IGNORED: (
+        "the behaviour is implemented but a qualifier the obligation states — "
+        "only, at most, when X, except Y — is not honoured"
+    ),
+    DefectType.CONDITION_INVERTED: "a guard or comparison runs the wrong way round",
+    DefectType.SCOPE_TOO_NARROW: (
+        "the behaviour holds for some of the inputs the obligation covers but not all of them"
+    ),
+    DefectType.NOT_WIRED: (
+        "the logic exists and is correct, but nothing on the delivered path calls it"
+    ),
+    DefectType.WRONG_OUTPUT_SHAPE: (
+        "the right value is produced in the wrong form — type, units, ordering, nesting"
+    ),
+    DefectType.MISSING_CASE: "an input the obligation covers falls through unhandled",
+    DefectType.BOUNDARY_WRONG_SIDE: (
+        "the boundary is off by one, or inclusive where it should be exclusive"
+    ),
+    DefectType.BOUNDARY_UNHANDLED: "the extreme value itself is not handled at all",
+    DefectType.ERROR_SWALLOWED: "the failure is caught and discarded, so the caller cannot see it",
+    DefectType.WRONG_ERROR_SURFACED: (
+        "a failure is reported, but as the wrong kind, or naming the wrong cause"
+    ),
+    DefectType.ESTABLISHED_NOT_MAINTAINED: (
+        "the invariant holds when first set up but is not preserved by later operations"
+    ),
+    DefectType.UNENFORCED_ON_ONE_PATH: (
+        "the invariant is enforced on one route into the code and not on another"
+    ),
+    DefectType.PRIOR_BEHAVIOR_ALTERED: "behaviour that was meant to stay the same has changed",
+    DefectType.PRIOR_BEHAVIOR_REMOVED: "behaviour that was meant to stay is gone entirely",
+    DefectType.OLD_INPUT_REJECTED: "input the previous version accepted is now refused",
+    DefectType.STORED_FORM_UNREADABLE: "data written by the previous version can no longer be read",
+    DefectType.EXPLANATION_ABSENT: "the situation arises but nothing is said about it",
+    DefectType.EXPLANATION_STATES_WRONG_CAUSE: (
+        "something is said, but it names a cause that is not the real one"
+    ),
+    DefectType.DOCUMENTED_NOT_IMPLEMENTED: (
+        "the documented behaviour and the delivered behaviour disagree"
+    ),
+    DefectType.DEFAULT_DISAGREES_WITH_DOCS: (
+        "the configured default differs from the one that is written down"
+    ),
+}
+
+CHECKLIST: dict[ObligationType, tuple[DefectType, ...]] = {
+    obligation_type: CORE + extra for obligation_type, extra in _BY_TYPE.items()
+}
+
+
+def enumerable(obligation_type: ObligationType) -> bool:
+    """Whether defects are enumerated for an obligation of this type at all.
+
+    False for `TEST_DEMAND` and `HUMAN_REVIEW` (DR-313 decision 2). The caller
+    must record *no set* for these rather than an empty one: an empty set means
+    "looked, found no plausible static defect, here is why", and claiming that
+    about an obligation the stage never examined would be a false negative
+    wearing a reason.
+    """
+    return obligation_type in CHECKLIST
+
+
+def checklist_for(obligation_type: ObligationType) -> tuple[DefectType, ...]:
+    """The defect types walked for this obligation type, core entries first.
+
+    Empty for a type `enumerable` rejects, so a caller that skips the predicate
+    gets an empty checklist rather than a silently core-only one.
+    """
+    return CHECKLIST.get(obligation_type, ())

--- a/src/acceptance/pipeline.py
+++ b/src/acceptance/pipeline.py
@@ -40,6 +40,7 @@ from acceptance.coverage.open_questions import (
 )
 from acceptance.coverage.recommendations import recommend_tests
 from acceptance.coverage.unrequested import detect_unrequested_changes
+from acceptance.defects.enumeration import enumerate_defects
 from acceptance.evidence.anchoring import build_anchors
 from acceptance.evidence.discovery import discover_tests
 from acceptance.evidence.discrimination import judge_discrimination
@@ -298,11 +299,6 @@ def run_review(
     decomposition = link_duplicate_obligations(
         derived, client, unusable, link_pair_batch_size, link_distance_threshold, ledger_prior
     )
-    # Handed back rather than written here: the pipeline does not own the run id,
-    # the parent pointer or the file, and a stage that wrote to disk on the way
-    # past would make the benchmark's own runs leave ledger entries behind.
-    if ledger_sink is not None:
-        ledger_sink.append((derived, decomposition))
 
     # Open-question resolution runs HERE, ahead of every judging stage, because
     # a question the diff resolves yields an obligation (#214) and that
@@ -316,6 +312,37 @@ def run_review(
     question_obligations = derive_obligations(open_questions, resolutions)
     derived_ids = {obligation.id for obligation in question_obligations}
     obligations = decomposition.obligations + question_obligations
+
+    # Defect enumeration runs HERE, before test discovery, and the position is
+    # the point (#313). The stage must never see a test — a denominator chosen
+    # by something that can see what is already covered drifts toward it, and a
+    # thin enumeration then earns a strong rating (#252). Running it before any
+    # test has been discovered makes that structural rather than a promise: at
+    # this line there is no test evidence in existence for it to be handed.
+    #
+    # Advisory in this milestone. Nothing below reads `defect_sets`, and no
+    # verdict or rating depends on it. That is DR-312 decision 5's staged
+    # migration: landing enumeration beside the existing chain rather than in
+    # place of it is what lets a later rating movement be attributed to one
+    # cause instead of three.
+    defect_sets = enumerate_defects(
+        obligations,
+        change_set,
+        client,
+        unusable,
+        prior=list(ledger_prior.defect_sets) if ledger_prior is not None else None,
+    )
+
+    # Handed back rather than written here: the pipeline does not own the run id,
+    # the parent pointer or the file, and a stage that wrote to disk on the way
+    # past would make the benchmark's own runs leave ledger entries behind.
+    #
+    # Handed back HERE rather than straight after linking, which is where it used
+    # to sit, because the entry now carries the defect sets as well and they do
+    # not exist until the line above. One hand-back, so a caller cannot write an
+    # entry holding half of what the run produced.
+    if ledger_sink is not None:
+        ledger_sink.append((derived, decomposition, defect_sets))
 
     # Every obligation reaches every stage below (#293). There used to be a
     # narrowing here — `obligations_to_rederive`, which dropped any obligation
@@ -507,6 +534,7 @@ def run_review(
         # from one place (M1.2.r1).
         requirement_map=decomposition.requirement_map,
         open_questions=open_questions,
+        defect_sets=defect_sets,
         change_set=change_set,
         declaration=declaration,
         findings=findings,

--- a/src/acceptance/report.py
+++ b/src/acceptance/report.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from acceptance.review_state import (
     UNREQUESTED_CHANGE,
     CompletionVerdict,
+    DefectSet,
     MandateCoverage,
     Obligation,
     RequirementMap,
@@ -113,6 +114,10 @@ def render_report(review: Review) -> str:
         lines.append(_EMPTY)
     lines.append("")
 
+    if review.defect_sets:
+        lines.extend(_defect_block(review.defect_sets))
+        lines.append("")
+
     if review.delta is not None:
         lines.extend(_delta_block(review.delta))
         lines.append("")
@@ -149,6 +154,37 @@ def render_report(review: Review) -> str:
         lines.append("Recommended next instruction: (none)")
 
     return "\n".join(lines)
+
+
+def _defect_block(defect_sets: list[DefectSet]) -> list[str]:
+    """The enumerated ways the change could fail each criterion (#313).
+
+    **Advisory.** Labelled so in the heading, because nothing here moved the
+    verdict or any criterion's rating and a reader would otherwise reasonably
+    assume it had. It is deliberately placed after the criteria and the mandate
+    coverage: it is context for those judgements, not one of them.
+
+    A set that was reused rather than produced again says so, per the mandate.
+    A reader has to be able to tell which parts of a review are fresh — a
+    carried set is a statement about an earlier head, and presenting it as
+    current would overstate what this run examined.
+    """
+    lines = ["Ways the change could fail a criterion (advisory — no verdict depends on these):"]
+    for entry in defect_sets:
+        reused = "  (reused from an earlier run)" if entry.carried_from else ""
+        lines.append("")
+        lines.append(f"  {entry.obligation_id}{reused}")
+        if not entry.defects:
+            # An empty set is a result, not a blank. Rendering the reason is what
+            # makes it one a reader can disagree with.
+            lines.append(f"    none enumerated: {entry.reason}")
+            continue
+        for defect in entry.defects:
+            lines.append(f"    [{defect.type.value}] {defect.id}")
+            lines.append(f"      {defect.description}")
+            for ref in defect.code_refs:
+                lines.append(f"      {ref}")
+    return lines
 
 
 def _has_gaps(review: Review) -> bool:

--- a/src/acceptance/requirement/carry.py
+++ b/src/acceptance/requirement/carry.py
@@ -46,6 +46,12 @@ from .ledger import (
     RequirementDerivation,
 )
 
+# This step issues a model call, so it names itself in the run's per-stage cost
+# footer like every other (#264). Its own name, not `decompose`: it fires only on
+# a continued run whose requirement text moved, and folding it into decompose
+# would hide a cost that appears on some runs and not others.
+_STAGE = "requirement carry alignment"
+
 
 @dataclass(frozen=True)
 class CarryPlan:
@@ -174,6 +180,7 @@ def plan_carry(
             [derivation.text for derivation in residue_prior],
             [requirement.text for requirement in unmatched],
             client,
+            stage=_STAGE,
         )
         prior_by_residue_text = {derivation.text: derivation for derivation in residue_prior}
         for requirement in unmatched:

--- a/src/acceptance/requirement/ledger.py
+++ b/src/acceptance/requirement/ledger.py
@@ -49,7 +49,7 @@ from pydantic import Field
 
 from acceptance.carry import carry_key as shared_carry_key
 from acceptance.model_base import PersistableModel
-from acceptance.review_state import Disposition, Obligation, OpenQuestion
+from acceptance.review_state import DefectSet, Disposition, Obligation, OpenQuestion
 from acceptance.serialization import canonical_json
 
 DEFAULT_LEDGER_ROOT = Path(".acceptance/ledger")
@@ -184,6 +184,15 @@ class LedgerEntry(PersistableModel):
     calls_issued: int = 0
     derivations: list[RequirementDerivation] = Field(default_factory=list)
     merge_decisions: list[MergeDecision] = Field(default_factory=list)
+    # The defect sets this run enumerated, so `--continue` carries them (#313).
+    # Empty on a `decompose` run, which has no change set and therefore nothing
+    # to enumerate against — and empty on every entry written before #313, which
+    # reads as "nothing to carry" and re-enumerates. That is the conservative
+    # direction, the same one an absent `evidence_carry_key` takes.
+    #
+    # Keyed on obligation TEXT inside each set rather than on its position here,
+    # so a run that renamed an obligation still finds its set.
+    defect_sets: list[DefectSet] = Field(default_factory=list)
 
     def decisions_by_pair(self) -> dict[tuple[str, str], bool]:
         """Every merge decision this run holds, keyed by fingerprint pair."""

--- a/src/acceptance/requirement/obligations.py
+++ b/src/acceptance/requirement/obligations.py
@@ -66,6 +66,7 @@ from acceptance.requirement.summary import (
 )
 from acceptance.requirement.task_file import ParsedTaskFile
 from acceptance.review_state import (
+    DefectSet,
     Disposition,
     Obligation,
     ObligationType,
@@ -1357,6 +1358,7 @@ def build_ledger_entry(
     parent_run_id: str | None,
     task_digest: str,
     linked: Decomposition | None = None,
+    defect_sets: list[DefectSet] | None = None,
 ) -> LedgerEntry:
     """This run's ledger record, ready to write.
 
@@ -1365,6 +1367,10 @@ def build_ledger_entry(
     derived, and recording the post-merge set would let one run's merge silently
     become the next run's premise (DR-204). The **merge decisions** come from
     `linked`, because that is the stage that made them.
+
+    `defect_sets` is absent on a `decompose` run and present on a `check` (#313).
+    Absent means no set carries forward, which is the conservative direction: a
+    `decompose` never enumerated any, so there is nothing to lose by saying so.
     """
     return LedgerEntry(
         run_id=run_id,
@@ -1374,6 +1380,7 @@ def build_ledger_entry(
         calls_issued=derived.calls_issued,
         derivations=list(derived.derivations),
         merge_decisions=list((linked or derived).merge_decisions),
+        defect_sets=list(defect_sets or []),
     )
 
 

--- a/src/acceptance/review_state.py
+++ b/src/acceptance/review_state.py
@@ -93,6 +93,103 @@ class ObligationType(str, Enum):
     TEST_DEMAND = "test_demand"
 
 
+class DefectType(str, Enum):
+    """A way a change can fail an obligation (DR-313, from DR-312 decision 4).
+
+    Classification only. Every defect's `description` is free text regardless,
+    and nothing downstream — the reachability prefilter, pair mapping, M8.4
+    mutation — reads this field, so `OTHER` costs nothing but per-type scoring
+    granularity on the defects that use it.
+
+    The four before the divider are walked for EVERY obligation type; the rest
+    are walked only for the obligation type they belong to. Which list an
+    obligation type gets is `defects/taxonomy.py`, deliberately not here: this
+    is the vocabulary, that is the stage logic that spends it.
+    """
+
+    QUALIFIER_IGNORED = "qualifier_ignored"
+    CONDITION_INVERTED = "condition_inverted"
+    SCOPE_TOO_NARROW = "scope_too_narrow"
+    NOT_WIRED = "not_wired"
+
+    WRONG_OUTPUT_SHAPE = "wrong_output_shape"
+    MISSING_CASE = "missing_case"
+    BOUNDARY_WRONG_SIDE = "boundary_wrong_side"
+    BOUNDARY_UNHANDLED = "boundary_unhandled"
+    ERROR_SWALLOWED = "error_swallowed"
+    WRONG_ERROR_SURFACED = "wrong_error_surfaced"
+    ESTABLISHED_NOT_MAINTAINED = "established_not_maintained"
+    UNENFORCED_ON_ONE_PATH = "unenforced_on_one_path"
+    PRIOR_BEHAVIOR_ALTERED = "prior_behavior_altered"
+    PRIOR_BEHAVIOR_REMOVED = "prior_behavior_removed"
+    OLD_INPUT_REJECTED = "old_input_rejected"
+    STORED_FORM_UNREADABLE = "stored_form_unreadable"
+    EXPLANATION_ABSENT = "explanation_absent"
+    EXPLANATION_STATES_WRONG_CAUSE = "explanation_states_wrong_cause"
+    DOCUMENTED_NOT_IMPLEMENTED = "documented_not_implemented"
+    DEFAULT_DISAGREES_WITH_DOCS = "default_disagrees_with_docs"
+
+    OTHER = "other"
+    """The escape. A defect the checklist has no value for, carrying a free
+    description. DR-312 asks for its share as a standing metric: a rising share
+    is a taxonomy gap, and a near-zero share alongside poor enumeration recall
+    is odd defects being forced into the nearest slot."""
+
+
+class Defect(_Model):
+    """One concrete way the delivered code could plausibly fail an obligation.
+
+    Enumerated BEFORE any test is looked at, which is the whole point of the
+    defect-first shape (DR-312): a denominator chosen by something that can see
+    what is already covered drifts toward it, and a thinner enumeration then
+    earns a stronger rating (#252).
+
+    Identified and persisted so every later consumer refers to a defect by
+    `id` rather than restating it. `code_refs` are `path#hunk` labels, the same
+    currency `Obligation.coverage_refs` uses, so a defect is linked to exact
+    lines like every other typed record (§13.6).
+    """
+
+    id: str
+    obligation_id: str
+    type: DefectType
+    description: str
+    code_refs: list[str] = Field(default_factory=list)
+
+
+class DefectSet(_Model):
+    """Every defect enumerated for one obligation, or a reasoned absence.
+
+    A set with no defects is a valid, meaningful result — #270's shape, where an
+    obligation true by construction earns a defect that cannot exist — but only
+    when it says why. `reason` is required to be non-empty for an empty set and
+    empty otherwise, so "nothing found" and "not looked at" stay distinguishable.
+
+    `carried_from` records that this set was reused rather than produced again,
+    which the review reports: a reader has to be able to tell which parts of a
+    review are fresh, exactly as `Obligation.carried_forward_from` does.
+    """
+
+    obligation_id: str
+    defects: list[Defect] = Field(default_factory=list)
+    reason: str = ""
+    # The obligation's own text, as the identity a later run matches on. Not the
+    # id: obligation ids are model-chosen and move when a requirement is
+    # reworded, so keying on one would carry a set onto a different obligation.
+    # Same reason `RequirementDerivation` keys on requirement text.
+    obligation_text: str = ""
+    # What this set is valid under: the determinism controls, the stage-logic
+    # version, this obligation's text, and `region_digests` below.
+    carry_key: str = ""
+    # The content digest of each changed region this set's defects implicate,
+    # keyed by `path#hunk` label (DR-293's shape). Stored as well as folded into
+    # the key because it answers a question the key cannot — *which* implicated
+    # region moved — and because it cannot be recomputed later: the labels name
+    # hunks of a diff that is gone by the next run.
+    region_digests: dict[str, str] = Field(default_factory=dict)
+    carried_from: str | None = None
+
+
 class RequiredEvidence(str, Enum):
     """Which kinds of evidence an obligation REQUIRES (#153, restructured #266).
 
@@ -998,6 +1095,17 @@ class Review(_Model):
     # of which requirements produced nothing.
     requirement_map: RequirementMap | None = None
     open_questions: list[OpenQuestion] = Field(default_factory=list)
+    # One entry per obligation the enumeration stage was asked about (#313).
+    # Advisory: nothing here reaches `completion` or any obligation's rating,
+    # which is what makes #312's staged migration attributable — a rating that
+    # moves while this is only being *recorded* has some other cause.
+    #
+    # An obligation with no entry at all is different from one with an empty
+    # entry, and both occur: a `test_demand` obligation is excluded from
+    # enumeration entirely (DR-313 decision 2, because the enumerator may not
+    # see tests and such an obligation is about a test), while an obligation
+    # with no plausible static defect gets an entry whose `reason` says so.
+    defect_sets: list[DefectSet] = Field(default_factory=list)
     findings: list[Finding] = Field(default_factory=list)
     recommendations: list[TestRecommendation] = Field(default_factory=list)
     # Criteria the recommendation stage was asked about and returned nothing for

--- a/tests/defects/test_enumeration.py
+++ b/tests/defects/test_enumeration.py
@@ -1,0 +1,557 @@
+"""Defect enumeration: what is recorded, what is never shown, what carries (#313).
+
+The stage records — per criterion, before any test is looked at — the concrete
+ways the delivered code could plausibly fail that criterion. Three properties
+carry the design and each has its own test below:
+
+- **the stage is never shown a test**, which is the #252 mitigation and the
+  reason the whole thing is worth building;
+- **an empty set is a real answer**, carrying its reason, rather than an
+  invitation to invent a defect (#270);
+- **a set carries** while its criterion's text and the contents of the regions
+  it implicates are both unchanged, and re-derives wholesale when either moves.
+
+The last group is the wiring: the pipeline really calls this, the ledger really
+carries it, and nothing it records moves a verdict or a rating.
+"""
+
+from __future__ import annotations
+
+from acceptance.change.diff import extract_change_set
+from acceptance.defects.enumeration import (
+    enumerate_defects,
+    non_test_changes,
+    obligation_text,
+)
+from acceptance.defects.taxonomy import CHECKLIST, CORE, checklist_for, enumerable
+from acceptance.pipeline import run_review
+from acceptance.report import render_report
+from acceptance.review_state import (
+    ChangeSet,
+    DefectType,
+    DiffHunk,
+    FileChange,
+    Obligation,
+    ObligationType,
+)
+from tests.support import client_dispatching
+
+_PRORATE = "+def prorate(monthly, days):\n+    return monthly / 30\n"
+_TEST_SOURCE = "+def test_prorate():\n+    assert prorate(300, 31) > 0\n"
+
+
+def _hunk(content: str) -> DiffHunk:
+    return DiffHunk(
+        header="@@ -1 +1 @@", old_start=1, old_lines=1, new_start=1, new_lines=2, content=content
+    )
+
+
+def _change_set(source: str = _PRORATE, with_test: bool = True) -> ChangeSet:
+    files = [
+        FileChange(path="billing.py", status="modified", category="source", hunks=[_hunk(source)])
+    ]
+    if with_test:
+        files.append(
+            FileChange(
+                path="test_billing.py",
+                status="added",
+                category="test",
+                hunks=[_hunk(_TEST_SOURCE)],
+            )
+        )
+    return ChangeSet(base_revision="base", head_revision="head", files=files)
+
+
+def _obligation(
+    obligation_id: str = "daily-rate",
+    description: str = "The daily rate is the monthly price divided by the days in that month.",
+    obligation_type: ObligationType = ObligationType.FUNCTIONAL,
+) -> Obligation:
+    return Obligation(
+        id=obligation_id,
+        description=description,
+        type=obligation_type,
+        importance="normal",
+        explicit=True,
+        observable_behavior="prorate(300, 31) uses 31 as the divisor",
+    )
+
+
+def _answer(defects: list[dict], reason: str = "") -> dict:
+    return {"_Enumeration": {"obligation_id": "", "defects": defects, "reason": reason}}
+
+
+def _defect(
+    slug: str = "thirty-day-month",
+    defect_type: str = DefectType.QUALIFIER_IGNORED.value,
+    code_refs: list[str] | None = None,
+) -> dict:
+    return {
+        "slug": slug,
+        "type": defect_type,
+        "description": "The divisor is hard-coded to 30, so February is wrong.",
+        "code_refs": ["billing.py#0"] if code_refs is None else code_refs,
+    }
+
+
+# --- the stage is never shown a test ---------------------------------------
+
+
+def test_the_enumerator_is_given_no_test():
+    """The #252 mitigation, asserted on the request as sent.
+
+    A denominator chosen by something that can see what is already covered
+    drifts toward it, and a thin enumeration then earns a strong rating. So this
+    checks the prompt the stage actually built, not that a filter function
+    exists: a correct filter the stage forgets to call reads identically from
+    the outside.
+    """
+    capture: list = []
+    client = client_dispatching(_answer([_defect()]), capture=capture)
+
+    enumerate_defects([_obligation()], _change_set(with_test=True), client)
+
+    assert capture, "the stage issued no call, so there is no request to inspect"
+    prompt = capture[0]["prompt"]
+    assert "billing.py" in prompt, "the production change was not shown either"
+    assert "test_billing.py" not in prompt
+    assert "test_prorate" not in prompt
+
+
+def test_the_filter_removes_test_files_and_keeps_everything_else():
+    """`non_test_changes` on its own, so a failure says which half broke."""
+    filtered = non_test_changes(_change_set(with_test=True))
+
+    assert [file.path for file in filtered.files] == ["billing.py"]
+
+
+# --- an empty set is a real answer -----------------------------------------
+
+
+def test_a_criterion_with_no_plausible_defect_yields_an_empty_set_with_its_reason():
+    """#270's shape: an obligation true by construction earns no defect.
+
+    The failure this guards against is an invented defect — one that would be
+    counted in a denominator and make the criterion look better tested than it
+    is. So it asserts both halves: nothing invented, and a reason present.
+    """
+    client = client_dispatching(
+        _answer([], reason="The type system makes this true by construction.")
+    )
+
+    sets = enumerate_defects([_obligation()], _change_set(), client)
+
+    assert len(sets) == 1
+    assert sets[0].defects == []
+    assert sets[0].reason == "The type system makes this true by construction."
+
+
+def test_an_empty_set_with_no_reason_is_recorded_as_one_rather_than_left_blank():
+    """ "Found nothing, here is why" and "answered nothing" must stay apart.
+
+    An empty set with a blank reason is indistinguishable from a stage that did
+    not run, which is the failure #275 names on the recommendation stage.
+    """
+    client = client_dispatching(_answer([], reason="   "))
+
+    sets = enumerate_defects([_obligation()], _change_set(), client)
+
+    assert sets[0].defects == []
+    assert sets[0].reason, "an empty set was recorded with no reason at all"
+
+
+def test_a_set_that_found_defects_carries_no_empty_set_reason():
+    """The reason field belongs to the empty case alone; carrying one alongside
+    defects would read as a caveat on findings that have none."""
+    client = client_dispatching(_answer([_defect()], reason="left over"))
+
+    sets = enumerate_defects([_obligation()], _change_set(), client)
+
+    assert sets[0].defects
+    assert sets[0].reason == ""
+
+
+# --- the records themselves -------------------------------------------------
+
+
+def test_every_defect_id_is_unique_within_the_review():
+    """Uniqueness is composed in code, not taken from the answer.
+
+    Two criteria about the same code invite the same model-chosen slug, and a
+    duplicate id would let a later consumer that refers to defects by id join
+    one criterion's defect onto another's.
+    """
+    client = client_dispatching(_answer([_defect(slug="same"), _defect(slug="same")]))
+
+    sets = enumerate_defects(
+        [_obligation("first"), _obligation("second", description="A different criterion.")],
+        _change_set(),
+        client,
+    )
+
+    ids = [defect.id for entry in sets for defect in entry.defects]
+    assert len(ids) == 4
+    assert len(set(ids)) == 4, f"ids collided: {ids}"
+
+
+def test_each_defect_carries_its_criterion_a_type_a_description_and_its_code_regions():
+    client = client_dispatching(_answer([_defect()]))
+
+    defect = enumerate_defects([_obligation()], _change_set(), client)[0].defects[0]
+
+    assert defect.obligation_id == "daily-rate"
+    assert defect.type is DefectType.QUALIFIER_IGNORED
+    assert defect.description
+    assert defect.code_refs == ["billing.py#0"]
+
+
+def test_a_code_reference_the_change_set_does_not_contain_is_dropped():
+    """A defect may cite only regions it was actually shown, so a link is a link
+    to something (§13.6)."""
+    client = client_dispatching(_answer([_defect(code_refs=["billing.py#0", "invented.py#9"])]))
+
+    defect = enumerate_defects([_obligation()], _change_set(), client)[0].defects[0]
+
+    assert defect.code_refs == ["billing.py#0"]
+
+
+# --- the checklist ----------------------------------------------------------
+
+
+def test_the_checklist_walked_is_the_one_for_that_criterion_s_type():
+    capture: list = []
+    client = client_dispatching(_answer([_defect()]), capture=capture)
+
+    enumerate_defects([_obligation(obligation_type=ObligationType.BOUNDARY)], _change_set(), client)
+
+    prompt = capture[0]["prompt"]
+    assert DefectType.BOUNDARY_WRONG_SIDE.value in prompt
+    assert DefectType.ERROR_SWALLOWED.value not in prompt, (
+        "another obligation type's checklist reached this call"
+    )
+
+
+def test_the_core_checklist_is_walked_for_every_enumerable_type():
+    for obligation_type in CHECKLIST:
+        assert set(CORE) <= set(checklist_for(obligation_type)), obligation_type
+
+
+def test_the_escape_is_offered_alongside_the_checklist():
+    """DR-312 decision 4: a defect that fits no entry is recorded as `other`
+    rather than forced into the nearest slot."""
+    capture: list = []
+    client = client_dispatching(_answer([_defect()]), capture=capture)
+
+    enumerate_defects([_obligation()], _change_set(), client)
+
+    assert DefectType.OTHER.value in capture[0]["prompt"]
+
+
+def test_a_defect_typed_other_is_recorded_as_such():
+    client = client_dispatching(_answer([_defect(defect_type=DefectType.OTHER.value)]))
+
+    defect = enumerate_defects([_obligation()], _change_set(), client)[0].defects[0]
+
+    assert defect.type is DefectType.OTHER
+
+
+def test_a_test_demand_criterion_gets_no_set_at_all_rather_than_an_empty_one():
+    """DR-313 decision 2, and the distinction it turns on.
+
+    The enumerator may never see a test, and a `test_demand` obligation is about
+    a test — so it is excluded. Excluded is not the same as empty: an empty set
+    claims "looked, found no plausible static defect", which would be a false
+    negative wearing a reason.
+    """
+    client = client_dispatching(_answer([_defect()]))
+
+    sets = enumerate_defects(
+        [
+            _obligation("behaviour"),
+            _obligation("demand", obligation_type=ObligationType.TEST_DEMAND),
+            _obligation("judgement", obligation_type=ObligationType.HUMAN_REVIEW),
+        ],
+        _change_set(),
+        client,
+    )
+
+    assert [entry.obligation_id for entry in sets] == ["behaviour"]
+    assert not enumerable(ObligationType.TEST_DEMAND)
+    assert not enumerable(ObligationType.HUMAN_REVIEW)
+
+
+# --- carry ------------------------------------------------------------------
+
+
+def _enumerated(client, obligations, change_set, prior=None):
+    return enumerate_defects(obligations, change_set, client, prior=prior)
+
+
+class _Counting:
+    """A client that answers as `client_dispatching` does and counts the calls."""
+
+    def __init__(self, answer: dict):
+        self.calls = 0
+        capture: list = []
+        self._capture = capture
+        self.client = client_dispatching(answer, capture=capture)
+        original = self.client.complete
+
+        def counted(*args, **kwargs):
+            if kwargs.get("stage") == "defect enumeration":
+                self.calls += 1
+            return original(*args, **kwargs)
+
+        self.client.complete = counted  # type: ignore[method-assign]
+
+
+def test_a_set_is_reused_when_the_criterion_and_its_implicated_regions_are_unchanged():
+    """The mandate's carry rule, exercised as two continued runs.
+
+    Asserted on the call count, not only on the result: a set that came back
+    identical because the stage re-asked and got the same answer is not a
+    carried set, and the whole point of the carry is the call not being made.
+    """
+    counting = _Counting(_answer([_defect()]))
+    obligations = [_obligation()]
+    change_set = _change_set()
+
+    first = _enumerated(counting.client, obligations, change_set)
+    assert counting.calls == 1
+
+    second = _enumerated(counting.client, obligations, change_set, prior=first)
+
+    assert counting.calls == 1, "the set was produced again although nothing moved"
+    assert second[0].carried_from, "a reused set does not say it was reused"
+    assert [d.description for d in second[0].defects] == [d.description for d in first[0].defects]
+
+
+def test_a_criterion_whose_text_changed_keeps_no_part_of_its_earlier_set():
+    counting = _Counting(_answer([_defect()]))
+    change_set = _change_set()
+
+    first = _enumerated(counting.client, [_obligation()], change_set)
+    reworded = [_obligation(description="The daily rate uses the calendar month's real length.")]
+    second = _enumerated(counting.client, reworded, change_set, prior=first)
+
+    assert counting.calls == 2, "a reworded criterion was not re-enumerated"
+    assert second[0].carried_from is None
+    assert second[0].carry_key != first[0].carry_key
+
+
+def test_changing_one_criterion_leaves_every_other_criterion_s_set_reused():
+    """The carry is per criterion, so one rewording costs one call.
+
+    This is the property that makes `--continue` worth having: without it a
+    single edited bullet re-enumerates the whole mandate, and the figures either
+    side of the edit stop being comparable.
+    """
+    counting = _Counting(_answer([_defect()]))
+    change_set = _change_set()
+    first_run = [_obligation("a"), _obligation("b", description="A second criterion entirely.")]
+
+    first = _enumerated(counting.client, first_run, change_set)
+    assert counting.calls == 2
+
+    second_run = [_obligation("a"), _obligation("b", description="A second criterion, reworded.")]
+    second = _enumerated(counting.client, second_run, change_set, prior=first)
+
+    assert counting.calls == 3, "an untouched criterion was re-enumerated"
+    by_id = {entry.obligation_id: entry for entry in second}
+    assert by_id["a"].carried_from
+    assert by_id["b"].carried_from is None
+
+
+def test_a_set_is_produced_again_when_the_contents_of_its_implicated_region_change():
+    """The other half of the rule, and the half a file-touch comparison misses.
+
+    #293 deleted the touched-file test because it fires when a byte-identical
+    region moves within a file. This is keyed on the region's CONTENTS, so it
+    fires when — and only when — the implicated code really changed.
+    """
+    counting = _Counting(_answer([_defect()]))
+
+    first = _enumerated(counting.client, [_obligation()], _change_set())
+    moved = _change_set(source="+def prorate(monthly, days):\n+    return monthly / days\n")
+    second = _enumerated(counting.client, [_obligation()], moved, prior=first)
+
+    assert counting.calls == 2
+    assert second[0].carried_from is None
+
+
+def test_a_carried_set_is_re_identified_onto_this_run_s_criterion_id():
+    """Ids are model-chosen and move; the carry matches on text.
+
+    Without the re-identification a carried set would keep the previous run's
+    obligation id and every consumer that joins by id would silently lose it.
+    """
+    counting = _Counting(_answer([_defect()]))
+    change_set = _change_set()
+
+    first = _enumerated(counting.client, [_obligation("old-id")], change_set)
+    second = _enumerated(counting.client, [_obligation("new-id")], change_set, prior=first)
+
+    assert counting.calls == 1
+    assert second[0].obligation_id == "new-id"
+    assert {defect.obligation_id for defect in second[0].defects} == {"new-id"}
+
+
+def test_the_carry_identity_is_the_text_the_enumerator_was_shown():
+    """Neither more nor less: a field the prompt never renders would
+    re-enumerate on a change that could not have altered the answer."""
+    same = obligation_text(_obligation("one"))
+    renamed = obligation_text(_obligation("two"))
+    reworded = obligation_text(_obligation("one", description="Something else."))
+
+    assert same == renamed
+    assert same != reworded
+
+
+# --- wiring -----------------------------------------------------------------
+
+
+_TASK = (
+    "# Task\nThe billing export prorates a partial month.\n\n"
+    "## Constraints\n- The daily rate is the monthly price divided by the days in that month\n"
+)
+
+_QUOTE = "The daily rate is the monthly price divided by the days in that month"
+
+# The decomposition the wiring tests run over. Supplied rather than left to the
+# double's empty default: with no obligations the pipeline has nothing to
+# enumerate against, and every assertion below would pass vacuously on a review
+# that never reached this stage.
+_DECOMPOSITION = {
+    "obligations": [
+        {
+            "id": "daily-rate",
+            "description": f"{_QUOTE}.",
+            "type": "functional",
+            "importance": "normal",
+            "explicit": True,
+            "observable_behavior": "prorate(300, 31) divides by 31",
+            "source_quote": _QUOTE,
+        }
+    ],
+    "open_questions": [],
+    "requirement_dispositions": [],
+}
+
+
+def _repo(tmp_path):
+    import subprocess
+
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True)
+
+    def git(*args):
+        return subprocess.run(
+            ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+        ).stdout.strip()
+
+    git("init", "-q")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "t")
+    (repo / "billing.py").write_text("def prorate(monthly, days):\n    return monthly\n")
+    git("add", "-A")
+    git("commit", "-qm", "base")
+    base = git("rev-parse", "HEAD")
+    (repo / "billing.py").write_text("def prorate(monthly, days):\n    return monthly / 30\n")
+    git("add", "-A")
+    git("commit", "-qm", "head")
+    return repo, base, git("rev-parse", "HEAD")
+
+
+def _reviewed(tmp_path, answer: dict | None = None):
+    repo, base, head = _repo(tmp_path)
+    client = client_dispatching(
+        {"_Decomposition": _DECOMPOSITION, **(answer or _answer([_defect(code_refs=[])]))}
+    )
+    return run_review(
+        task_text=_TASK,
+        change_set=extract_change_set(repo, base, head),
+        repo=repo,
+        client=client,
+        reviewed_revision=head,
+    )
+
+
+def test_the_pipeline_really_calls_the_enumerator(tmp_path):
+    """The wiring, not the function.
+
+    Defect injection has repeatedly found a helper with a good unit test that
+    the pipeline never calls (CLAUDE.md), so the acceptance is asserted on a
+    real `run_review` rather than on `enumerate_defects` alone.
+    """
+    review = _reviewed(tmp_path)
+
+    assert review.defect_sets, "the pipeline produced no defect sets"
+    assert any(entry.defects for entry in review.defect_sets)
+
+
+def test_the_review_reports_the_recorded_ways_of_failing(tmp_path):
+    review = _reviewed(tmp_path)
+
+    rendered = render_report(review)
+
+    assert "Ways the change could fail a criterion" in rendered
+    for entry in review.defect_sets:
+        for defect in entry.defects:
+            assert defect.id in rendered, "a defect is not named by its identifier in the report"
+            assert defect.type.value in rendered
+
+
+def test_the_report_says_when_a_set_was_reused_rather_than_produced_again(tmp_path):
+    review = _reviewed(tmp_path)
+    carried = review.model_copy(
+        update={
+            "defect_sets": [
+                entry.model_copy(update={"carried_from": "an-earlier-key"})
+                for entry in review.defect_sets
+            ]
+        }
+    )
+
+    assert "reused from an earlier run" in render_report(carried)
+    assert "reused from an earlier run" not in render_report(review)
+
+
+def test_recording_ways_of_failing_changes_no_verdict_and_no_rating(tmp_path):
+    """The advisory guarantee, checked by difference.
+
+    Two reviews over the same input, one whose enumerator found defects and one
+    whose found none. Every part of the review except `defect_sets` must be
+    identical — that is what "advisory" means, and it is what makes a later
+    rating movement attributable to the stage that caused it (DR-312 decision 5).
+    """
+    with_defects = _reviewed(tmp_path / "a", _answer([_defect(code_refs=[])]))
+    without = _reviewed(tmp_path / "b", _answer([], reason="Nothing plausible."))
+
+    assert any(entry.defects for entry in with_defects.defect_sets)
+    assert not any(entry.defects for entry in without.defect_sets)
+
+    def apart(review):
+        return review.model_copy(update={"defect_sets": []}).to_canonical_json()
+
+    assert apart(with_defects) == apart(without)
+
+
+def test_the_enumerated_sets_survive_a_round_trip_through_persisted_state(tmp_path):
+    """Defects persist with the rest of the review, unchanged."""
+    from acceptance.review_state import Review
+
+    review = _reviewed(tmp_path)
+
+    reloaded = Review.model_validate_json(review.to_canonical_json())
+
+    assert reloaded.defect_sets == review.defect_sets
+    assert reloaded.to_canonical_json() == review.to_canonical_json()
+
+
+def test_two_runs_over_the_same_input_agree_byte_for_byte(tmp_path):
+    """M0.5, over the stage this issue adds."""
+    first = _reviewed(tmp_path / "one")
+    second = _reviewed(tmp_path / "two")
+
+    assert first.to_canonical_json() == second.to_canonical_json()
+    assert render_report(first) == render_report(second)

--- a/tests/defects/test_enumeration.py
+++ b/tests/defects/test_enumeration.py
@@ -462,8 +462,17 @@ def _repo(tmp_path):
     return repo, base, git("rev-parse", "HEAD")
 
 
-def _reviewed(tmp_path, answer: dict | None = None):
-    repo, base, head = _repo(tmp_path)
+def _review_over(built, answer: dict | None = None):
+    """One review over an already-built repo.
+
+    Two reviews that must agree byte for byte have to run over the SAME repo.
+    Building one each would compare reviews whose `reviewed_revision` differs:
+    the two repos hold identical content but their commits are stamped with the
+    time they were made, so the head SHAs match only when both landed inside the
+    same second. That is a test that passes most of the time, which is worse
+    than one that does not exist.
+    """
+    repo, base, head = built
     client = client_dispatching(
         {"_Decomposition": _DECOMPOSITION, **(answer or _answer([_defect(code_refs=[])]))}
     )
@@ -474,6 +483,10 @@ def _reviewed(tmp_path, answer: dict | None = None):
         client=client,
         reviewed_revision=head,
     )
+
+
+def _reviewed(tmp_path, answer: dict | None = None):
+    return _review_over(_repo(tmp_path), answer)
 
 
 def test_the_pipeline_really_calls_the_enumerator(tmp_path):
@@ -524,8 +537,9 @@ def test_recording_ways_of_failing_changes_no_verdict_and_no_rating(tmp_path):
     identical — that is what "advisory" means, and it is what makes a later
     rating movement attributable to the stage that caused it (DR-312 decision 5).
     """
-    with_defects = _reviewed(tmp_path / "a", _answer([_defect(code_refs=[])]))
-    without = _reviewed(tmp_path / "b", _answer([], reason="Nothing plausible."))
+    built = _repo(tmp_path)
+    with_defects = _review_over(built, _answer([_defect(code_refs=[])]))
+    without = _review_over(built, _answer([], reason="Nothing plausible."))
 
     assert any(entry.defects for entry in with_defects.defect_sets)
     assert not any(entry.defects for entry in without.defect_sets)
@@ -550,8 +564,9 @@ def test_the_enumerated_sets_survive_a_round_trip_through_persisted_state(tmp_pa
 
 def test_two_runs_over_the_same_input_agree_byte_for_byte(tmp_path):
     """M0.5, over the stage this issue adds."""
-    first = _reviewed(tmp_path / "one")
-    second = _reviewed(tmp_path / "two")
+    built = _repo(tmp_path)
+    first = _review_over(built)
+    second = _review_over(built)
 
     assert first.to_canonical_json() == second.to_canonical_json()
     assert render_report(first) == render_report(second)

--- a/tests/requirement/test_carry_forward.py
+++ b/tests/requirement/test_carry_forward.py
@@ -1193,7 +1193,7 @@ def test_the_review_pipeline_carries_forward_and_hands_back_what_it_derived(tmp_
 
     assert counting.decompose_calls == 0
     assert len(sink) == 1
-    derived, _linked = sink[0]
+    derived, _linked, _defect_sets = sink[0]
     assert {d.derivation for d in derived.derivations} == {Derivation.CARRIED}
 
 

--- a/tests/support.py
+++ b/tests/support.py
@@ -457,6 +457,14 @@ def _completed(response: dict, **kwargs) -> dict:
         if response.get("__whole_summary_uncovered__"):
             return uncovered_summary([_summary_text(**kwargs)])
         return covered_summary(**kwargs)
+    # Defect enumeration asks about ONE criterion per call and constrains
+    # `obligation_id` to it, so a fixed fixture cannot name it. Filled from the
+    # call's own enum, exactly as the recommendation branch below does — a blank
+    # would otherwise be scanned as an id the call never supplied and file an
+    # unusable-answer finding in every unrelated test (#313).
+    if _schema_name(**kwargs) == "_Enumeration" and not response.get("obligation_id"):
+        supplied = _supplied_enum("obligation_id", **kwargs)
+        return {**response, "obligation_id": supplied[0] if supplied else ""}
     if response.get("requirement_dispositions") == []:
         supplied = _supplied_enum("requirement_id", **kwargs)
         obligations = response.get("obligations") or []
@@ -770,6 +778,17 @@ _EMPTY_BY_SCHEMA = {
     # completion helper fills a supplied-id enum when it sees one, so the double
     # answers the pairs it was actually given rather than none of them.
     "_Verdicts": {"verdicts": []},
+    # Defect enumeration (#313). `obligation_id` is filled in by the completion
+    # helper from the supplied-id enum, so the double answers about the criterion
+    # it was actually asked about. No defects and a reason for the empty set,
+    # which is a valid answer rather than a degenerate one — and the stage is
+    # advisory, so a test with no opinion about defects gets a review whose
+    # verdict and ratings are what they were before this stage existed.
+    "_Enumeration": {
+        "obligation_id": "",
+        "defects": [],
+        "reason": "No defects were enumerated by this test's model double.",
+    },
     "_Mappings": {"mappings": []},
     "_Discrimination": {"discriminations": []},
     "_Coverage": {"classifications": []},

--- a/tests/test_carry.py
+++ b/tests/test_carry.py
@@ -17,6 +17,7 @@ import pytest
 
 from acceptance import carry as shared_carry
 from acceptance.carry import Decision, Refusal, carry_key, decide
+from acceptance.llm import UNKNOWN_STAGE
 from acceptance.requirement import carry as requirement_carry
 from acceptance.requirement.ledger import (
     DECOMPOSE_STAGE_LOGIC_VERSION,
@@ -32,6 +33,7 @@ from acceptance.review_state import (
     RequirementRef,
     TextSpan,
 )
+from tests.support import client_dispatching
 
 CONTROLS = {
     "system_prompt": "you decompose task files",
@@ -203,6 +205,44 @@ def test_decomposition_reaches_its_carry_verdict_through_the_shared_rule(monkeyp
 
     assert calls == ["constraint-01"]
     assert set(plan.carried) == {"constraint-01"}
+
+
+def test_matching_a_reworded_requirement_attributes_its_model_call_to_a_stage():
+    """The wiring, not the scan (#313's Gate 1).
+
+    `plan_carry` reaches into the benchmark harness for `align_obligations` to
+    tell a reworded requirement from a new one. That call named no stage, so
+    every continued run whose requirement text moved grew an `unknown` row in
+    its per-stage cost footer — the one bucket `llm.py` says a review-pipeline
+    call site may never land in (#264). `tests/test_stage_attribution.py` scans
+    for the omission statically; this drives the path that produced it, because
+    a call site can pass `stage=` to a client that never records it.
+    """
+    reworded = "A carried obligation keeps the identifier it was given."
+    registry = [
+        RequirementRef(
+            id="constraint-01",
+            section="constraint",
+            ordinal=1,
+            span=TextSpan(text=reworded, start=0, end=len(reworded)),
+        )
+    ]
+    prior = LedgerEntry(
+        run_id="abc123",
+        stage_logic_version=DECOMPOSE_STAGE_LOGIC_VERSION,
+        derivations=[_derivation(REQUIREMENT_TEXT, "any-key")],
+    )
+    client = client_dispatching(
+        {"_Alignment": {"matches": [{"ground_truth": "g0", "reviewer": "r0"}]}}
+    )
+
+    plan = requirement_carry.plan_carry(registry, prior, {"constraint-01": "todays-key"}, client)
+
+    # The alignment really did run and really did match, so the assertion below
+    # is about an attributed call rather than about a call that never happened.
+    assert set(plan.revised) == {"constraint-01"}
+    assert client.observed_calls
+    assert not [call for call in client.observed_calls if call["stage"] == UNKNOWN_STAGE]
 
 
 def test_a_requirement_whose_key_moved_is_derived_rather_than_carried():

--- a/tests/test_stage_attribution.py
+++ b/tests/test_stage_attribution.py
@@ -14,6 +14,13 @@ that never records it.
 
 `benchmark/` is deliberately out of scope: it is not part of a review run
 (CLAUDE.md, repo layout), and its spend must not land in a review's footer.
+
+That exclusion had a hole, found at #313's Gate 1. `requirement/carry.py`
+imports `align_obligations` from the benchmark harness, so its model call was
+made *by* a review and *from* a module the scan skips, and landed in the
+`unknown` bucket on every continued run whose requirement text moved. The scan
+below now follows imports out of `benchmark/` as well, and a wiring test drives
+the carry path itself.
 """
 
 from __future__ import annotations
@@ -99,6 +106,68 @@ def test_no_review_pipeline_call_site_omits_its_stage():
 
     assert not offenders, (
         "these review-pipeline model calls do not name the stage that issued them, "
+        f"so their cost would aggregate as {UNKNOWN_STAGE!r}: {offenders}"
+    )
+
+
+def _benchmark_imports(path: Path) -> set[str]:
+    """Names a review-pipeline module pulls in from `acceptance.benchmark`.
+
+    Such a name is a model call the scan above cannot see: the call site is in
+    `benchmark/`, which is excluded, but the spend belongs to the review that
+    triggered it.
+    """
+    tree = ast.parse(path.read_text())
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and (node.module or "").startswith(
+            "acceptance.benchmark"
+        ):
+            names.update(alias.asname or alias.name for alias in node.names)
+    return names
+
+
+def test_the_import_scan_still_finds_the_one_crossing_it_polices():
+    """Guards the test below from passing vacuously, as its sibling does.
+
+    If `align_obligations` moves into the pipeline the crossing disappears and
+    this fails — which is the right outcome, and a visible test edit rather than
+    a scan that quietly polices nothing.
+    """
+    crossings = {
+        str(path.relative_to(_SRC)): sorted(_benchmark_imports(path))
+        for path in _product_modules()
+        if _benchmark_imports(path)
+    }
+
+    assert crossings == {"requirement/carry.py": ["align_obligations"]}, (
+        f"the set of review-pipeline modules reaching into benchmark/ changed: {crossings}"
+    )
+
+
+def test_no_call_into_benchmark_from_the_pipeline_omits_its_stage():
+    """Acceptance: the crossing that produced the `unknown` row cannot recur.
+
+    `benchmark/` is excluded from the scan above because its own spend is not a
+    review's. A pipeline module that imports from it inherits the review's
+    obligation to attribute, so the call must name a stage here instead.
+    """
+    offenders = []
+    for path in _product_modules():
+        imported = _benchmark_imports(path)
+        if not imported:
+            continue
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+                continue
+            if node.func.id not in imported:
+                continue
+            if not any(keyword.arg == "stage" for keyword in node.keywords):
+                offenders.append(f"{path.relative_to(_SRC)}:{node.lineno} {node.func.id}")
+
+    assert not offenders, (
+        "these calls run a model on the review's behalf from inside benchmark/, "
         f"so their cost would aggregate as {UNKNOWN_STAGE!r}: {offenders}"
     )
 


### PR DESCRIPTION
Closes #313, sub-issue A of #312 (the defect-first evidence design). Design: `docs/DR-312-defect-first-evidence.md`; the taxonomy decision this issue's Gate 1 owned is now `docs/DR-313-defect-taxonomy.md`.

## What this adds

A `Defect` model and an enumeration stage. Per obligation, the stage is shown the obligation and the changed **production** code, and walks a checklist chosen by that obligation's type, with a free-text `other` escape where nothing fits. A reasoned empty set is a valid answer.

**The stage is never shown a test.** The change set reaching it is filtered to non-test files in code, and the stage runs in `pipeline.py` *before test discovery*, so at that line there is no test evidence in existence to hand it. That is the mitigation for #252, where a denominator chosen by something that can see what is already covered drifts toward it.

**Advisory.** Nothing reads `defect_sets`, and no verdict or rating depends on it — DR-312 decision 5's staged migration, which is what lets a later rating movement be attributed to one cause instead of three.

**Carry.** A set is reused while the obligation's text and the contents of the regions its defects implicate are both unchanged, so one reworded obligation costs one call. The carry key names neither the obligation's id nor the change set's hunk labels: the first would re-enumerate a renamed obligation, the second would re-enumerate everything whenever any unrelated file gained a hunk.

## Decision this makes, which #314 and #316 inherit

`test_demand` and `human_review` obligations are **excluded from enumeration entirely** (DR-313 decision 2). This resolves a conflict inside DR-312: the enumerator may never see the tests, but a `test_demand` obligation is *about* a test. #313's own mandate produced six of them, so it is not a corner case.

**Consequence: an absent defect set must be kept distinct from an empty one.** An empty set means "looked, found no plausible static defect, here is why". Claiming that about an obligation the stage never examined would be a false negative wearing a reason.

## Acceptance

| item | demonstrated by |
|---|---|
| the stage sees no test | `test_the_enumerator_is_given_no_test` — asserts on the request as sent, not on the filter |
| a true-by-construction obligation yields a reasoned empty set, not an invented defect | `test_a_criterion_with_no_plausible_defect_yields_an_empty_set_with_its_reason`, `test_an_empty_set_with_no_reason_is_recorded_as_one_rather_than_left_blank` |
| only a reworded obligation re-enumerates, asserted by call count | `test_changing_one_criterion_leaves_every_other_criterion_s_set_reused`, `test_a_set_is_reused_when_the_criterion_and_its_implicated_regions_are_unchanged` |
| a changed obligation keeps no part of its earlier set | `test_a_criterion_whose_text_changed_keeps_no_part_of_its_earlier_set` |
| two recorded runs are byte-identical, report included | `test_two_runs_over_the_same_input_agree_byte_for_byte` |
| the verdict and every rating are unchanged | `test_recording_ways_of_failing_changes_no_verdict_and_no_rating` — compares two reviews of one repo whose enumerations differ |
| the pipeline really calls it | `test_the_pipeline_really_calls_the_enumerator` |

**Verified by defect injection, not by reading.** Removing the test filter, making every obligation type enumerable, disabling the carry, and leaking defects into `findings` each failed the tests written for them. The third injection also exposed a flaky test of my own — two tests each built a fresh git repo per review, so their head SHAs agreed only when both commits landed in the same second. Fixed in its own commit.

## One change outside this mandate, deliberately

`align_obligations` gains a `stage` parameter and `requirement/carry.py` passes one. Before this, every continued run whose requirement text moved reported that call under `unknown` — the one bucket `llm.py` says a review-pipeline call site may never land in — which also broke #317's just-landed requirement that a run says which model each step used.

Found at this issue's Gate 1 and rolled in on the maintainer's instruction rather than filed. `tests/test_stage_attribution.py`'s scan had a hole rather than a bug: it excludes `benchmark/` on the grounds that the harness is not part of a review run, and `carry.py` imports out of it. The scan now follows those imports, and a companion test pins the crossing set to exactly one. Both tests verified to fail with the fix reverted.

The check correctly flags this as unrequested. Left unfixed: `carry.py` still imports from `benchmark/`, against the layering CLAUDE.md states. Moving the function would touch `benchmark/scoring.py`, `benchmark/instability.py` and their tests.

## Gates

**Gate 1 passed** on run 5 (`dogfood-logs/313-gate1-run{3,4,5}/`). Runs 3 and 4 derived two obligations demanding the behaviour their requirement forbids, on two different wordings; run 5 states those requirements as what a test must assert rather than when a test must fail, and both came out correct. Recorded against #262, the issue for a paraphrase that does not preserve entailment.

**Gate 2 was run once and is not clean** (`dogfood-logs/313-gate2-run1/`), which the suspension in CLAUDE.md permits while #312's sub-issues land. `UNABLE-TO-DETERMINE` on one obligation of twenty-eight: `pre-test-failure-modes` has no mapped test, because the test that evidences it was mapped only to `completion-02`'s `test_demand` obligation. The two are correctly unmerged — `ObligationType.TEST_DEMAND` exists to keep them apart (DR-232) — so this is a recall failure in test-to-obligation mapping, in #182's area, and in the stage #316 retires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)