### PR TITLE
Benchmark: defect-set ground truth and scoring (#315)

### DIFF
--- a/current-task.md
+++ b/current-task.md
@@ -1,63 +1,58 @@
 # Task
-Before any test is looked at, the review records — for each criterion it derived
-from the mandate — the concrete ways the delivered code could plausibly fail that
-criterion.
+The measurement harness scores the ways of failing that a review recorded
+against a human-authored reference set. The figure for what the review failed to
+record and the figure for what it wrongly predicted about tests are never
+combined into a single figure.
 
 ## Constraints
-- Each recorded way of failing carries an identifier unique within the review,
-  the criterion it belongs to, a classification, a free-text description, and the
-  regions of changed source it implicates.
-- Every other part of the review that names a recorded way of failing names it by
-  that identifier, and does not restate its content.
-- A classification is either a value from a fixed vocabulary or a single escape
-  value meaning the vocabulary has no value for this way of failing.
-- The recorded ways of failing persist with the rest of the review's state, and a
-  review reloaded from storage carries them unchanged.
-- The step that produces them is given the criterion and the changed source, and
-  is given no test.
-- That step is guided by a checklist of ways to fail chosen by the criterion's
-  type, and may still record a way of failing that no entry on that checklist
-  names.
-- Recording no way of failing for a criterion is a valid result for that
-  criterion, and carries the reason the set is empty.
-- A criterion's set of records is reused rather than produced again exactly while
-  both that criterion's text and the contents of the source regions its records
-  implicate are unchanged.
-- A criterion whose text changed has its entire set produced again, and keeps no
-  part of the set recorded for it before.
-- A run continuing an earlier run reuses every set it is entitled to reuse.
-- A run continuing an earlier run produces again only the sets it is not
-  entitled to reuse.
-- Where a set was reused rather than produced again, the review says so.
-- The review reports the recorded ways of failing.
-- Whether the review reports the work complete, and every rating it gives a
-  criterion, are what they would be if no way of failing had been recorded at
-  all.
+- A reference set states, for each criterion of a labelled case, the ways of
+  failing a competent reviewer should record. Each carries an identifier, a
+  classification drawn from the same fixed vocabulary the review uses, a
+  free-text description, and the tests that would fail if the delivered code
+  contained it.
+- A criterion for which no way of failing is plausible carries that fact and the
+  reason, and stays distinguishable from a criterion the reference set says
+  nothing about.
+- A reference set naming a criterion its case does not define, or naming a test
+  its case does not supply, is rejected rather than loaded.
+- A recorded way of failing is matched to a labelled one by what the two
+  describe, not by their wording, and each side takes part in at most one match.
+- Whether a match was found and whether the two classifications agree are
+  reported as separate figures.
+- The share of recorded ways of failing carrying the vocabulary's escape value is
+  reported as a standing figure.
+- The share of labelled ways of failing that the review recorded is reported for
+  each classification separately.
+- How well the predicted catching tests agree with the labelled ones is reported
+  as its own figure, computed independently of the share above.
+- A figure with nothing to compute from is reported as absent, and never as zero.
+- The existing measure of whether two criteria stating the same demand receive
+  the same tests is also computed over the tests reached by way of the recorded
+  ways of failing.
+- Scoring runs from recorded material and issues no live call to a model.
+- Every reference set shipped with the harness loads and validates.
 
 ## Scope exclusions
-- Judging whether any test would fail if the delivered code contained a recorded
-  way of failing.
-- Deriving any rating, classification or conclusion about a criterion from its
-  recorded ways of failing.
-- Which criteria the review derives from the mandate, and how it derives them.
-- How the review gathers, judges or rates test evidence today.
-- Running the delivered code, and altering it to produce a failure.
-- Comparing a recorded set against an expected set supplied from outside the
-  review.
+- Producing the ways of failing that are scored, and predicting which tests
+  would catch one.
+- Any rating, conclusion, recommendation or report the review itself produces.
+- Which criteria the review derives from a mandate, and how it derives them.
+- Judging whether a labelled way of failing is itself the right one to expect.
+- Running any code under review.
 
 ## Completion expectations
 - Implementation.
-- A test asserts that the step that records ways of failing is given no test.
-- A test fails when a criterion with no plausible way of failing is given an
-  invented one instead of an empty set carrying its reason.
-- A test fails when a set is produced again across two continued runs although
-  the criterion's text and the contents of its implicated source regions are both
-  unchanged.
-- A test fails when a criterion whose text changed keeps any part of the set
-  recorded for it before.
-- A test asserts that changing one criterion's text leaves every other
-  criterion's set reused rather than produced again.
-- A test fails when recording ways of failing changes the review's completion
-  conclusion or any criterion's rating.
-- Two recorded runs over the same input produce byte-identical review state and
-  byte-identical report output.
+- A test fails when a reference set naming a criterion its case does not define
+  is loaded rather than rejected.
+- A test fails when a criterion with no plausible way of failing is stored so
+  that it cannot be told apart from one the reference set is silent about.
+- A test asserts that a recorded way of failing worded differently from its
+  labelled counterpart still matches it.
+- A test fails when a disagreement between two classifications is counted as a
+  way of failing the review never recorded.
+- A test asserts that the share of labelled ways of failing recorded, and the
+  agreement between predicted and labelled catching tests, are computed
+  independently of each other.
+- On a small set whose figures are known by hand, every computed figure equals
+  the hand-computed one.
+- A test fails when scoring issues a live call to a model.

--- a/src/acceptance/benchmark/case.py
+++ b/src/acceptance/benchmark/case.py
@@ -45,6 +45,7 @@ from acceptance.model_base import PersistableModel
 from acceptance.requirement.registry import build_registry
 from acceptance.requirement.task_file import parse_task_file
 from acceptance.review_state import (
+    DefectType,
     EvidenceClassification,
     ObligationType,
     Review,
@@ -110,6 +111,43 @@ class GroundTruthObligation(PersistableModel):
     candidate_tests: list[str] = Field(default_factory=list)  # test ids (pytest nodeids)
     expected_type: ObligationType | None = None
     required_symbols: list[str] = Field(default_factory=list)
+    # Set when the ground truth's position is that this obligation admits no
+    # plausible static defect — #270's shape, an obligation true by construction.
+    # That is a *label*, distinct in both directions from `None`, which says the
+    # ground truth takes no position on this obligation's defects at all. The
+    # distinction is the whole of DefectSet's own "nothing found" versus "not
+    # looked at" rule, restated on the labelling side: without it a case with no
+    # defect labels scores an enumerator that invented three defects the same as
+    # one that correctly recorded none.
+    no_plausible_defect_reason: str | None = None
+
+
+class GroundTruthDefect(PersistableModel):
+    """One way of failing an obligation that a competent reviewer should record,
+    and the tests that would fail if the delivered code contained it (#315).
+
+    The label counterpart of `review_state.Defect`, and deliberately the same
+    shape: `type` is drawn from the same `DefectType` vocabulary the enumerator
+    spends, with `OTHER` allowed, so a labelled defect and a recorded one can be
+    compared on classification without a translation table.
+
+    `killed_by` is what separates the two failures this issue exists to tell
+    apart. Enumeration recall asks whether the review recorded this defect at
+    all; kill agreement asks whether it then got the tests right. An **empty**
+    `killed_by` is a real label, not a missing one: archetype #4 is the case
+    where a present, relevant test kills nothing, and a defect no test catches
+    is exactly the finding the review is supposed to produce.
+
+    `description` is free text and is never matched verbatim — see
+    `defect_scoring.align_defects`, which matches on what two descriptions
+    describe, for the same reason `align_obligations` exists.
+    """
+
+    id: str
+    obligation_id: str
+    type: DefectType
+    description: str
+    killed_by: list[str] = Field(default_factory=list)  # test ids (pytest nodeids)
 
 
 class GroundTruthGap(PersistableModel):
@@ -193,6 +231,7 @@ class GroundTruthLabels(PersistableModel):
     gaps: list[GroundTruthGap] = Field(default_factory=list)
     unrequested_changes: list[GroundTruthUnrequestedChange] = Field(default_factory=list)
     open_questions: list[GroundTruthOpenQuestion] = Field(default_factory=list)
+    defects: list[GroundTruthDefect] = Field(default_factory=list)
 
     @model_validator(mode="after")
     def _check_tree_integrity(self) -> GroundTruthLabels:
@@ -243,7 +282,88 @@ class GroundTruthLabels(PersistableModel):
             raise ValueError("unrequested-change ids must be unique")
         if any(not u.file.strip() for u in self.unrequested_changes):
             raise ValueError("every unrequested change must name a non-empty file")
+
+        self._check_defect_integrity(known)
         return self
+
+    def _check_defect_integrity(self, obligation_ids: set[str]) -> None:
+        """Defect labels resolve, and say nothing they cannot say (#315).
+
+        Rejecting rather than loading, for the reason the rest of this validator
+        does: ground truth that carries a dangling reference scores the checker
+        against something no reviewer could have produced, and the failure is
+        silent — a defect labelled against an obligation the case does not define
+        can never be matched, so it depresses enumeration recall forever while
+        looking like a real miss.
+
+        `killed_by` is checked against the tests the case actually supplies, that
+        being the union of every obligation's `candidate_tests`. A label naming a
+        test outside it is either a typo or a test the case does not have, and
+        both make kill agreement unscoreable in the same invisible way.
+        """
+        defect_ids = [d.id for d in self.defects]
+        if any(not did.strip() for did in defect_ids):
+            raise ValueError("every defect id must be a non-empty string")
+        if len(set(defect_ids)) != len(defect_ids):
+            raise ValueError("defect ids must be unique")
+
+        supplied_tests = {t for o in self.obligations for t in o.candidate_tests}
+        for defect in self.defects:
+            if defect.obligation_id not in obligation_ids:
+                raise ValueError(
+                    f"defect {defect.id!r} references unknown obligation {defect.obligation_id!r}"
+                )
+            if not defect.description.strip():
+                raise ValueError(f"defect {defect.id!r} must have a non-empty description")
+            for test_id in defect.killed_by:
+                if not test_id.strip():
+                    raise ValueError(f"defect {defect.id!r} has an empty test id in killed_by")
+                if test_id not in supplied_tests:
+                    raise ValueError(
+                        f"defect {defect.id!r} is killed_by {test_id!r}, which no "
+                        "obligation lists as a candidate test"
+                    )
+
+        # "No plausible defect" and a labelled defect are contradictory claims
+        # about the same obligation. Left to coexist, the pair would let a case
+        # score an enumerator both for recording the defect and for correctly
+        # recording none.
+        labelled = {d.obligation_id for d in self.defects}
+        for obligation in self.obligations:
+            if obligation.no_plausible_defect_reason is None:
+                continue
+            if not obligation.no_plausible_defect_reason.strip():
+                raise ValueError(
+                    f"obligation {obligation.id!r} has an empty "
+                    "no_plausible_defect_reason; omit the field to take no position"
+                )
+            if obligation.id in labelled:
+                raise ValueError(
+                    f"obligation {obligation.id!r} says no defect is plausible but "
+                    "also carries labelled defects"
+                )
+
+
+class DefectScore(PersistableModel):
+    """Every defect-set figure for one case (#315), each independently absent-able.
+
+    Lives here rather than in `defect_scoring.py` so that module can import it
+    without a cycle, and beside `BenchmarkScore` because it is one.
+
+    Counts travel with the shares because a share alone cannot be read: "recall
+    1.0" over one labelled defect and over twenty are different claims, and
+    DR-312 requires the denominator to be disclosed wherever the figure renders.
+    """
+
+    enumeration_recall: float | None = None
+    recall_by_type: dict[DefectType, float] = Field(default_factory=dict)
+    type_agreement: float | None = None
+    other_share: float | None = None
+    kill_agreement: float | None = None
+    labelled: int = 0
+    recorded: int = 0
+    matched: int = 0
+    predicted: int = 0
 
 
 class BenchmarkScore(PersistableModel):
@@ -268,6 +388,11 @@ class BenchmarkScore(PersistableModel):
     open_question_recall: float | None = None
     open_question_precision: float | None = None
     obligation_type_accuracy: float | None = None
+    # Defect-set figures (#315). A nested record rather than flat fields because
+    # every figure inside it shares one denominator disclosure, and because it
+    # is absent as a whole on a case with no defect labels — which is different
+    # from each figure being individually absent.
+    defects: DefectScore | None = None
 
 
 class BenchmarkCase(PersistableModel):

--- a/src/acceptance/benchmark/defect_scoring.py
+++ b/src/acceptance/benchmark/defect_scoring.py
@@ -1,0 +1,342 @@
+"""Scoring the ways of failing a review recorded, against labelled ones (#315).
+
+Separates two failures the ratings alone cannot tell apart: **the enumerator
+missed the defect**, and **the judge missed the kill**. They have different
+causes and different fixes, and a single "evidence quality" number hides which
+one moved — which is #252's shape, where a self-enumerated denominator lets a
+thinner enumeration earn a stronger rating.
+
+So `enumeration_recall` and `kill_agreement` are computed by separate functions
+over separate denominators, and neither can move the other:
+
+- a labelled defect the review never recorded lowers recall, and contributes
+  **nothing at all** to kill agreement — it is not in that figure's denominator,
+  so a thin enumeration cannot flatter its kill predictions;
+- a matched defect whose predicted killers are wrong lowers kill agreement and
+  leaves recall untouched.
+
+`type_agreement` is third and equally separate: a defect recorded with the right
+description and the wrong classification is a *match* with a type disagreement,
+never a miss. Folding the two together would report a taxonomy problem as an
+enumeration problem.
+
+## What this module does not do
+
+It does not produce defects and it does not predict kills. Predicted kills
+arrive as `PredictedKills`, a plain mapping supplied by the caller — #314 fills
+it, this module only scores it. Where nothing supplies a prediction the figure
+is **absent, not zero**, on the same discipline `GroundTruthObligation.
+expected_type` already follows: silence is not agreement, and a metric computed
+over no data is not a score of zero.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+from acceptance.benchmark.case import DefectScore, GroundTruthDefect, GroundTruthObligation
+from acceptance.benchmark.twin_splitting import ReportMapping
+from acceptance.llm import ModelClient, StrictResponseModel
+from acceptance.review_state import Defect, DefectType
+
+__all__ = [
+    "DefectScore",
+    "PredictedKills",
+    "align_defects",
+    "enumeration_recall",
+    "kill_agreement",
+    "mapping_from_defects",
+    "other_share",
+    "recall_by_type",
+    "score_defects",
+    "type_agreement",
+]
+
+# Recorded defect id -> the pytest node ids predicted to fail if the delivered
+# code contained that defect. The one interface #314 fills and this module
+# reads; changing its shape is a decision, not a refactor.
+PredictedKills = Mapping[str, set[str]]
+
+
+_SYSTEM_PROMPT = """\
+You align two lists of DEFECTS: LABELLED (human-authored) and RECORDED
+(produced by a tool). Each defect is a concrete way a piece of code could fail
+one requirement.
+
+Match each recorded defect to the ONE labelled defect describing the SAME way of
+failing — the same mistake in the same rule, even if worded differently. Not
+every defect has a match; leave unmatched ones out. Each labelled defect and
+each recorded defect may appear in at most one match.
+
+Match on the mistake described, not on surface wording. Two defects that would
+be introduced by different edits are NOT the same defect, even when they mention
+the same function, value or field. A defect about a wrong value and a defect
+about a missing case are different defects. Do not match a defect describing a
+failure of one rule to a defect describing a failure of a different rule.
+
+Return the matches as pairs of the given labels (e.g. labelled "l2",
+recorded "r0")."""
+
+
+class _LabelMatch(StrictResponseModel):
+    labelled: str
+    recorded: str
+
+
+class _DefectAlignment(StrictResponseModel):
+    matches: list[_LabelMatch]
+
+
+def _render_prompt(labelled: dict[str, GroundTruthDefect], recorded: dict[str, Defect]) -> str:
+    lines = ["## Labelled defects", ""]
+    for label, defect in labelled.items():
+        lines.append(f"[{label}] {defect.description}")
+    lines.append("")
+    lines.append("## Recorded defects")
+    lines.append("")
+    for label, defect in recorded.items():
+        lines.append(f"[{label}] {defect.description}")
+    return "\n".join(lines)
+
+
+def align_defects(
+    labelled: Sequence[GroundTruthDefect],
+    recorded: Sequence[Defect],
+    client: ModelClient,
+    stage: str | None = None,
+) -> dict[str, str]:
+    """Return a `recorded defect id -> labelled defect id` map, a bijection over
+    the matched subset.
+
+    By id, not by description: two defects of one review can legitimately carry
+    near-identical descriptions under different obligations, and a
+    description-keyed map would silently collapse them.
+
+    Matching is a model judgement for the reason `align_obligations` is one — a
+    real enumerator words a defect differently from the human who labelled it,
+    and an exact-string join scores a perfect enumeration at zero. This does not
+    reuse `align_obligations`: that prompt is written for acceptance criteria
+    and asks which two state the same *requirement*, which is a different
+    question from which two describe the same *mistake*. `case.py` already
+    records the same misapplication risk for open questions.
+
+    **Known limitation.** Alignment is global, not per obligation: a recorded
+    defect may match a labelled defect belonging to a different obligation. The
+    prompt argues against it, but nothing enforces it, so enumeration recall is
+    an upper bound on per-obligation recall. Enforcing it needs the ground-truth
+    and reviewer obligations aligned first, which is a second model call and a
+    second thing to be wrong; not worth it until a case is observed where the
+    two figures differ.
+    """
+    if not labelled or not recorded:
+        return {}
+
+    labelled_labels = {f"l{i}": d for i, d in enumerate(labelled)}
+    recorded_labels = {f"r{i}": d for i, d in enumerate(recorded)}
+
+    messages = [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {"role": "user", "content": _render_prompt(labelled_labels, recorded_labels)},
+    ]
+    result = client.complete(messages, _DefectAlignment, stage=stage)
+
+    alignment: dict[str, str] = {}
+    used_labelled: set[str] = set()
+    used_recorded: set[str] = set()
+    for match in result.matches:
+        if (
+            match.labelled in labelled_labels
+            and match.recorded in recorded_labels
+            and match.labelled not in used_labelled
+            and match.recorded not in used_recorded
+        ):
+            alignment[recorded_labels[match.recorded].id] = labelled_labels[match.labelled].id
+            used_labelled.add(match.labelled)
+            used_recorded.add(match.recorded)
+    return alignment
+
+
+def enumeration_recall(
+    labelled: Sequence[GroundTruthDefect],
+    alignment: Mapping[str, str],
+) -> float | None:
+    """Share of labelled defects the review recorded. `None` when nothing is
+    labelled — a case that takes no position scores no recall, rather than 0.0.
+
+    Reads only the alignment's labelled side, so it cannot see a prediction and
+    cannot be moved by one.
+    """
+    if not labelled:
+        return None
+    matched = set(alignment.values())
+    return sum(1 for d in labelled if d.id in matched) / len(labelled)
+
+
+def recall_by_type(
+    labelled: Sequence[GroundTruthDefect],
+    alignment: Mapping[str, str],
+) -> dict[DefectType, float]:
+    """Enumeration recall per labelled `DefectType`.
+
+    Only types the labels actually use appear. A type with no labelled defect is
+    absent from the mapping rather than present at 0.0, for the same reason
+    `enumeration_recall` returns `None` on an empty set: an unmeasured type and
+    a type the enumerator missed entirely must not read alike.
+    """
+    matched = set(alignment.values())
+    totals: dict[DefectType, list[int]] = {}
+    for defect in labelled:
+        bucket = totals.setdefault(defect.type, [0, 0])
+        bucket[1] += 1
+        if defect.id in matched:
+            bucket[0] += 1
+    return {t: hits / total for t, (hits, total) in totals.items()}
+
+
+def type_agreement(
+    labelled: Sequence[GroundTruthDefect],
+    recorded: Sequence[Defect],
+    alignment: Mapping[str, str],
+) -> float | None:
+    """Share of *matched* pairs whose classifications agree. `None` when nothing
+    matched.
+
+    Over matched pairs only, which is the whole point: a recorded defect that
+    describes the right mistake under the wrong type is a classification
+    disagreement, not a defect the review failed to record. Scoring it as a miss
+    would report a taxonomy problem as an enumeration problem and send the fix
+    to the wrong stage.
+    """
+    labelled_by_id = {d.id: d for d in labelled}
+    recorded_by_id = {d.id: d for d in recorded}
+    pairs = [
+        (recorded_by_id[r], labelled_by_id[label])
+        for r, label in alignment.items()
+        if r in recorded_by_id and label in labelled_by_id
+    ]
+    if not pairs:
+        return None
+    return sum(1 for rec, lab in pairs if rec.type == lab.type) / len(pairs)
+
+
+def other_share(recorded: Sequence[Defect]) -> float | None:
+    """Share of recorded defects carrying the taxonomy's escape value.
+
+    A standing figure, per DR-312: a rising share is a taxonomy gap, and a
+    near-zero share alongside poor enumeration recall is odd defects being
+    forced into the nearest slot rather than a taxonomy that fits. Neither
+    reading is available from recall alone, which is why this is reported even
+    when it looks uninteresting.
+    """
+    if not recorded:
+        return None
+    return sum(1 for d in recorded if d.type is DefectType.OTHER) / len(recorded)
+
+
+def _jaccard(predicted: set[str], expected: set[str]) -> float:
+    """Agreement between two test sets, with empty-vs-empty scored as exact.
+
+    Empty against empty is 1.0 deliberately. A labelled defect with no killing
+    test is a real label and the most important one in the corpus — archetype #4
+    is exactly a present, relevant test that kills nothing — so a prediction of
+    "no test catches this" is a correct prediction and must score as one. The
+    usual convention of undefined-on-empty would drop that case out of the
+    figure entirely, which is the one case it most needs to cover.
+    """
+    if not predicted and not expected:
+        return 1.0
+    union = predicted | expected
+    return len(predicted & expected) / len(union)
+
+
+def kill_agreement(
+    labelled: Sequence[GroundTruthDefect],
+    alignment: Mapping[str, str],
+    predicted: PredictedKills | None,
+) -> float | None:
+    """How well the predicted killing tests agree with the labelled ones, over
+    matched defects that carry a prediction. `None` when nothing supplies one.
+
+    The denominator is matched defects with a prediction, and that is what keeps
+    this figure independent of `enumeration_recall`. A labelled defect the
+    review never recorded is outside the denominator, so failing to enumerate
+    cannot raise or lower kill agreement; and a wrong prediction cannot reach
+    recall, which never reads this argument.
+
+    `None` rather than 0.0 when `predicted` is absent or covers none of the
+    matched defects: before #314 exists there is nothing to score, and a zero
+    would read as a stage that predicts badly rather than one that has not run.
+    """
+    if not predicted:
+        return None
+    labelled_by_id = {d.id: d for d in labelled}
+    scores = [
+        _jaccard(set(predicted[recorded_id]), set(labelled_by_id[labelled_id].killed_by))
+        for recorded_id, labelled_id in alignment.items()
+        if recorded_id in predicted and labelled_id in labelled_by_id
+    ]
+    if not scores:
+        return None
+    return sum(scores) / len(scores)
+
+
+def mapping_from_defects(
+    source: str,
+    obligations: Sequence[GroundTruthObligation],
+    recorded: Sequence[Defect],
+    predicted: PredictedKills | None,
+) -> ReportMapping:
+    """The tests each obligation reaches *by way of* its recorded defects, in the
+    shape `twin_splitting.twin_pairs` already consumes.
+
+    Builds the input rather than duplicating the measure: whether two
+    obligations stating the same demand receive the same tests is the same
+    question before and after the defect-first change, and it deserves the same
+    code. What moves is only how an obligation reaches a test — directly under
+    the current mapping stage, and through its defects here — so recomputing the
+    existing split rate over this mapping is a regression check on the change,
+    not a new metric to calibrate.
+
+    An obligation whose defects have no prediction reaches no test, which
+    `twin_pairs` already handles: a pair where neither side maps a test scores
+    no opportunities and so cannot register a split.
+    """
+    reached: dict[int, list[str]] = {}
+    texts: dict[int, str] = {}
+    defects_by_obligation: dict[str, list[Defect]] = {}
+    for defect in recorded:
+        defects_by_obligation.setdefault(defect.obligation_id, []).append(defect)
+
+    for index, obligation in enumerate(obligations):
+        texts[index] = obligation.description
+        tests: set[str] = set()
+        for defect in defects_by_obligation.get(obligation.id, []):
+            if predicted:
+                tests |= set(predicted.get(defect.id, ()))
+        reached[index] = sorted(tests)
+    return ReportMapping(source=source, obligations=texts, mapped_tests=reached)
+
+
+def score_defects(
+    labelled: Sequence[GroundTruthDefect],
+    recorded: Sequence[Defect],
+    alignment: Mapping[str, str],
+    predicted: PredictedKills | None = None,
+) -> DefectScore:
+    """Every figure for one case, from an alignment already computed.
+
+    Takes the alignment rather than a client so scoring itself makes no model
+    call: the one model judgement in this module is `align_defects`, which the
+    caller runs once, and everything here is arithmetic over its result.
+    """
+    return DefectScore(
+        enumeration_recall=enumeration_recall(labelled, alignment),
+        recall_by_type=recall_by_type(labelled, alignment),
+        type_agreement=type_agreement(labelled, recorded, alignment),
+        other_share=other_share(recorded),
+        kill_agreement=kill_agreement(labelled, alignment, predicted),
+        labelled=len(labelled),
+        recorded=len(recorded),
+        matched=len(alignment),
+        predicted=len(predicted or {}),
+    )

--- a/src/acceptance/benchmark/scoring.py
+++ b/src/acceptance/benchmark/scoring.py
@@ -304,10 +304,20 @@ def _defect_score(
     """Defect-set figures for this case, or `None` where there is nothing to
     score (#315).
 
-    Guarded on both sides having content, and on a client being available,
-    because the alignment is a model call: a case with no defect labels, or a
-    review that recorded no defects, must not spend one to compute figures that
-    would all be absent anyway.
+    The three cases are deliberately different, and conflating the middle one
+    with the others is the mistake this docstring exists to prevent:
+
+    - **No labelled defects** — the ground truth takes no position, so there is
+      nothing to score and every figure would be meaningless. `None`.
+    - **Labelled defects but the review recorded none** — a real, total
+      enumeration miss, and one of the more important results the corpus can
+      produce. It scores `enumeration_recall` **0.0**, not absent. Reporting it
+      as unmeasured would hide a failed enumerator behind the same blank an
+      unlabelled case shows. No model call is needed or made: with one side
+      empty there is nothing to align.
+    - **No client** — the alignment cannot run, so a recorded defect cannot be
+      matched to its label. Scoring anyway would report every match as a miss,
+      which is a measurement artefact, not a result. `None`.
 
     `predicted` is #314's output and does not exist yet. Absent, every figure
     here still computes except `kill_agreement`, which reports absent rather
@@ -315,7 +325,11 @@ def _defect_score(
     """
     labelled = case.ground_truth.defects
     recorded = [d for s in case.reviewer_output.defect_sets for d in s.defects]
-    if not labelled or not recorded or client is None:
+    if not labelled:
+        return None
+    if not recorded:
+        return score_defects(labelled, recorded, {}, predicted)
+    if client is None:
         return None
     alignment = align_defects(labelled, recorded, client)
     return score_defects(labelled, recorded, alignment, predicted)

--- a/src/acceptance/benchmark/scoring.py
+++ b/src/acceptance/benchmark/scoring.py
@@ -51,6 +51,12 @@ from pydantic import Field
 
 from acceptance.benchmark.alignment import align_obligations
 from acceptance.benchmark.case import BenchmarkCase, BenchmarkScore
+from acceptance.benchmark.defect_scoring import (
+    DefectScore,
+    PredictedKills,
+    align_defects,
+    score_defects,
+)
 from acceptance.llm import ModelClient
 from acceptance.model_base import PersistableModel
 from acceptance.review_state import UNREQUESTED_CHANGE
@@ -290,10 +296,45 @@ def _score_from_counts(counts: dict[str, _MatchCounts]) -> BenchmarkScore:
     )
 
 
-def score_case(case: BenchmarkCase, client: ModelClient | None = None) -> BenchmarkScore:
+def _defect_score(
+    case: BenchmarkCase,
+    client: ModelClient | None,
+    predicted: PredictedKills | None,
+) -> DefectScore | None:
+    """Defect-set figures for this case, or `None` where there is nothing to
+    score (#315).
+
+    Guarded on both sides having content, and on a client being available,
+    because the alignment is a model call: a case with no defect labels, or a
+    review that recorded no defects, must not spend one to compute figures that
+    would all be absent anyway.
+
+    `predicted` is #314's output and does not exist yet. Absent, every figure
+    here still computes except `kill_agreement`, which reports absent rather
+    than zero.
+    """
+    labelled = case.ground_truth.defects
+    recorded = [d for s in case.reviewer_output.defect_sets for d in s.defects]
+    if not labelled or not recorded or client is None:
+        return None
+    alignment = align_defects(labelled, recorded, client)
+    return score_defects(labelled, recorded, alignment, predicted)
+
+
+def score_case(
+    case: BenchmarkCase,
+    client: ModelClient | None = None,
+    predicted_kills: PredictedKills | None = None,
+) -> BenchmarkScore:
     """Score one case. Pass a `client` for semantic obligation matching (#118);
-    with none, the obligation-keyed metrics fall back to exact-string match."""
-    return _score_from_counts(_all_counts(case, client))
+    with none, the obligation-keyed metrics fall back to exact-string match.
+
+    `predicted_kills` is #314's per-defect prediction of which tests would fail.
+    Until that stage exists nothing supplies it, and the kill figure inside
+    `defects` reports absent rather than zero."""
+    score = _score_from_counts(_all_counts(case, client))
+    score.defects = _defect_score(case, client, predicted_kills)
+    return score
 
 
 class BenchmarkReport(PersistableModel):
@@ -355,14 +396,26 @@ def score_case_set(
         counts = _all_counts(case, client)
         for family in _FAMILIES:
             totals[family] += counts[family]
-        per_case.append(_score_from_counts(counts))
+        score = _score_from_counts(counts)
+        score.defects = _defect_score(case, client, None)
+        per_case.append(score)
         modes.add(_case_determinism_mode(case))
 
     pooled = _score_from_counts(totals)
+    # `defects` is dropped from the pooled figures rather than aggregated, and
+    # this is a real limit, not an oversight: the other families pool by raw
+    # `_MatchCounts`, so a large case and a small one contribute in proportion.
+    # A DefectScore carries shares, not counts, and averaging shares across
+    # cases would weight a case with one labelled defect equally with one
+    # carrying twenty — the reading DR-312's disclosed-denominator rule exists
+    # to prevent. Per-case defect figures are in `per_case`; a pooled figure
+    # needs the counts threaded through `_MatchCounts`, which is its own change.
+    pooled_fields = pooled.model_dump()
+    pooled_fields.pop("defects", None)
     return BenchmarkReport(
         case_count=len(cases),
         determinism_mode=_reconcile_determinism_modes(modes),
-        **pooled.model_dump(),
+        **pooled_fields,
         per_case=per_case,
     )
 

--- a/tests/benchmark/test_defect_scoring.py
+++ b/tests/benchmark/test_defect_scoring.py
@@ -456,6 +456,50 @@ def test_score_case_populates_the_defect_figures():
     assert score.defects.kill_agreement is None
 
 
+def test_an_enumerator_that_recorded_nothing_scores_zero_not_absent():
+    """A total enumeration miss is a result, not a blank.
+
+    Reported as absent it would look exactly like a case the ground truth takes
+    no position on, so the worst enumeration outcome the corpus can show would
+    be indistinguishable from having nothing to say. Found by the Gate 2 run on
+    this issue's own change.
+    """
+    from acceptance.benchmark.scoring import score_case
+
+    case = _scoreable_case(
+        labelled=[_labelled("d1", oid="o1", desc="The total is not rounded")],
+        defect_sets=[],
+    )
+    # No client at all: with one side empty there is nothing to align, so the
+    # figure is still computable and must still be computed.
+    score = score_case(case, None)
+
+    assert score.defects is not None
+    assert score.defects.enumeration_recall == 0.0
+    assert score.defects.labelled == 1
+    assert score.defects.recorded == 0
+    assert score.defects.matched == 0
+    # These genuinely have nothing to compute from and stay absent.
+    assert score.defects.type_agreement is None
+    assert score.defects.other_share is None
+
+
+def test_no_client_leaves_the_figures_absent_rather_than_scoring_every_match_a_miss():
+    from acceptance.benchmark.scoring import score_case
+    from acceptance.review_state import DefectSet
+
+    case = _scoreable_case(
+        labelled=[_labelled("d1", oid="o1", desc="The total is not rounded")],
+        defect_sets=[DefectSet(obligation_id="o1", defects=[_recorded("r1", oid="o1")])],
+    )
+
+    score = score_case(case, None)
+
+    # Both sides have content, but nothing can match them. A 0.0 here would be a
+    # measurement artefact reported as an enumerator failure.
+    assert score.defects is None
+
+
 def test_score_case_leaves_the_defect_figures_absent_with_no_labels():
     """And spends no model call doing it."""
     from acceptance.benchmark.scoring import score_case

--- a/tests/benchmark/test_defect_scoring.py
+++ b/tests/benchmark/test_defect_scoring.py
@@ -1,0 +1,479 @@
+"""#315: defect-set ground truth, and scoring a review's recorded defects.
+
+The whole point of this module is that two failures stay apart — the enumerator
+missed the defect, and the judge missed the kill. Several tests below exist only
+to hold that separation in place, because collapsing the two is the easy and
+invisible mistake: every figure still computes, and the number that moves points
+at the wrong stage.
+
+Alignment is a schema-constrained model call, so per the replay-first invariant
+these tests inject the recorded response and make no live call.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from acceptance.benchmark.case import (
+    GroundTruthDefect,
+    GroundTruthLabels,
+    GroundTruthObligation,
+)
+from acceptance.benchmark.defect_scoring import (
+    align_defects,
+    enumeration_recall,
+    kill_agreement,
+    mapping_from_defects,
+    other_share,
+    recall_by_type,
+    score_defects,
+    type_agreement,
+)
+from acceptance.benchmark.fixtures import load_labels
+from acceptance.benchmark.twin_splitting import twin_pairs
+from acceptance.review_state import Defect, DefectType
+from tests.support import client_dispatching, client_returning
+
+ARCHETYPES = Path(__file__).resolve().parents[1] / "fixtures" / "archetypes"
+
+
+def _obligation(oid: str, description: str = "d", tests: list[str] | None = None, **kwargs):
+    return GroundTruthObligation(
+        id=oid,
+        description=description,
+        explicit=True,
+        evidence_class="partially_supported",
+        evidence_rationale="because",
+        candidate_tests=tests if tests is not None else [],
+        **kwargs,
+    )
+
+
+def _labelled(did: str, oid: str = "o1", dtype=DefectType.MISSING_CASE, killed=None, desc="x"):
+    return GroundTruthDefect(
+        id=did, obligation_id=oid, type=dtype, description=desc, killed_by=killed or []
+    )
+
+
+def _recorded(did: str, oid: str = "o1", dtype=DefectType.MISSING_CASE, desc="x"):
+    return Defect(id=did, obligation_id=oid, type=dtype, description=desc)
+
+
+# --- the label format rejects what it cannot score ---
+
+
+def test_defect_naming_an_undefined_obligation_is_rejected():
+    # Not merely wrong: unscoreable and silently so. The label can never be
+    # matched, so it depresses enumeration recall forever while reading as a
+    # real miss by the enumerator.
+    with pytest.raises(ValidationError, match="unknown obligation"):
+        GroundTruthLabels(
+            obligations=[_obligation("o1")],
+            defects=[_labelled("d1", oid="no-such-obligation")],
+        )
+
+
+def test_defect_killed_by_a_test_the_case_does_not_supply_is_rejected():
+    with pytest.raises(ValidationError, match="no obligation lists as a candidate test"):
+        GroundTruthLabels(
+            obligations=[_obligation("o1", tests=["t.py::a"])],
+            defects=[_labelled("d1", killed=["t.py::typo"])],
+        )
+
+
+def test_duplicate_defect_ids_are_rejected():
+    with pytest.raises(ValidationError, match="defect ids must be unique"):
+        GroundTruthLabels(
+            obligations=[_obligation("o1")],
+            defects=[_labelled("d1"), _labelled("d1")],
+        )
+
+
+def test_no_plausible_defect_is_distinguishable_from_saying_nothing():
+    """The label for "nothing is plausible here" must not read as "unlabelled".
+
+    Without the distinction, a case that takes no position scores an enumerator
+    that invented three defects exactly like one that correctly recorded none —
+    which is DefectSet's own "nothing found" versus "not looked at" rule, on the
+    labelling side.
+    """
+    silent = _obligation("o1")
+    reasoned = _obligation("o2", no_plausible_defect_reason="true by construction")
+
+    assert silent.no_plausible_defect_reason is None
+    assert reasoned.no_plausible_defect_reason == "true by construction"
+    assert silent.no_plausible_defect_reason != reasoned.no_plausible_defect_reason
+
+
+def test_empty_no_plausible_defect_reason_is_rejected():
+    # An empty string would collapse the distinction the test above holds open.
+    with pytest.raises(ValidationError, match="omit the field to take no position"):
+        GroundTruthLabels(obligations=[_obligation("o1", no_plausible_defect_reason="  ")])
+
+
+def test_no_plausible_defect_cannot_coexist_with_a_labelled_defect():
+    with pytest.raises(ValidationError, match="also carries labelled defects"):
+        GroundTruthLabels(
+            obligations=[_obligation("o1", no_plausible_defect_reason="none plausible")],
+            defects=[_labelled("d1", oid="o1")],
+        )
+
+
+# --- matching is on the described mistake, not the wording ---
+
+
+def test_a_reworded_defect_still_matches_its_label():
+    labelled = [_labelled("d1", desc="The daily rate divides by a hard-coded 30")]
+    recorded = [_recorded("r1", desc="Rate uses a fixed 30-day month instead of days_in_month")]
+    response = {"matches": [{"labelled": "l0", "recorded": "r0"}]}
+
+    alignment = align_defects(labelled, recorded, client_returning(response))
+
+    assert alignment == {"r1": "d1"}
+
+
+def test_alignment_is_bijective_so_a_second_claim_on_one_label_is_dropped():
+    labelled = [_labelled("d1")]
+    recorded = [_recorded("r1"), _recorded("r2")]
+    response = {
+        "matches": [
+            {"labelled": "l0", "recorded": "r0"},
+            {"labelled": "l0", "recorded": "r1"},
+        ]
+    }
+
+    alignment = align_defects(labelled, recorded, client_returning(response))
+
+    assert alignment == {"r1": "d1"}
+
+
+# --- a type disagreement is a match, not a miss ---
+
+
+def test_wrong_classification_counts_as_matched_not_as_missed():
+    """The failure this guards against sends the fix to the wrong stage.
+
+    A defect recorded with the right description and the wrong type is a
+    taxonomy problem. Scored as a miss it reads as an enumerator that did not
+    find the defect at all, and the enumerator is then "fixed" for something it
+    got right.
+    """
+    labelled = [_labelled("d1", dtype=DefectType.BOUNDARY_WRONG_SIDE)]
+    recorded = [_recorded("r1", dtype=DefectType.MISSING_CASE)]
+    alignment = {"r1": "d1"}
+
+    assert enumeration_recall(labelled, alignment) == 1.0
+    assert type_agreement(labelled, recorded, alignment) == 0.0
+
+
+# --- recall and kill agreement do not touch each other ---
+
+
+def test_recall_and_kill_agreement_are_computed_independently():
+    """Vary each input in turn; only its own figure moves.
+
+    Sharing a denominator between the two is the mistake #252 describes — a
+    thinner enumeration earning a stronger rating — and it would be invisible,
+    because both numbers still compute.
+    """
+    labelled = [
+        _labelled("d1", killed=["t.py::a"]),
+        _labelled("d2", killed=["t.py::b"]),
+    ]
+    both_matched = {"r1": "d1", "r2": "d2"}
+    one_matched = {"r1": "d1"}
+    right = {"r1": {"t.py::a"}, "r2": {"t.py::b"}}
+    wrong = {"r1": {"t.py::z"}, "r2": {"t.py::z"}}
+
+    # Enumeration changes, kill agreement does not: the defect that dropped out
+    # of the alignment leaves the kill denominator too, rather than scoring 0.
+    assert enumeration_recall(labelled, both_matched) == 1.0
+    assert enumeration_recall(labelled, one_matched) == 0.5
+    assert kill_agreement(labelled, both_matched, right) == 1.0
+    assert kill_agreement(labelled, one_matched, right) == 1.0
+
+    # Predictions change, enumeration does not.
+    assert kill_agreement(labelled, both_matched, wrong) == 0.0
+    assert enumeration_recall(labelled, both_matched) == 1.0
+
+
+def test_recall_never_reads_the_predictions():
+    labelled = [_labelled("d1", killed=["t.py::a"])]
+    alignment = {"r1": "d1"}
+
+    # `enumeration_recall` takes no prediction argument at all, which is the
+    # structural half of the guarantee the test above makes behaviourally.
+    assert enumeration_recall(labelled, alignment) == 1.0
+
+
+# --- absent, never zero ---
+
+
+def test_figures_with_nothing_to_compute_from_are_absent():
+    assert enumeration_recall([], {}) is None
+    assert type_agreement([], [], {}) is None
+    assert other_share([]) is None
+    # No prediction supplied at all — the state before #314 exists. Zero would
+    # read as a stage that predicts badly rather than one that has not run.
+    assert kill_agreement([_labelled("d1")], {"r1": "d1"}, None) is None
+    assert kill_agreement([_labelled("d1")], {"r1": "d1"}, {}) is None
+
+
+def test_a_type_with_no_labelled_defect_is_absent_from_recall_by_type():
+    labelled = [_labelled("d1", dtype=DefectType.MISSING_CASE)]
+
+    by_type = recall_by_type(labelled, {})
+
+    assert by_type == {DefectType.MISSING_CASE: 0.0}
+    assert DefectType.BOUNDARY_WRONG_SIDE not in by_type
+
+
+# --- predicting "no test catches this" is a correct prediction ---
+
+
+def test_predicting_no_killer_for_an_uncaught_defect_scores_as_exact():
+    """Archetype 4's shape, and the one the corpus most needs covered.
+
+    A labelled defect that no test kills is the finding the review exists to
+    produce. Under the usual undefined-on-empty convention it would drop out of
+    the figure entirely.
+    """
+    labelled = [_labelled("d1", killed=[])]
+
+    assert kill_agreement(labelled, {"r1": "d1"}, {"r1": set()}) == 1.0
+    assert kill_agreement(labelled, {"r1": "d1"}, {"r1": {"t.py::a"}}) == 0.0
+
+
+# --- every figure against hand-computed values ---
+
+
+def test_every_figure_matches_the_hand_computed_value():
+    """One small set worked out by hand, in the comments beside each assertion."""
+    labelled = [
+        _labelled("d1", dtype=DefectType.MISSING_CASE, killed=["t.py::a"]),
+        _labelled("d2", dtype=DefectType.MISSING_CASE, killed=["t.py::a", "t.py::b"]),
+        _labelled("d3", dtype=DefectType.BOUNDARY_WRONG_SIDE, killed=[]),
+        _labelled("d4", dtype=DefectType.BOUNDARY_WRONG_SIDE, killed=["t.py::c"]),
+    ]
+    recorded = [
+        _recorded("r1", dtype=DefectType.MISSING_CASE),
+        _recorded("r2", dtype=DefectType.BOUNDARY_WRONG_SIDE),  # type disagrees with d2
+        _recorded("r3", dtype=DefectType.BOUNDARY_WRONG_SIDE),
+        _recorded("r4", dtype=DefectType.OTHER),
+    ]
+    alignment = {"r1": "d1", "r2": "d2", "r3": "d3"}  # d4 missed; r4 spurious
+    predicted = {
+        "r1": {"t.py::a"},  # exact
+        "r2": {"t.py::a"},  # 1 of 2 -> 1/2
+        "r3": set(),  # empty vs empty -> exact
+    }
+
+    score = score_defects(labelled, recorded, alignment, predicted)
+
+    # 3 of 4 labelled defects matched.
+    assert score.enumeration_recall == 0.75
+    # missing_case: d1 and d2 both matched -> 1.0. boundary: d3 matched, d4 not -> 0.5.
+    assert score.recall_by_type == {
+        DefectType.MISSING_CASE: 1.0,
+        DefectType.BOUNDARY_WRONG_SIDE: 0.5,
+    }
+    # 3 matched pairs; r1/d1 agrees, r2/d2 does not, r3/d3 agrees -> 2/3.
+    assert score.type_agreement == pytest.approx(2 / 3)
+    # 1 of 4 recorded defects is `other`.
+    assert score.other_share == 0.25
+    # jaccard 1.0, 0.5, 1.0 over the three matched defects with a prediction.
+    assert score.kill_agreement == pytest.approx(2.5 / 3)
+    assert (score.labelled, score.recorded, score.matched, score.predicted) == (4, 4, 3, 3)
+
+
+# --- scoring makes no model call ---
+
+
+def test_scoring_makes_no_model_call():
+    """`score_defects` takes an alignment, never a client.
+
+    Passing a client that raises on use would only prove this module does not
+    call *that* client; taking no client at all is the property itself. The one
+    model judgement is `align_defects`, which the caller runs once.
+    """
+    import inspect
+
+    for fn in (score_defects, enumeration_recall, kill_agreement, type_agreement, other_share):
+        params = set(inspect.signature(fn).parameters)
+        assert "client" not in params, f"{fn.__name__} takes a client"
+
+    exploding = client_returning({"matches": []})
+    exploding.complete = lambda *a, **k: pytest.fail("scoring issued a model call")
+
+    score_defects([_labelled("d1")], [_recorded("r1")], {"r1": "d1"}, {"r1": set()})
+
+
+# --- the split measure, recomputed over defect-derived edges ---
+
+
+def test_split_measure_runs_over_tests_reached_through_defects():
+    """Two obligations stating the same demand, reached by way of their defects.
+
+    The measure itself is unchanged — `mapping_from_defects` only builds the
+    input `twin_pairs` already consumes — so the figure stays comparable across
+    the change in how an obligation reaches a test.
+    """
+    obligations = [
+        _obligation("o1", "Round to two decimals"),
+        _obligation("o2", "Round to two decimals"),
+    ]
+    recorded = [_recorded("r1", oid="o1"), _recorded("r2", oid="o2")]
+    predicted = {"r1": {"t.py::a"}, "r2": {"t.py::b"}}
+
+    mapping = mapping_from_defects("synthetic", obligations, recorded, predicted)
+    pairs = twin_pairs(mapping)
+
+    assert len(pairs) == 1
+    assert pairs[0].identical is True
+    assert pairs[0].shared == 0
+    assert pairs[0].split == 2  # a and b, each reached by exactly one side
+
+
+def test_an_obligation_with_no_prediction_reaches_no_test():
+    obligations = [
+        _obligation("o1", "Round to two decimals"),
+        _obligation("o2", "Round to two decimals"),
+    ]
+    recorded = [_recorded("r1", oid="o1"), _recorded("r2", oid="o2")]
+
+    mapping = mapping_from_defects("synthetic", obligations, recorded, None)
+
+    assert mapping.mapped_tests == {0: [], 1: []}
+    assert twin_pairs(mapping)[0].opportunities == 0
+
+
+# --- the shipped labels ---
+
+
+@pytest.mark.parametrize("case_dir", sorted(p.name for p in ARCHETYPES.iterdir() if p.is_dir()))
+def test_every_archetype_label_set_loads_and_validates(case_dir):
+    labels = load_labels(ARCHETYPES / case_dir)
+
+    assert labels.defects, f"{case_dir} carries no defect labels"
+    for defect in labels.defects:
+        assert defect.description.strip()
+
+
+def test_archetype_four_labels_its_non_discriminating_defect_as_uncaught():
+    """The case the whole defect-first change exists for.
+
+    A hard-coded 30-day divisor that the only test cannot distinguish. If this
+    label ever gains a killing test, the fixture has stopped being an example of
+    a non-discriminating input.
+    """
+    labels = load_labels(ARCHETYPES / "04-non-discriminating-input")
+
+    defect = next(d for d in labels.defects if d.id == "d-hard-coded-thirty-day-month")
+    assert defect.obligation_id == "daily-rate"
+    assert defect.killed_by == []
+
+
+# --- the pipeline actually calls it ---
+
+
+def _scoreable_case(labelled, defect_sets):
+    """A minimal case `score_case` will accept, carrying defect labels and a
+    review that recorded defects."""
+    from acceptance.benchmark.case import (
+        BenchmarkCase,
+        BenchmarkCaseInputs,
+        BenchmarkCaseSource,
+    )
+    from acceptance.review_state import (
+        DeterminismControls,
+        Obligation,
+        ObligationType,
+        Review,
+        ReviewProvenance,
+    )
+
+    return BenchmarkCase(
+        case_id="wiring",
+        source=BenchmarkCaseSource(kind="archetype", identifier="wiring"),
+        inputs=BenchmarkCaseInputs(repo="r", task_text="t", base_revision="a", head_revision="b"),
+        ground_truth=GroundTruthLabels(
+            obligations=[_obligation("o1", "Round the total to two decimals")],
+            defects=labelled,
+        ),
+        reviewer_output=Review(
+            mode="local",
+            reviewed_revision="b",
+            provenance=ReviewProvenance(
+                determinism_mode="replay",
+                model="m",
+                controls_requested=DeterminismControls(temperature=0.0),
+            ),
+            obligation_map=[
+                Obligation(
+                    id="o1",
+                    description="Round the total to two decimals",
+                    type=ObligationType.FUNCTIONAL,
+                    importance="critical",
+                    explicit=True,
+                    observable_behavior="...",
+                )
+            ],
+            defect_sets=defect_sets,
+        ),
+    )
+
+
+def test_score_case_populates_the_defect_figures():
+    """The wiring, not the function.
+
+    `score_defects` having a passing unit test says nothing about whether the
+    scorer ever calls it — the shape of hole defect injection keeps finding in
+    this repo.
+    """
+    from acceptance.benchmark.scoring import score_case
+    from acceptance.review_state import DefectSet
+
+    case = _scoreable_case(
+        labelled=[_labelled("d1", oid="o1", desc="The total is not rounded")],
+        defect_sets=[DefectSet(obligation_id="o1", defects=[_recorded("r1", oid="o1")])],
+    )
+    client = client_dispatching(
+        {
+            "_Alignment": {"matches": []},
+            "_DefectAlignment": {"matches": [{"labelled": "l0", "recorded": "r0"}]},
+        }
+    )
+
+    score = score_case(case, client)
+
+    assert score.defects is not None
+    assert score.defects.enumeration_recall == 1.0
+    assert score.defects.labelled == 1
+    assert score.defects.matched == 1
+    # Nothing supplies a prediction yet; absent, not zero.
+    assert score.defects.kill_agreement is None
+
+
+def test_score_case_leaves_the_defect_figures_absent_with_no_labels():
+    """And spends no model call doing it."""
+    from acceptance.benchmark.scoring import score_case
+    from acceptance.review_state import DefectSet
+
+    case = _scoreable_case(
+        labelled=[],
+        defect_sets=[DefectSet(obligation_id="o1", defects=[_recorded("r1", oid="o1")])],
+    )
+    client = client_dispatching({"_Alignment": {"matches": []}})
+
+    score = score_case(case, client)
+
+    assert score.defects is None
+
+
+def test_labels_json_defect_ids_are_unique_within_each_case():
+    for case_dir in sorted(p for p in ARCHETYPES.iterdir() if p.is_dir()):
+        raw = json.loads((case_dir / "labels.json").read_text())
+        ids = [d["id"] for d in raw.get("defects", [])]
+        assert len(ids) == len(set(ids)), case_dir.name

--- a/tests/fixtures/archetypes/01-missed-obligation/labels.json
+++ b/tests/fixtures/archetypes/01-missed-obligation/labels.json
@@ -6,7 +6,10 @@
       "explicit": true,
       "evidence_class": "strongly_supported",
       "evidence_rationale": "Both tests assert the full formatted line exactly, so a missing or malformed field would fail.",
-      "candidate_tests": ["test_receipt.py::test_positive_line", "test_receipt.py::test_two_decimal_formatting"]
+      "candidate_tests": [
+        "test_receipt.py::test_positive_line",
+        "test_receipt.py::test_two_decimal_formatting"
+      ]
     },
     {
       "id": "line-total",
@@ -14,7 +17,10 @@
       "explicit": true,
       "evidence_class": "strongly_supported",
       "evidence_rationale": "Both tests assert the exact total (3x2.5=7.50, 1x4=4.00); a wrong total formula would fail.",
-      "candidate_tests": ["test_receipt.py::test_positive_line", "test_receipt.py::test_two_decimal_formatting"]
+      "candidate_tests": [
+        "test_receipt.py::test_positive_line",
+        "test_receipt.py::test_two_decimal_formatting"
+      ]
     },
     {
       "id": "money-format",
@@ -22,7 +28,10 @@
       "explicit": true,
       "evidence_class": "strongly_supported",
       "evidence_rationale": "Both tests assert exact $ formatting ($2.50, $7.50, $4.00); wrong formatting would fail.",
-      "candidate_tests": ["test_receipt.py::test_positive_line", "test_receipt.py::test_two_decimal_formatting"]
+      "candidate_tests": [
+        "test_receipt.py::test_positive_line",
+        "test_receipt.py::test_two_decimal_formatting"
+      ]
     },
     {
       "id": "returns-in-parens",
@@ -39,6 +48,55 @@
       "description": "Returns (negative quantity) are not shown in parentheses; the fourth stated rule is unimplemented and untested",
       "obligation_id": "returns-in-parens",
       "severity": "high"
+    }
+  ],
+  "defects": [
+    {
+      "id": "d-show-fields-drops-unit-price",
+      "obligation_id": "show-fields",
+      "type": "scope_too_narrow",
+      "description": "The formatted line shows the name and quantity but omits the unit price.",
+      "killed_by": [
+        "test_receipt.py::test_positive_line",
+        "test_receipt.py::test_two_decimal_formatting"
+      ]
+    },
+    {
+      "id": "d-line-total-adds-instead-of-multiplies",
+      "obligation_id": "line-total",
+      "type": "other",
+      "description": "The line total is quantity plus unit price rather than quantity times unit price.",
+      "killed_by": [
+        "test_receipt.py::test_positive_line",
+        "test_receipt.py::test_two_decimal_formatting"
+      ]
+    },
+    {
+      "id": "d-money-format-one-decimal",
+      "obligation_id": "money-format",
+      "type": "qualifier_ignored",
+      "description": "Money is formatted to one decimal place, so 2.5 renders as $2.5 rather than $2.50.",
+      "killed_by": [
+        "test_receipt.py::test_positive_line",
+        "test_receipt.py::test_two_decimal_formatting"
+      ]
+    },
+    {
+      "id": "d-money-format-no-symbol",
+      "obligation_id": "money-format",
+      "type": "qualifier_ignored",
+      "description": "The leading $ is omitted from formatted money.",
+      "killed_by": [
+        "test_receipt.py::test_positive_line",
+        "test_receipt.py::test_two_decimal_formatting"
+      ]
+    },
+    {
+      "id": "d-returns-not-parenthesised",
+      "obligation_id": "returns-in-parens",
+      "type": "not_wired",
+      "description": "A negative quantity is rendered with a minus sign rather than with the quantity and total in parentheses; the rule is not implemented at all.",
+      "killed_by": []
     }
   ]
 }

--- a/tests/fixtures/archetypes/02-qualifier-missed/labels.json
+++ b/tests/fixtures/archetypes/02-qualifier-missed/labels.json
@@ -6,7 +6,10 @@
       "explicit": true,
       "evidence_class": "strongly_supported",
       "evidence_rationale": "Both tests assert the ISO code for a symbol prefix (USD, EUR); a wrong mapping would fail.",
-      "candidate_tests": ["test_pricing.py::test_dollar_symbol", "test_pricing.py::test_euro_symbol"]
+      "candidate_tests": [
+        "test_pricing.py::test_dollar_symbol",
+        "test_pricing.py::test_euro_symbol"
+      ]
     },
     {
       "id": "parse-amount",
@@ -14,7 +17,10 @@
       "explicit": true,
       "evidence_class": "strongly_supported",
       "evidence_rationale": "Both tests assert the exact parsed amount (12.50, 3.00); a wrong parse would fail.",
-      "candidate_tests": ["test_pricing.py::test_dollar_symbol", "test_pricing.py::test_euro_symbol"]
+      "candidate_tests": [
+        "test_pricing.py::test_dollar_symbol",
+        "test_pricing.py::test_euro_symbol"
+      ]
     },
     {
       "id": "backward-compat",
@@ -31,6 +37,41 @@
       "description": "Plain numeric strings without a symbol now raise (the first digit is stripped and used as a symbol lookup) instead of parsing and defaulting to USD; the backward-compatibility qualifier is unimplemented and untested",
       "obligation_id": "backward-compat",
       "severity": "high"
+    }
+  ],
+  "defects": [
+    {
+      "id": "d-symbol-maps-to-wrong-code",
+      "obligation_id": "parse-symbol",
+      "type": "other",
+      "description": "A recognised symbol maps to the wrong ISO code, for instance EUR returned as USD.",
+      "killed_by": [
+        "test_pricing.py::test_euro_symbol"
+      ]
+    },
+    {
+      "id": "d-amount-parsed-with-symbol",
+      "obligation_id": "parse-amount",
+      "type": "other",
+      "description": "The amount is parsed from the whole string including the leading symbol, so conversion to float raises ValueError.",
+      "killed_by": [
+        "test_pricing.py::test_dollar_symbol",
+        "test_pricing.py::test_euro_symbol"
+      ]
+    },
+    {
+      "id": "d-plain-numeric-string-rejected",
+      "obligation_id": "backward-compat",
+      "type": "not_wired",
+      "description": "A plain numeric string with no symbol has its first digit treated as a currency symbol, so the lookup raises KeyError and plain strings stop working.",
+      "killed_by": []
+    },
+    {
+      "id": "d-plain-numeric-defaults-wrong",
+      "obligation_id": "backward-compat",
+      "type": "qualifier_ignored",
+      "description": "A plain numeric string parses but is given a currency other than USD.",
+      "killed_by": []
     }
   ]
 }

--- a/tests/fixtures/archetypes/03-superficial-test/labels.json
+++ b/tests/fixtures/archetypes/03-superficial-test/labels.json
@@ -6,7 +6,9 @@
       "explicit": true,
       "evidence_class": "nominally_supported",
       "evidence_rationale": "The candidate test exercises amortize (in the changed code, lifts coverage) but asserts only the list length and that values are positive; it references nothing about equality, so a mutant that makes the payments unequal survives it. A present, relevant test that kills zero mapped mutants.",
-      "candidate_tests": ["test_loan.py::test_returns_a_payment_for_each_month"]
+      "candidate_tests": [
+        "test_loan.py::test_returns_a_payment_for_each_month"
+      ]
     },
     {
       "id": "one-per-month",
@@ -14,7 +16,9 @@
       "explicit": true,
       "evidence_class": "strongly_supported",
       "evidence_rationale": "The test asserts len(schedule)==12 for a 12-month loan, which kills any wrong-count mutant.",
-      "candidate_tests": ["test_loan.py::test_returns_a_payment_for_each_month"]
+      "candidate_tests": [
+        "test_loan.py::test_returns_a_payment_for_each_month"
+      ]
     },
     {
       "id": "fully-amortizing",
@@ -22,7 +26,9 @@
       "explicit": true,
       "evidence_class": "nominally_supported",
       "evidence_rationale": "The candidate test exercises amortize but never asserts the payment amounts or that they pay off the loan, so a wrong-payment-formula mutant survives it. A present, relevant test that kills zero mapped mutants.",
-      "candidate_tests": ["test_loan.py::test_returns_a_payment_for_each_month"]
+      "candidate_tests": [
+        "test_loan.py::test_returns_a_payment_for_each_month"
+      ]
     }
   ],
   "gaps": [
@@ -37,6 +43,31 @@
       "description": "The test never asserts the payment amounts or that they pay off the loan, so a wrong payment formula would pass",
       "obligation_id": "fully-amortizing",
       "severity": "medium"
+    }
+  ],
+  "defects": [
+    {
+      "id": "d-payments-not-equal",
+      "obligation_id": "equal-payments",
+      "type": "other",
+      "description": "The schedule varies the payment from month to month instead of returning a list of equal payments.",
+      "killed_by": []
+    },
+    {
+      "id": "d-one-entry-short",
+      "obligation_id": "one-per-month",
+      "type": "other",
+      "description": "The schedule has one entry fewer than the number of months requested.",
+      "killed_by": [
+        "test_loan.py::test_returns_a_payment_for_each_month"
+      ]
+    },
+    {
+      "id": "d-interest-ignored",
+      "obligation_id": "fully-amortizing",
+      "type": "other",
+      "description": "The payment is principal divided by months, ignoring interest entirely, so the schedule does not pay the loan off.",
+      "killed_by": []
     }
   ]
 }

--- a/tests/fixtures/archetypes/04-non-discriminating-input/labels.json
+++ b/tests/fixtures/archetypes/04-non-discriminating-input/labels.json
@@ -6,7 +6,9 @@
       "explicit": true,
       "evidence_class": "nominally_supported",
       "evidence_rationale": "The candidate test asserts prorate(30,15,30)==15.0, but the plausible defect (a hard-coded price/30) gives the same answer for a 30-day month, so that mapped mutant survives - a present, relevant test that kills zero mapped mutants for this rule.",
-      "candidate_tests": ["test_billing.py::test_half_of_a_month"]
+      "candidate_tests": [
+        "test_billing.py::test_half_of_a_month"
+      ]
     },
     {
       "id": "charge-days-used",
@@ -14,7 +16,9 @@
       "explicit": true,
       "evidence_class": "partially_supported",
       "evidence_rationale": "A mutant that ignores days_used gives 30 not 15, so the test kills it; but boundaries (0 days, a full month) are untested, so those mutants survive - kills some, misses some.",
-      "candidate_tests": ["test_billing.py::test_half_of_a_month"]
+      "candidate_tests": [
+        "test_billing.py::test_half_of_a_month"
+      ]
     },
     {
       "id": "round-2",
@@ -22,7 +26,9 @@
       "explicit": true,
       "evidence_class": "nominally_supported",
       "evidence_rationale": "The candidate test exercises prorate (covering the round() call) but its asserted result (15.0) is a whole number, so a mutant that changes the rounding survives it. A present, relevant test that kills zero mapped mutants.",
-      "candidate_tests": ["test_billing.py::test_half_of_a_month"]
+      "candidate_tests": [
+        "test_billing.py::test_half_of_a_month"
+      ]
     }
   ],
   "gaps": [
@@ -43,6 +49,31 @@
       "description": "Only one input (15 of 30 days) is exercised, with no boundaries (0 days, a full month), so a violation at those boundaries would pass - partial coverage, acceptance only with that caveat",
       "obligation_id": "charge-days-used",
       "severity": "low"
+    }
+  ],
+  "defects": [
+    {
+      "id": "d-hard-coded-thirty-day-month",
+      "obligation_id": "daily-rate",
+      "type": "other",
+      "description": "The daily rate divides the monthly price by a hard-coded 30 rather than by days_in_month.",
+      "killed_by": []
+    },
+    {
+      "id": "d-days-used-ignored",
+      "obligation_id": "charge-days-used",
+      "type": "scope_too_narrow",
+      "description": "The charge ignores days_used and returns the full monthly price.",
+      "killed_by": [
+        "test_billing.py::test_half_of_a_month"
+      ]
+    },
+    {
+      "id": "d-result-not-rounded",
+      "obligation_id": "round-2",
+      "type": "qualifier_ignored",
+      "description": "The result is returned without rounding to two decimals.",
+      "killed_by": []
     }
   ]
 }

--- a/tests/fixtures/archetypes/05-circular-expected-result/labels.json
+++ b/tests/fixtures/archetypes/05-circular-expected-result/labels.json
@@ -6,7 +6,9 @@
       "explicit": true,
       "evidence_class": "nominally_supported",
       "evidence_rationale": "The candidate test is present and targets order_total, but its expected value is derived from the same production helper (_apply_tax), so it can never fail - every mapped mutant survives (structurally unfailable / circular).",
-      "candidate_tests": ["test_orders.py::test_total_applies_tax"]
+      "candidate_tests": [
+        "test_orders.py::test_total_applies_tax"
+      ]
     },
     {
       "id": "round-2",
@@ -14,7 +16,9 @@
       "explicit": true,
       "evidence_class": "nominally_supported",
       "evidence_rationale": "The same circular test can never fail, so a rounding mutant survives it too. A present, relevant test that kills zero mapped mutants.",
-      "candidate_tests": ["test_orders.py::test_total_applies_tax"]
+      "candidate_tests": [
+        "test_orders.py::test_total_applies_tax"
+      ]
     }
   ],
   "gaps": [
@@ -29,6 +33,31 @@
       "description": "The same circular test can never fail, so it does not establish the two-decimal rounding either",
       "obligation_id": "round-2",
       "severity": "medium"
+    }
+  ],
+  "defects": [
+    {
+      "id": "d-tax-helper-wrong",
+      "obligation_id": "add-tax",
+      "type": "other",
+      "description": "The tax helper multiplies the subtotal by tax_rate instead of by (1 + tax_rate), so the total is the tax rather than the taxed subtotal.",
+      "killed_by": []
+    },
+    {
+      "id": "d-total-skips-tax",
+      "obligation_id": "add-tax",
+      "type": "not_wired",
+      "description": "The total returns the subtotal without applying tax at all.",
+      "killed_by": [
+        "test_orders.py::test_total_applies_tax"
+      ]
+    },
+    {
+      "id": "d-total-not-rounded",
+      "obligation_id": "round-2",
+      "type": "qualifier_ignored",
+      "description": "The total is returned without rounding to two decimals.",
+      "killed_by": []
     }
   ]
 }

--- a/tests/fixtures/archetypes/06-mocked-out-behavior/labels.json
+++ b/tests/fixtures/archetypes/06-mocked-out-behavior/labels.json
@@ -6,7 +6,9 @@
       "explicit": true,
       "evidence_class": "nominally_supported",
       "evidence_rationale": "The candidate test targets coupon but mocks rate_for to a constant, so a mutant that selects the wrong rate for the date survives it. A present, relevant test that kills zero mapped mutants (behavior mocked out).",
-      "candidate_tests": ["test_coupon.py::test_coupon_uses_selected_rate"]
+      "candidate_tests": [
+        "test_coupon.py::test_coupon_uses_selected_rate"
+      ]
     },
     {
       "id": "compute-coupon",
@@ -14,7 +16,9 @@
       "explicit": true,
       "evidence_class": "partially_supported",
       "evidence_rationale": "The test asserts nominal times rate (1000*0.05=50), so a wrong-multiply mutant is killed; but rounding to four decimals is not exercised, so those mutants survive - kills some, misses some.",
-      "candidate_tests": ["test_coupon.py::test_coupon_uses_selected_rate"]
+      "candidate_tests": [
+        "test_coupon.py::test_coupon_uses_selected_rate"
+      ]
     }
   ],
   "gaps": [
@@ -29,6 +33,31 @@
       "description": "The multiplication is checked (1000*0.05=50) but rounding to four decimals is never exercised, so a wrong rounding would pass - partial coverage, acceptance only with that caveat",
       "obligation_id": "compute-coupon",
       "severity": "low"
+    }
+  ],
+  "defects": [
+    {
+      "id": "d-rate-not-selected-by-date",
+      "obligation_id": "select-rate",
+      "type": "qualifier_ignored",
+      "description": "The rate is fetched for a fixed date rather than for the date given to the function, so the date-based selection never happens.",
+      "killed_by": []
+    },
+    {
+      "id": "d-coupon-adds-rate",
+      "obligation_id": "compute-coupon",
+      "type": "other",
+      "description": "The coupon adds the rate to the nominal instead of multiplying by it.",
+      "killed_by": [
+        "test_coupon.py::test_coupon_uses_selected_rate"
+      ]
+    },
+    {
+      "id": "d-coupon-not-rounded",
+      "obligation_id": "compute-coupon",
+      "type": "qualifier_ignored",
+      "description": "The coupon is returned without rounding to four decimals.",
+      "killed_by": []
     }
   ]
 }

--- a/tests/fixtures/archetypes/07-declaration-mismatch/labels.json
+++ b/tests/fixtures/archetypes/07-declaration-mismatch/labels.json
@@ -6,7 +6,9 @@
       "explicit": true,
       "evidence_class": "strongly_supported",
       "evidence_rationale": "The test asserts the exact record for an existing id; a wrong lookup would fail.",
-      "candidate_tests": ["test_users.py::test_existing_id_returns_the_record"]
+      "candidate_tests": [
+        "test_users.py::test_existing_id_returns_the_record"
+      ]
     }
   ],
   "gaps": [
@@ -15,6 +17,24 @@
       "description": "The declaration claims get_user raises KeyError with a clear message on a missing id, but the implementation returns None and no test exercises the missing-id path. This is a declaration-vs-code discrepancy, not a task obligation (the task never asked for missing-id handling), so it has no obligation_id",
       "obligation_id": null,
       "severity": "medium"
+    }
+  ],
+  "defects": [
+    {
+      "id": "d-missing-id-returns-none",
+      "obligation_id": "lookup",
+      "type": "other",
+      "description": "A user id absent from the mapping returns None rather than raising, so a caller cannot tell a missing record from a stored empty one.",
+      "killed_by": []
+    },
+    {
+      "id": "d-lookup-ignores-user-id",
+      "obligation_id": "lookup",
+      "type": "not_wired",
+      "description": "The lookup returns a fixed entry rather than the one matching user_id.",
+      "killed_by": [
+        "test_users.py::test_existing_id_returns_the_record"
+      ]
     }
   ]
 }

--- a/tests/fixtures/archetypes/08-unrequested-change-in-service/labels.json
+++ b/tests/fixtures/archetypes/08-unrequested-change-in-service/labels.json
@@ -6,7 +6,9 @@
       "explicit": true,
       "evidence_class": "strongly_supported",
       "evidence_rationale": "The test asserts apply_discount reduces a $100 subtotal by 10% to $90; a wrong discount computation would fail.",
-      "candidate_tests": ["test_cart.py::test_apply_discount_formats_as_money"]
+      "candidate_tests": [
+        "test_cart.py::test_apply_discount_formats_as_money"
+      ]
     },
     {
       "id": "format-as-money",
@@ -27,6 +29,37 @@
       "description": "format_total's signature was widened with a currency parameter so apply_discount could format its result consistently with checkout's existing formatting. Nothing in the task asked for format_total to change, but apply_discount cannot format its result without it -- removing the widening breaks the apply_discount obligation, not just tidiness. checkout is unaffected since the parameter defaults to USD.",
       "file": "cart.py",
       "disposition": "in_service"
+    }
+  ],
+  "defects": [
+    {
+      "id": "d-discount-not-applied",
+      "obligation_id": "apply-discount",
+      "type": "not_wired",
+      "description": "apply_discount returns the subtotal unchanged, applying no percentage.",
+      "killed_by": [
+        "test_cart.py::test_apply_discount_formats_as_money",
+        "test_cart.py::test_apply_discount_supports_other_currency"
+      ]
+    },
+    {
+      "id": "d-currency-argument-ignored",
+      "obligation_id": "format-as-money",
+      "type": "qualifier_ignored",
+      "description": "The currency argument is ignored and every amount is rendered with a $ prefix.",
+      "killed_by": [
+        "test_cart.py::test_apply_discount_supports_other_currency"
+      ]
+    },
+    {
+      "id": "d-money-missing-decimals",
+      "obligation_id": "format-as-money",
+      "type": "other",
+      "description": "The formatted amount omits the two decimal places, rendering $90 rather than $90.00.",
+      "killed_by": [
+        "test_cart.py::test_apply_discount_formats_as_money",
+        "test_cart.py::test_apply_discount_supports_other_currency"
+      ]
     }
   ]
 }

--- a/tests/fixtures/archetypes/08-unrequested-change-risky-adjacent/labels.json
+++ b/tests/fixtures/archetypes/08-unrequested-change-risky-adjacent/labels.json
@@ -6,7 +6,9 @@
       "explicit": true,
       "evidence_class": "strongly_supported",
       "evidence_rationale": "The test asserts cancel_order returns True and sets status to \"cancelled\"; a wrong status or return value would fail.",
-      "candidate_tests": ["test_orders.py::test_cancel_order_marks_cancelled"]
+      "candidate_tests": [
+        "test_orders.py::test_cancel_order_marks_cancelled"
+      ]
     }
   ],
   "gaps": [],
@@ -16,6 +18,26 @@
       "description": "ship_order gained shipped_count tracking though only cancel_order was requested. It edits existing, adjacent behavior (not a new file, not needed by cancel_order), and no test covers the new shipped_count field -- an untested behavior change that could hide a regression.",
       "file": "orders.py",
       "disposition": "risky"
+    }
+  ],
+  "defects": [
+    {
+      "id": "d-cancel-does-not-set-status",
+      "obligation_id": "cancel-order",
+      "type": "not_wired",
+      "description": "cancel_order returns True without setting the order's status to cancelled.",
+      "killed_by": [
+        "test_orders.py::test_cancel_order_marks_cancelled"
+      ]
+    },
+    {
+      "id": "d-cancel-returns-none",
+      "obligation_id": "cancel-order",
+      "type": "wrong_output_shape",
+      "description": "cancel_order sets the status but returns None rather than True.",
+      "killed_by": [
+        "test_orders.py::test_cancel_order_marks_cancelled"
+      ]
     }
   ]
 }

--- a/tests/fixtures/archetypes/08-unrequested-change-separable/labels.json
+++ b/tests/fixtures/archetypes/08-unrequested-change-separable/labels.json
@@ -6,7 +6,9 @@
       "explicit": true,
       "evidence_class": "strongly_supported",
       "evidence_rationale": "The test asserts restock({'qty':5},3)==8 and that the item's qty is mutated to 8; a wrong increment or missing mutation would fail.",
-      "candidate_tests": ["test_inventory.py::test_restock_increases_quantity"]
+      "candidate_tests": [
+        "test_inventory.py::test_restock_increases_quantity"
+      ]
     }
   ],
   "gaps": [],
@@ -16,6 +18,26 @@
       "description": "low_stock_report was added in a new file (report.py) with its own test; nothing in the task asked for a reporting feature. It is self-contained -- restock's obligation is fully satisfied without it -- so it belongs in its own PR/backlog item.",
       "file": "report.py",
       "disposition": "separable"
+    }
+  ],
+  "defects": [
+    {
+      "id": "d-restock-returns-previous-quantity",
+      "obligation_id": "restock",
+      "type": "other",
+      "description": "restock returns the quantity as it was before the increase.",
+      "killed_by": [
+        "test_inventory.py::test_restock_increases_quantity"
+      ]
+    },
+    {
+      "id": "d-restock-does-not-update-item",
+      "obligation_id": "restock",
+      "type": "scope_too_narrow",
+      "description": "restock computes and returns the new quantity without updating the item.",
+      "killed_by": [
+        "test_inventory.py::test_restock_increases_quantity"
+      ]
     }
   ]
 }

--- a/tests/fixtures/archetypes/08-unrequested-change-test-support/labels.json
+++ b/tests/fixtures/archetypes/08-unrequested-change-test-support/labels.json
@@ -6,7 +6,9 @@
       "explicit": true,
       "evidence_class": "strongly_supported",
       "evidence_rationale": "test_line_total_applies_the_item_discount asserts a 10% discount turns 10.0 into 9.0; an implementation that ignored the discount would return 10.0 and fail.",
-      "candidate_tests": ["test_pricing.py::test_line_total_applies_the_item_discount"]
+      "candidate_tests": [
+        "test_pricing.py::test_line_total_applies_the_item_discount"
+      ]
     },
     {
       "id": "round-to-two-decimals",
@@ -14,7 +16,9 @@
       "explicit": true,
       "evidence_class": "nominally_supported",
       "evidence_rationale": "Every asserted result (10.0, 3.25, 9.0) is already exact at two decimals, so a mutant that dropped the rounding would still pass. A present, relevant test that kills zero mapped mutants for this rule.",
-      "candidate_tests": ["test_pricing.py::test_line_total_applies_the_item_discount"]
+      "candidate_tests": [
+        "test_pricing.py::test_line_total_applies_the_item_discount"
+      ]
     }
   ],
   "gaps": [
@@ -31,6 +35,33 @@
       "description": "The _item() test helper gained a discount key/parameter. The task never asked for the test helper to change, but line_total now reads item['discount'], so without it every pre-existing test raises KeyError. Removing this change breaks the suite, and 'split the fixture update into its own PR' is not coherent advice -- it is in service of the requested change, not separable work.",
       "file": "test_pricing.py",
       "disposition": "in_service"
+    }
+  ],
+  "defects": [
+    {
+      "id": "d-item-discount-ignored",
+      "obligation_id": "apply-item-discount",
+      "type": "not_wired",
+      "description": "The item's discount percentage is ignored and the line total is quantity times price.",
+      "killed_by": [
+        "test_pricing.py::test_line_total_applies_the_item_discount"
+      ]
+    },
+    {
+      "id": "d-discount-treated-as-fraction",
+      "obligation_id": "apply-item-discount",
+      "type": "other",
+      "description": "The discount is treated as a fraction rather than a percentage, so a discount of 10 is applied as 1000%.",
+      "killed_by": [
+        "test_pricing.py::test_line_total_applies_the_item_discount"
+      ]
+    },
+    {
+      "id": "d-line-total-not-rounded",
+      "obligation_id": "round-to-two-decimals",
+      "type": "qualifier_ignored",
+      "description": "The discounted line total is returned without rounding to two decimals.",
+      "killed_by": []
     }
   ]
 }

--- a/tests/fixtures/archetypes/08-unrequested-change/labels.json
+++ b/tests/fixtures/archetypes/08-unrequested-change/labels.json
@@ -6,7 +6,9 @@
       "explicit": true,
       "evidence_class": "strongly_supported",
       "evidence_rationale": "The test asserts apply_discount(100,10)==90.0; a wrong discount would fail.",
-      "candidate_tests": ["test_cart.py::test_apply_discount"]
+      "candidate_tests": [
+        "test_cart.py::test_apply_discount"
+      ]
     },
     {
       "id": "leave-existing",
@@ -14,7 +16,9 @@
       "explicit": true,
       "evidence_class": "partially_supported",
       "evidence_rationale": "The test asserts checkout's default still returns 5.0, so a mutant that changes the default output is killed; but the actual unrequested change (added tax_rate parameter and rounding) leaves the default path unchanged, so that mutant survives - kills some, misses some.",
-      "candidate_tests": ["test_cart.py::test_checkout_default_unchanged"]
+      "candidate_tests": [
+        "test_cart.py::test_checkout_default_unchanged"
+      ]
     }
   ],
   "gaps": [
@@ -31,6 +35,33 @@
       "description": "checkout gained a tax_rate parameter and rounding; no obligation asked for a checkout change, only apply_discount",
       "file": "cart.py",
       "disposition": "risky"
+    }
+  ],
+  "defects": [
+    {
+      "id": "d-discount-increases-total",
+      "obligation_id": "apply-discount",
+      "type": "condition_inverted",
+      "description": "The discount is added to the total rather than subtracted from it.",
+      "killed_by": [
+        "test_cart.py::test_apply_discount"
+      ]
+    },
+    {
+      "id": "d-discount-not-rounded",
+      "obligation_id": "apply-discount",
+      "type": "qualifier_ignored",
+      "description": "The discounted total is returned without rounding to two decimals.",
+      "killed_by": []
+    },
+    {
+      "id": "d-checkout-default-moves",
+      "obligation_id": "leave-existing",
+      "type": "prior_behavior_altered",
+      "description": "The existing checkout function returns a different value for a caller that passes no tax rate, so pre-existing behaviour changes.",
+      "killed_by": [
+        "test_cart.py::test_checkout_default_unchanged"
+      ]
     }
   ]
 }

--- a/tests/fixtures/archetypes/09-revision-cycle/labels.json
+++ b/tests/fixtures/archetypes/09-revision-cycle/labels.json
@@ -6,7 +6,10 @@
       "explicit": true,
       "evidence_class": "strongly_supported",
       "evidence_rationale": "Covered by both tests; 2.3->2 together with the tie cases pins nearest-integer rounding.",
-      "candidate_tests": ["test_rounding.py::test_rounds_to_nearest", "test_rounding.py::test_ties_round_to_even"]
+      "candidate_tests": [
+        "test_rounding.py::test_rounds_to_nearest",
+        "test_rounding.py::test_ties_round_to_even"
+      ]
     },
     {
       "id": "ties-to-even",
@@ -14,8 +17,31 @@
       "explicit": true,
       "evidence_class": "strongly_supported",
       "evidence_rationale": "test_ties_round_to_even asserts 2.5->2 and 3.5->4, which distinguishes banker's rounding from round-half-up.",
-      "candidate_tests": ["test_rounding.py::test_ties_round_to_even"]
+      "candidate_tests": [
+        "test_rounding.py::test_ties_round_to_even"
+      ]
     }
   ],
-  "gaps": []
+  "gaps": [],
+  "defects": [
+    {
+      "id": "d-always-rounds-up",
+      "obligation_id": "round-nearest",
+      "type": "other",
+      "description": "Every value is rounded up rather than to the nearest integer.",
+      "killed_by": [
+        "test_rounding.py::test_rounds_to_nearest",
+        "test_rounding.py::test_ties_round_to_even"
+      ]
+    },
+    {
+      "id": "d-ties-round-up",
+      "obligation_id": "ties-to-even",
+      "type": "boundary_wrong_side",
+      "description": "An exact tie rounds away from zero rather than to the even neighbour.",
+      "killed_by": [
+        "test_rounding.py::test_ties_round_to_even"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Closes #315. Sub-issue D of #312, the umbrella replacing the current evidence machinery with one that enumerates ways a change could fail an obligation before any test is looked at. Design is `docs/DR-312-defect-first-evidence.md`; the taxonomy scored against was settled at #313's Gate 1 and is `docs/DR-313-defect-taxonomy.md`.

Separates two failures the current ratings cannot tell apart: the enumerator missed the defect, versus the judge missed the kill.

## What this adds

**A label format.** `GroundTruthDefect` in `benchmark/case.py` — id, obligation id, a type from the same `DefectType` vocabulary the enumerator spends with `other` allowed, a description, and `killed_by`, the pytest node ids of tests that would fail if the code contained that defect. An empty `killed_by` is a real label, not a missing one: archetype 4 is the case where a present, relevant test kills nothing. `GroundTruthObligation` gains `no_plausible_defect_reason`, so "nothing is plausible here" stays distinct from "the labels say nothing", the same rule `DefectSet` already applies on the review's own side.

Validation rejects rather than loads: a defect naming an obligation the case does not define, a `killed_by` naming a test the case does not supply, duplicate ids, and an obligation claiming both no plausible defect and a labelled one. Each of those is unscoreable *and silent* — a label that can never be matched depresses enumeration recall forever while reading as a real miss.

**Labels for all thirteen archetype cases, 38 in total.** Each grounded in that fixture's own source and tests. Twelve are labelled as caught by no test, which are the load-bearing ones: they include the hard-coded 30-day divisor in `04-non-discriminating-input`, the unimplemented parentheses rule in `01-missed-obligation`, and the tax helper in `05-circular-expected-result` that both sides of the circular assertion use. Every "not rounded" defect was checked against the actual float arithmetic rather than assumed; all five produce exact values in their test's input, so none is caught.

**The metrics**, in a new `benchmark/defect_scoring.py`, wired into `score_case` and `score_case_set`:

- enumeration recall, overall and per defect type;
- type agreement, over matched pairs only — a right description with a wrong type is a match with a disagreement, never a miss, or a taxonomy problem gets reported as an enumeration problem and the fix goes to the wrong stage;
- the `other` share, as the standing figure DR-312 asks for;
- kill-prediction agreement, over matched defects that carry a prediction.

Recall and kill agreement are separate functions over separate denominators, and neither can move the other. A labelled defect the review never recorded is outside the kill denominator entirely, so a thin enumeration cannot flatter its own predictions — #252's shape, where a self-enumerated denominator lets a thinner enumeration earn a stronger rating.

Matching a recorded defect to a labelled one is a model judgement, because a real enumerator words a defect differently from the human who labelled it and an exact-string join scores a perfect enumeration at zero. It does not reuse `align_obligations`: that prompt asks which two state the same *requirement*, which is a different question from which two describe the same *mistake*.

The existing split measure is recomputed over the tests an obligation reaches by way of its defects. `mapping_from_defects` builds the input `twin_splitting.twin_pairs` already consumes, so the measure itself is untouched and the figure stays comparable across the change.

## Landing without #314

#314, the pair-mapping issue, does not exist yet, so predicted kills arrive as a plain mapping supplied by the caller — defect id to the pytest node ids predicted to fail. #314 fills it; this only scores it. Absent, every other figure still computes and kill agreement reports **absent rather than zero**. This is the one interface later work depends on, so changing its shape is a decision rather than a refactor.

## Acceptance

- **Each archetype case carries a reviewed defect-set label that validates** — `test_every_archetype_label_set_loads_and_validates` runs all thirteen through `load_labels`. The labels were reviewed by the human before this PR was opened, which is what the `human-gate` label on #315 asks for.
- **Scoring runs off recorded transcripts with no live calls** — `test_scoring_makes_no_model_call` asserts no scoring function takes a client at all, which is the property rather than a proxy for it.
- **On a synthetic set with known labels the computed metrics match hand-calculated values** — `test_every_figure_matches_the_hand_computed_value`, with each expected number worked out in the comment beside its assertion.
- **Enumeration recall and pair-verdict accuracy report as separate figures** — `test_recall_and_kill_agreement_are_computed_independently` varies each input in turn and asserts only its own figure moves.

## Dogfooding

Gate 1 passed at `dc9a22a` on run 2, after one rewrite of my own wording. Gate 2 was **not clean** — verdict incomplete, three obligations non-discriminating — which the suspension in `CLAUDE.md` permits until #316 lands, so `check` was run once and not repeated.

That run found a real defect in this change, and it is the first thing #313's enumeration stage has caught in work under review rather than in its own tests: the figures were reported as absent whenever the review recorded no defects at all, even with labelled ones present. A total enumeration miss is a result, and reporting it as unmeasured made the worst outcome the corpus can show indistinguishable from a case the labels say nothing about. Fixed in the second commit.

The three non-discriminating obligations each had their evidence recommended as a test that already exists — #250 and #287's shape, downstream of the mapping stage #314 replaces. Known defect, recorded in the judgement, not re-filed.

Runs are committed on `main` under `dogfood-logs/315-gate1-run{1,2}/` and `dogfood-logs/315-gate2-run1/`, each with its judgement.

## Known limits, chosen and documented in the code

The pooled `BenchmarkReport` carries no defect figures. Every other metric family pools by raw match counts, so a large case and a small one contribute in proportion; a defect score carries shares, and averaging those across cases would weight a case with one labelled defect equally with one carrying twenty. Per-case figures are in `per_case`; a pooled figure needs counts threaded through the existing `_MatchCounts`, which is its own change.

Defect alignment is global rather than per obligation, so a recorded defect could match a label belonging to a different obligation. The prompt argues against it; nothing enforces it. Enumeration recall is therefore an upper bound on per-obligation recall.

## Verification

Full suite 1617 passed, 2 xfailed — the two strict xfails already recorded in `docs/DEFERRED.md`. `ruff check .` clean at 0.16.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)