### PR TITLE
Group tests into pair requests, and stop enumerating test_id (#324)

### DIFF
--- a/docs/experiments/pair-response-shape/README.md
+++ b/docs/experiments/pair-response-shape/README.md
@@ -8,14 +8,21 @@ repeat the measurement and the traps in it.
 
 ```bash
 .venv/bin/python docs/experiments/pair-response-shape/pilot.py
+.venv/bin/python docs/experiments/pair-response-shape/pilot.py --arms per-test,no-test-id
 ```
 
-Makes live calls — 624 of them, and records them, so a second run replays and
-costs nothing. Roughly $0.86 from cold. Four arms are drawn nine times and four
-three; `DEEP_SEED_ARMS` says which and why. Writes
-`findings.json` beside the script, holding every per-case prediction as well as
-the aggregate figures, so a disagreement with the write-up can be traced to the
-case that caused it.
+Makes live calls — 1,038 across all ten arms, and records them, so a second run
+replays and costs nothing. Six arms are drawn nine times and four three;
+`DEEP_SEED_ARMS` says which and why. Writes `findings.json` beside the script,
+holding every per-case prediction as well as the aggregate figures, so a
+disagreement with the write-up can be traced to the case that caused it.
+
+**`--arms` calls only the arms named and keeps every other arm's row exactly as
+`findings.json` already holds it.** Use it when adding an arm. The recordings
+behind the eight arms written up before 2026-09-01 are **no longer in the live
+cache**, so a bare run re-draws them live: about $0.86, and figures that could
+move for reasons having nothing to do with the arm being added. The two per-test
+arms cost $0.42 to draw nine times each.
 
 ## What it measures against
 
@@ -72,7 +79,221 @@ side.
 by about 3 points. Enough to separate the arms; not enough for a confidence
 interval on either.
 
+**23 tests across the 13 cases**, and 5 of the 13 hold exactly one test. That
+split is what makes the batching question below answerable: on a single-test
+case, a per-test arm and a case-batched arm send the same tests, so anything
+that separates them there is not batching.
+
 ---
+
+## Dropping `test_id`, and what per-test batching costs — 2026-09-01
+
+**Dropping `test_id` from the response costs no recall, and the pilot cannot
+measure whether it buys any caching.** Those are two separate answers to #324,
+which is the issue saying that every stage sends a unique response schema and
+nothing caches. The first is what the issue asked for and it comes back clean.
+The second is unanswerable on this corpus, for a reason that is about fixture
+size and is stated below rather than glossed.
+
+**A third thing turned up that nobody asked about: one test per call is worth
+about 11 points of recall against putting a case's tests in one call.** That is
+a finding about the *shipped* stage, not about either new arm.
+
+### Why two new arms rather than one
+
+Every arm written up above puts a whole case in one call. The shipped stage does
+not: `defects/pair_mapping.py::_batches` groups pairs by test id and partitions
+within each group, so **a batch always holds exactly one test**. That is the
+only setting in which #324's question arises at all — the response can drop the
+`test_id` echo precisely because the request offered one test and the caller
+already knows which.
+
+So the candidate needed a control that batches the same way:
+
+- **`per-test`** — one call per test, the shipped `_Unions` schema unchanged, so
+  `test_id` is present and pinned by `constrain` to that call's single test.
+- **`no-test-id`** — the same, with `test_id` and its one-element `tests`
+  wrapper removed from the response schema entirely.
+
+The two send **byte-identical request content**: same shared prompt, same
+single-test instruction, same source, defect and test blocks, and the same
+`allowed` mapping (`constrain` ignores a key naming a field the model does not
+have). Only the response schema differs, which is the variable #324 is about.
+A probe asserts the byte-identity and the resulting schemas before any call.
+
+**Removing the field is deliberately not the same experiment as leaving it
+unconstrained.** Unconstrained, the judge would have to echo a long pytest node
+id exactly and a paraphrase would lose the whole call's judgements — the failure
+`tagged-alias` reproduced above. Absent, there is nothing left to get wrong.
+
+### The figures
+
+Nine draws each, nothing varied but the seed. The bar is still `verdict`'s worst
+of nine, 0.9375.
+
+| arm | n | recall min–max | mean | median | spread | kills/defect | prompt | out tokens |
+|---|---|---|---|---|---|---|---|---|
+| union (case-batched) | 9 | 0.9062–1.0000 | 0.9688 | 0.9688 | 0.0938 | 0.789–0.868 | 10,600 | 2404 |
+| per-test | 9 | 0.8125–0.9062 | 0.8785 | 0.8750 | 0.0938 | 0.711–0.842 | 17,831 | 2456 |
+| **no-test-id** | 9 | 0.8438–0.9062 | **0.8889** | **0.9062** | **0.0625** | 0.763–0.842 | **16,672** | **2110** |
+
+Head to head against its own control, `no-test-id` is **better on 4 draws, worse
+on 3, equal on 2**. Its mean is 0.0104 higher, its median a draw higher, its
+spread narrower, and its kills-per-defect floor higher — 0.763 against 0.711 —
+so DR-173's failure mode, an arm that buys a smaller response by answering *no*
+more often, is not present. It also sends **6.5% fewer prompt tokens** and
+**14% fewer output tokens** than the control, both of which are the schema
+shrinking rather than the answers doing so.
+
+**On this corpus the field is not doing any work.** That was expected: `constrain`
+pins it to a one-element enum, so in the control it is a value the model cannot
+get wrong and cannot learn anything from.
+
+### The caching half is unanswerable here, and the 0.0% must not be read as an answer
+
+Both new arms report a **0.0% cached prompt share** — measured, not assumed;
+`cached_tokens` is now recorded per arm in `findings.json`.
+
+**That figure says nothing about the schema.** The per-call prompt on this
+corpus is **725 tokens for `no-test-id` and 775 for `per-test`**, against
+OpenAI's **1,024-token minimum** for any prompt caching at all. Nothing on these
+fixtures could cache whatever the schema did. The archetype cases are small
+constructed programs; a real review's pair call carries a preamble and defect
+block measured at about 1,544 tokens, which is why #324 could see the question at
+all and why this pilot cannot.
+
+**So #324's second acceptance item — a run reporting a non-zero cached share on
+the pair stage — cannot be met by this script.** It needs a real review run.
+What this round establishes is only that the recall precondition is satisfied.
+
+The one caching-adjacent thing it does establish is direct rather than inferred:
+the 6.5% prompt-token drop between two arms whose request content is
+byte-identical is **the response schema being billed as prompt**, which is the
+premise the whole issue rests on and was previously believed rather than
+measured.
+
+### One test per call costs about 11 points of recall
+
+`per-test` and `no-test-id` fall below the bar on **9 draws of 9**, where the
+case-batched `union` falls below on 1. The gap is large — 0.9688 against 0.8785
+— and it is not the schema, because the two per-test arms are within a point of
+each other.
+
+**It is the batching, and the pilot can attribute that without another call.**
+Five of the thirteen cases hold exactly one test, so for those a per-test arm and
+`union` send the same tests and differ only in the instruction's wording.
+Splitting pooled recall by case size, over all nine draws:
+
+| arm | single-test cases (45 edge-draws) | multi-test cases (243) |
+|---|---|---|
+| union | 1.0000 | 0.9630 |
+| per-test | 1.0000 | 0.8560 |
+| no-test-id | 0.9556 | 0.8765 |
+
+`per-test` and `union` are **identical on every single-test case**, so the
+instruction rewrite costs nothing. The entire drop sits in the multi-test cases,
+where the only difference is that one call became several.
+
+**This is about the shipped stage, not about either new arm.** `_batches` chose
+one test per request deliberately, and its docstring gives the reason — a batch
+spanning several tests offers a schema in which every test × every defect is
+expressible, so the prompt would ask for fewer answers than the schema invites
+and the extras would be dropped on the way back, which is the silent filter
+DR-164 forbids. That reasoning anticipated a cost in **requests**. It did not
+anticipate a cost in **recall**, and this is the first measurement of one.
+
+**Do not act on it from this table.** 27 labelled edges over 8 cases is a small
+base, the corpus's cases hold 2–3 tests where a real review holds 496, and case
+batching does not scale to a real review anyway — the useful question is whether
+`DEFAULT_PAIR_BATCH_SIZE` and test-major grouping are the right operating point,
+which is a separate measurement. Filed rather than fixed.
+
+---
+
+## A free-text `test_id` — 2026-09-01
+
+**Leaving `test_id` in the response but not enumerating it costs nothing when
+the call carries several tests, and the judge does not invent node ids.** That
+matters because it is the only shape measured here that gets #324's cacheable
+schema *and* keeps a multi-test batch expressible; removing the field entirely
+gets the first and forecloses the second.
+
+### Why the field does not have to be an enum
+
+`constrain` puts the offered ids in the schema so a wrong one is unrepresentable.
+That is a stance, not a requirement. The detection half already exists and
+already runs: `supplied_ids.py::scan` walks every response and records any id
+the call never supplied as an `UnusableAnswer`, and its docstring says it runs
+*even when* `constrain` has pinned the ids, because the harness targets providers
+whose structured-output support differs. `pair_mapping.py::_ask` calls it on
+every batch. So an unenumerated id is caught, not believed.
+
+### The two arms
+
+Both send the **shipped `_Unions` schema unchanged**, with `test_id` simply left
+out of the `allowed` mapping so `constrain` leaves it a plain `str`.
+
+- **`free-test-id`** — one call per test. Request byte-identical to `per-test`.
+- **`union-free-id`** — one call per case, 2–3 tests. Request byte-identical to
+  `union`.
+
+An entry naming a test the call never offered is **dropped and counted**, never
+matched charitably — no nearest-match, no trimming, no case folding — because a
+generous match would hide the failure mode being measured.
+
+### The judge writes real node ids
+
+| arm | tests per call | ids written exactly | pairs lost | distinct invented ids |
+|---|---|---|---|---|
+| free-test-id | 1 | 100% on all 9 draws | 0 | none |
+| union-free-id | 2–3 | 95.65%–100% | 3 of 23,808 · see below | one |
+
+Over nine draws each, the only id the judge ever wrote that had not been offered
+was `test_cart.py::test_checkout_default-unchanged`, on one draw, which is a
+mangling of a real node id rather than an invention. It cost 3 pair judgements
+on that one seed and nothing on the other eight. **Hallucinated ids are not the
+risk here.**
+
+### Recall
+
+| arm | n | recall min–max | mean | median | spread | kills/defect | below the 0.9375 bar |
+|---|---|---|---|---|---|---|---|
+| union (enumerated) | 9 | 0.9062–1.0000 | 0.9688 | 0.9688 | 0.0938 | 0.789–0.868 | 1 of 9 |
+| **union-free-id** | 9 | 0.9062–1.0000 | **0.9653** | 0.9688 | 0.0938 | 0.789–0.895 | **1 of 9** |
+| per-test (enumerated) | 9 | 0.8125–0.9062 | 0.8785 | 0.8750 | 0.0938 | 0.711–0.842 | 9 of 9 |
+| free-test-id | 9 | 0.7188–0.8750 | 0.8021 | 0.8125 | 0.1562 | 0.632–0.789 | 9 of 9 |
+
+**Multi-test: free costs nothing.** `union-free-id` is 0.0035 under `union` on
+the mean — a tenth of one labelled edge — with the same median, the same spread,
+the same 1-of-9 sub-bar count, the same kills-per-defect floor and a higher
+ceiling. The two are indistinguishable at this sample size.
+
+**Single-test: free costs 7.6 points, and not through bad ids.** `free-test-id`
+lands 0.8021 against `per-test`'s 0.8785 with **zero** unanswerable ids and zero
+unanswered pairs on all nine draws, and precision holding at 0.897–1.000. It is
+not answering *wrong*; it is finding fewer kills — kills per defect drops to
+0.632–0.789, beneath the control's floor. Its spread, 0.1562, is the widest of
+any arm drawn nine times.
+
+That is DR-173's failure mode: a response-schema change moving the judgement for
+no reason connected to the mechanism. The one thing that separates the two arms
+is that `per-test`'s enum holds exactly one value, so the schema *tells* the
+judge which test the answer is about, where `free-test-id` makes it write that
+out first. Why removing that costs recall is not explained by anything measured
+here, and it does not reproduce when the call carries several tests.
+
+### What this leaves
+
+Three shapes now have a nine-draw recall figure against a matched control:
+removing `test_id`, leaving it free under one-test batching, and leaving it free
+under multi-test batching. Only the last is both cacheable and compatible with
+larger batches, and it is the only one of the three that does not cost recall
+against its own control. **It is also the only one whose control is not itself
+9-of-9 below the bar**, which is the batching finding above and is the larger
+effect in this table.
+
+Still not established: that any of it caches. Every prompt here is under the
+1,024-token floor — see the section above — so that needs a real review run.
 
 ## Tagged-reason and alias arms — 2026-08-30
 

--- a/docs/experiments/pair-response-shape/findings.json
+++ b/docs/experiments/pair-response-shape/findings.json
@@ -1,5 +1,1179 @@
 {
   "arms": {
+    "free-test-id/seed=0": {
+      "arm": "free-test-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2429,
+      "completion_tokens_per_case": 186.84615384615384,
+      "cost_usd": 0.024072750000000007,
+      "evidence_cost_usd": 0.024072750000000007,
+      "kills_per_defect": 0.7368421052631579,
+      "labelled_kills": 32,
+      "matched": 26,
+      "measured_prompt_tokens": 17523,
+      "precision": 0.9285714285714286,
+      "predicted_kills": 28,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [],
+          "test_pricing.py::test_euro_symbol": []
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_of_a_single_item": [
+            "d-item-discount-ignored"
+          ]
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 17523,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 28,
+        "survives_absent": 40,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.8125,
+      "seed": 0,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0,
+      "written_test_ids": {
+        "exact": 23,
+        "exact_share": 1.0,
+        "invented": 0,
+        "invented_ids": []
+      }
+    },
+    "free-test-id/seed=1": {
+      "arm": "free-test-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2436,
+      "completion_tokens_per_case": 187.3846153846154,
+      "cost_usd": 0.02410425,
+      "evidence_cost_usd": 0.02410425,
+      "kills_per_defect": 0.7368421052631579,
+      "labelled_kills": 32,
+      "matched": 26,
+      "measured_prompt_tokens": 17523,
+      "precision": 0.9285714285714286,
+      "predicted_kills": 28,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [],
+          "test_pricing.py::test_euro_symbol": []
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_of_a_single_item": [
+            "d-item-discount-ignored"
+          ]
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 17523,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 28,
+        "survives_absent": 40,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.8125,
+      "seed": 1,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0,
+      "written_test_ids": {
+        "exact": 23,
+        "exact_share": 1.0,
+        "invented": 0,
+        "invented_ids": []
+      }
+    },
+    "free-test-id/seed=2": {
+      "arm": "free-test-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2338,
+      "completion_tokens_per_case": 179.84615384615384,
+      "cost_usd": 0.023663250000000004,
+      "evidence_cost_usd": 0.023663250000000004,
+      "kills_per_defect": 0.631578947368421,
+      "labelled_kills": 32,
+      "matched": 23,
+      "measured_prompt_tokens": 17523,
+      "precision": 0.9583333333333334,
+      "predicted_kills": 24,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [
+            "d-symbol-maps-to-wrong-code"
+          ],
+          "test_pricing.py::test_euro_symbol": []
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": []
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": []
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 17523,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 24,
+        "survives_absent": 44,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.71875,
+      "seed": 2,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0,
+      "written_test_ids": {
+        "exact": 23,
+        "exact_share": 1.0,
+        "invented": 0,
+        "invented_ids": []
+      }
+    },
+    "free-test-id/seed=3": {
+      "arm": "free-test-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2358,
+      "completion_tokens_per_case": 181.3846153846154,
+      "cost_usd": 0.023753250000000007,
+      "evidence_cost_usd": 0.023753250000000007,
+      "kills_per_defect": 0.6842105263157895,
+      "labelled_kills": 32,
+      "matched": 25,
+      "measured_prompt_tokens": 17523,
+      "precision": 0.9615384615384616,
+      "predicted_kills": 26,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ],
+          "test_pricing.py::test_euro_symbol": []
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": []
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": []
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 17523,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 26,
+        "survives_absent": 42,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.78125,
+      "seed": 3,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0,
+      "written_test_ids": {
+        "exact": 23,
+        "exact_share": 1.0,
+        "invented": 0,
+        "invented_ids": []
+      }
+    },
+    "free-test-id/seed=4": {
+      "arm": "free-test-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2467,
+      "completion_tokens_per_case": 189.76923076923077,
+      "cost_usd": 0.02424375,
+      "evidence_cost_usd": 0.02424375,
+      "kills_per_defect": 0.7894736842105263,
+      "labelled_kills": 32,
+      "matched": 28,
+      "measured_prompt_tokens": 17523,
+      "precision": 0.9333333333333333,
+      "predicted_kills": 30,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [],
+          "test_pricing.py::test_euro_symbol": [
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_of_a_single_item": [
+            "d-item-discount-ignored"
+          ]
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 17523,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 30,
+        "survives_absent": 38,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.875,
+      "seed": 4,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0,
+      "written_test_ids": {
+        "exact": 23,
+        "exact_share": 1.0,
+        "invented": 0,
+        "invented_ids": []
+      }
+    },
+    "free-test-id/seed=5": {
+      "arm": "free-test-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2457,
+      "completion_tokens_per_case": 189.0,
+      "cost_usd": 0.02419875,
+      "evidence_cost_usd": 0.02419875,
+      "kills_per_defect": 0.7631578947368421,
+      "labelled_kills": 32,
+      "matched": 26,
+      "measured_prompt_tokens": 17523,
+      "precision": 0.896551724137931,
+      "predicted_kills": 29,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [],
+          "test_pricing.py::test_euro_symbol": [
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_of_a_single_item": [
+            "d-item-discount-ignored"
+          ]
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 17523,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 29,
+        "survives_absent": 39,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.8125,
+      "seed": 5,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0,
+      "written_test_ids": {
+        "exact": 23,
+        "exact_share": 1.0,
+        "invented": 0,
+        "invented_ids": []
+      }
+    },
+    "free-test-id/seed=6": {
+      "arm": "free-test-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2391,
+      "completion_tokens_per_case": 183.92307692307693,
+      "cost_usd": 0.023901750000000003,
+      "evidence_cost_usd": 0.023901750000000003,
+      "kills_per_defect": 0.6842105263157895,
+      "labelled_kills": 32,
+      "matched": 26,
+      "measured_prompt_tokens": 17523,
+      "precision": 1.0,
+      "predicted_kills": 26,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [],
+          "test_pricing.py::test_euro_symbol": [
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": []
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 17523,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 26,
+        "survives_absent": 42,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.8125,
+      "seed": 6,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0,
+      "written_test_ids": {
+        "exact": 23,
+        "exact_share": 1.0,
+        "invented": 0,
+        "invented_ids": []
+      }
+    },
+    "free-test-id/seed=7": {
+      "arm": "free-test-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2389,
+      "completion_tokens_per_case": 183.76923076923077,
+      "cost_usd": 0.023892750000000008,
+      "evidence_cost_usd": 0.023892750000000008,
+      "kills_per_defect": 0.6842105263157895,
+      "labelled_kills": 32,
+      "matched": 25,
+      "measured_prompt_tokens": 17523,
+      "precision": 0.9615384615384616,
+      "predicted_kills": 26,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [],
+          "test_pricing.py::test_euro_symbol": []
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": [
+            "d-item-discount-ignored"
+          ]
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 17523,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 26,
+        "survives_absent": 42,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.78125,
+      "seed": 7,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0,
+      "written_test_ids": {
+        "exact": 23,
+        "exact_share": 1.0,
+        "invented": 0,
+        "invented_ids": []
+      }
+    },
+    "free-test-id/seed=8": {
+      "arm": "free-test-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2365,
+      "completion_tokens_per_case": 181.92307692307693,
+      "cost_usd": 0.023784750000000004,
+      "evidence_cost_usd": 0.023784750000000004,
+      "kills_per_defect": 0.6842105263157895,
+      "labelled_kills": 32,
+      "matched": 26,
+      "measured_prompt_tokens": 17523,
+      "precision": 1.0,
+      "predicted_kills": 26,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [],
+          "test_pricing.py::test_euro_symbol": [
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": []
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 17523,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 26,
+        "survives_absent": 42,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.8125,
+      "seed": 8,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0,
+      "written_test_ids": {
+        "exact": 23,
+        "exact_share": 1.0,
+        "invented": 0,
+        "invented_ids": []
+      }
+    },
     "kills-only/seed=0": {
       "arm": "kills-only",
       "completion_tokens": 2629,
@@ -1498,6 +2672,2327 @@
       "recall": 0.84375,
       "seed": 2,
       "shedding_detectable": false,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0
+    },
+    "no-test-id/seed=0": {
+      "arm": "no-test-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2092,
+      "completion_tokens_per_case": 160.92307692307693,
+      "cost_usd": 0.021918000000000003,
+      "evidence_cost_usd": 0.021918000000000003,
+      "kills_per_defect": 0.7631578947368421,
+      "labelled_kills": 32,
+      "matched": 27,
+      "measured_prompt_tokens": 16672,
+      "precision": 0.9310344827586207,
+      "predicted_kills": 29,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [],
+          "test_pricing.py::test_euro_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": []
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-not-rounded",
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": [
+            "d-item-discount-ignored"
+          ]
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 16672,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 29,
+        "survives_absent": 39,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.84375,
+      "seed": 0,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0
+    },
+    "no-test-id/seed=1": {
+      "arm": "no-test-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2132,
+      "completion_tokens_per_case": 164.0,
+      "cost_usd": 0.022098000000000003,
+      "evidence_cost_usd": 0.022098000000000003,
+      "kills_per_defect": 0.8421052631578947,
+      "labelled_kills": 32,
+      "matched": 29,
+      "measured_prompt_tokens": 16672,
+      "precision": 0.90625,
+      "predicted_kills": 32,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [
+            "d-symbol-maps-to-wrong-code"
+          ],
+          "test_pricing.py::test_euro_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-not-rounded",
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": [
+            "d-item-discount-ignored"
+          ]
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 16672,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 32,
+        "survives_absent": 36,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.90625,
+      "seed": 1,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0
+    },
+    "no-test-id/seed=2": {
+      "arm": "no-test-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2126,
+      "completion_tokens_per_case": 163.53846153846155,
+      "cost_usd": 0.022071,
+      "evidence_cost_usd": 0.022071,
+      "kills_per_defect": 0.8421052631578947,
+      "labelled_kills": 32,
+      "matched": 29,
+      "measured_prompt_tokens": 16672,
+      "precision": 0.90625,
+      "predicted_kills": 32,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [
+            "d-symbol-maps-to-wrong-code"
+          ],
+          "test_pricing.py::test_euro_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-not-rounded",
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": [
+            "d-item-discount-ignored"
+          ]
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 16672,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 32,
+        "survives_absent": 36,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.90625,
+      "seed": 2,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0
+    },
+    "no-test-id/seed=3": {
+      "arm": "no-test-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2088,
+      "completion_tokens_per_case": 160.6153846153846,
+      "cost_usd": 0.021900000000000003,
+      "evidence_cost_usd": 0.021900000000000003,
+      "kills_per_defect": 0.8157894736842105,
+      "labelled_kills": 32,
+      "matched": 29,
+      "measured_prompt_tokens": 16672,
+      "precision": 0.9354838709677419,
+      "predicted_kills": 31,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [],
+          "test_pricing.py::test_euro_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-not-rounded",
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": [
+            "d-item-discount-ignored"
+          ]
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 16672,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 31,
+        "survives_absent": 37,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.90625,
+      "seed": 3,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0
+    },
+    "no-test-id/seed=4": {
+      "arm": "no-test-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2095,
+      "completion_tokens_per_case": 161.15384615384616,
+      "cost_usd": 0.0219315,
+      "evidence_cost_usd": 0.0219315,
+      "kills_per_defect": 0.8157894736842105,
+      "labelled_kills": 32,
+      "matched": 28,
+      "measured_prompt_tokens": 16672,
+      "precision": 0.9032258064516129,
+      "predicted_kills": 31,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [
+            "d-symbol-maps-to-wrong-code"
+          ],
+          "test_pricing.py::test_euro_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": []
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-not-rounded",
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": [
+            "d-item-discount-ignored"
+          ]
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 16672,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 31,
+        "survives_absent": 37,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.875,
+      "seed": 4,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0
+    },
+    "no-test-id/seed=5": {
+      "arm": "no-test-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2095,
+      "completion_tokens_per_case": 161.15384615384616,
+      "cost_usd": 0.0219315,
+      "evidence_cost_usd": 0.0219315,
+      "kills_per_defect": 0.7894736842105263,
+      "labelled_kills": 32,
+      "matched": 28,
+      "measured_prompt_tokens": 16672,
+      "precision": 0.9333333333333333,
+      "predicted_kills": 30,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [
+            "d-symbol-maps-to-wrong-code"
+          ],
+          "test_pricing.py::test_euro_symbol": [
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": [
+            "d-item-discount-ignored"
+          ]
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 16672,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 30,
+        "survives_absent": 38,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.875,
+      "seed": 5,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0
+    },
+    "no-test-id/seed=6": {
+      "arm": "no-test-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2115,
+      "completion_tokens_per_case": 162.69230769230768,
+      "cost_usd": 0.022021500000000003,
+      "evidence_cost_usd": 0.022021500000000003,
+      "kills_per_defect": 0.8421052631578947,
+      "labelled_kills": 32,
+      "matched": 29,
+      "measured_prompt_tokens": 16672,
+      "precision": 0.90625,
+      "predicted_kills": 32,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [
+            "d-symbol-maps-to-wrong-code"
+          ],
+          "test_pricing.py::test_euro_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-not-rounded",
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": [
+            "d-item-discount-ignored"
+          ]
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 16672,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 32,
+        "survives_absent": 36,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.90625,
+      "seed": 6,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0
+    },
+    "no-test-id/seed=7": {
+      "arm": "no-test-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2117,
+      "completion_tokens_per_case": 162.84615384615384,
+      "cost_usd": 0.0220305,
+      "evidence_cost_usd": 0.0220305,
+      "kills_per_defect": 0.8157894736842105,
+      "labelled_kills": 32,
+      "matched": 28,
+      "measured_prompt_tokens": 16672,
+      "precision": 0.9032258064516129,
+      "predicted_kills": 31,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [],
+          "test_pricing.py::test_euro_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-not-rounded",
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_of_a_single_item": [
+            "d-item-discount-ignored"
+          ]
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 16672,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 31,
+        "survives_absent": 37,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.875,
+      "seed": 7,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0
+    },
+    "no-test-id/seed=8": {
+      "arm": "no-test-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2133,
+      "completion_tokens_per_case": 164.07692307692307,
+      "cost_usd": 0.022102499999999997,
+      "evidence_cost_usd": 0.022102499999999997,
+      "kills_per_defect": 0.8421052631578947,
+      "labelled_kills": 32,
+      "matched": 29,
+      "measured_prompt_tokens": 16672,
+      "precision": 0.90625,
+      "predicted_kills": 32,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [
+            "d-symbol-maps-to-wrong-code"
+          ],
+          "test_pricing.py::test_euro_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-not-rounded",
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": [
+            "d-item-discount-ignored"
+          ]
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 16672,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 32,
+        "survives_absent": 36,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.90625,
+      "seed": 8,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0
+    },
+    "per-test/seed=0": {
+      "arm": "per-test",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2495,
+      "completion_tokens_per_case": 191.92307692307693,
+      "cost_usd": 0.02460075,
+      "evidence_cost_usd": 0.02460075,
+      "kills_per_defect": 0.8157894736842105,
+      "labelled_kills": 32,
+      "matched": 28,
+      "measured_prompt_tokens": 17831,
+      "precision": 0.9032258064516129,
+      "predicted_kills": 31,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ],
+          "test_pricing.py::test_euro_symbol": [
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-not-rounded",
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": [
+            "d-item-discount-ignored"
+          ]
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 17831,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 31,
+        "survives_absent": 37,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.875,
+      "seed": 0,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0
+    },
+    "per-test/seed=1": {
+      "arm": "per-test",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2438,
+      "completion_tokens_per_case": 187.53846153846155,
+      "cost_usd": 0.024344249999999998,
+      "evidence_cost_usd": 0.024344249999999998,
+      "kills_per_defect": 0.7631578947368421,
+      "labelled_kills": 32,
+      "matched": 28,
+      "measured_prompt_tokens": 17831,
+      "precision": 0.9655172413793104,
+      "predicted_kills": 29,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ],
+          "test_pricing.py::test_euro_symbol": [
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": []
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 17831,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 29,
+        "survives_absent": 39,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.875,
+      "seed": 1,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0
+    },
+    "per-test/seed=2": {
+      "arm": "per-test",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2388,
+      "completion_tokens_per_case": 183.69230769230768,
+      "cost_usd": 0.024119250000000002,
+      "evidence_cost_usd": 0.024119250000000002,
+      "kills_per_defect": 0.7105263157894737,
+      "labelled_kills": 32,
+      "matched": 26,
+      "measured_prompt_tokens": 17831,
+      "precision": 0.9629629629629629,
+      "predicted_kills": 27,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [],
+          "test_pricing.py::test_euro_symbol": [
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-not-rounded",
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": []
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 17831,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 27,
+        "survives_absent": 41,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.8125,
+      "seed": 2,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0
+    },
+    "per-test/seed=3": {
+      "arm": "per-test",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2438,
+      "completion_tokens_per_case": 187.53846153846155,
+      "cost_usd": 0.02434425,
+      "evidence_cost_usd": 0.02434425,
+      "kills_per_defect": 0.7631578947368421,
+      "labelled_kills": 32,
+      "matched": 28,
+      "measured_prompt_tokens": 17831,
+      "precision": 0.9655172413793104,
+      "predicted_kills": 29,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-show-fields-drops-unit-price"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ],
+          "test_pricing.py::test_euro_symbol": [
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": []
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 17831,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 29,
+        "survives_absent": 39,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.875,
+      "seed": 3,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0
+    },
+    "per-test/seed=4": {
+      "arm": "per-test",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2450,
+      "completion_tokens_per_case": 188.46153846153845,
+      "cost_usd": 0.024398250000000003,
+      "evidence_cost_usd": 0.024398250000000003,
+      "kills_per_defect": 0.8157894736842105,
+      "labelled_kills": 32,
+      "matched": 29,
+      "measured_prompt_tokens": 17831,
+      "precision": 0.9354838709677419,
+      "predicted_kills": 31,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [
+            "d-symbol-maps-to-wrong-code"
+          ],
+          "test_pricing.py::test_euro_symbol": [
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": [
+            "d-item-discount-ignored"
+          ]
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [
+            "d-always-rounds-up"
+          ],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 17831,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 31,
+        "survives_absent": 37,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.90625,
+      "seed": 4,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0
+    },
+    "per-test/seed=5": {
+      "arm": "per-test",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2456,
+      "completion_tokens_per_case": 188.92307692307693,
+      "cost_usd": 0.024425250000000003,
+      "evidence_cost_usd": 0.024425250000000003,
+      "kills_per_defect": 0.7631578947368421,
+      "labelled_kills": 32,
+      "matched": 28,
+      "measured_prompt_tokens": 17831,
+      "precision": 0.9655172413793104,
+      "predicted_kills": 29,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-show-fields-drops-unit-price"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [],
+          "test_pricing.py::test_euro_symbol": [
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-not-rounded",
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": []
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 17831,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 29,
+        "survives_absent": 39,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.875,
+      "seed": 5,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0
+    },
+    "per-test/seed=6": {
+      "arm": "per-test",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2510,
+      "completion_tokens_per_case": 193.07692307692307,
+      "cost_usd": 0.024668250000000003,
+      "evidence_cost_usd": 0.024668250000000003,
+      "kills_per_defect": 0.8421052631578947,
+      "labelled_kills": 32,
+      "matched": 29,
+      "measured_prompt_tokens": 17831,
+      "precision": 0.90625,
+      "predicted_kills": 32,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ],
+          "test_pricing.py::test_euro_symbol": [
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-not-rounded",
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": [
+            "d-item-discount-ignored"
+          ]
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 17831,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 32,
+        "survives_absent": 36,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.90625,
+      "seed": 6,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0
+    },
+    "per-test/seed=7": {
+      "arm": "per-test",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2445,
+      "completion_tokens_per_case": 188.07692307692307,
+      "cost_usd": 0.02437575,
+      "evidence_cost_usd": 0.02437575,
+      "kills_per_defect": 0.7894736842105263,
+      "labelled_kills": 32,
+      "matched": 29,
+      "measured_prompt_tokens": 17831,
+      "precision": 0.9666666666666667,
+      "predicted_kills": 30,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ],
+          "test_pricing.py::test_euro_symbol": [
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": []
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 17831,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 30,
+        "survives_absent": 38,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.90625,
+      "seed": 7,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0
+    },
+    "per-test/seed=8": {
+      "arm": "per-test",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2484,
+      "completion_tokens_per_case": 191.07692307692307,
+      "cost_usd": 0.02455125,
+      "evidence_cost_usd": 0.02455125,
+      "kills_per_defect": 0.8157894736842105,
+      "labelled_kills": 32,
+      "matched": 28,
+      "measured_prompt_tokens": 17831,
+      "precision": 0.9032258064516129,
+      "predicted_kills": 31,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ],
+          "test_pricing.py::test_euro_symbol": [
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-not-rounded",
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": [
+            "d-item-discount-ignored"
+          ]
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 17831,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 31,
+        "survives_absent": 37,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.875,
+      "seed": 8,
+      "shedding_detectable": true,
       "unanswered_pairs": 0,
       "undecodable_ids": 0
     },
@@ -3830,6 +7325,1237 @@
       "unanswered_pairs": 0,
       "undecodable_ids": 0
     },
+    "union-free-id/seed=0": {
+      "arm": "union-free-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2369,
+      "completion_tokens_per_case": 182.23076923076923,
+      "cost_usd": 0.018388500000000002,
+      "evidence_cost_usd": 0.018388500000000002,
+      "kills_per_defect": 0.8421052631578947,
+      "labelled_kills": 32,
+      "matched": 31,
+      "measured_prompt_tokens": 10304,
+      "precision": 0.96875,
+      "predicted_kills": 32,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ],
+          "test_pricing.py::test_euro_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": []
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [
+            "d-always-rounds-up"
+          ],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 10304,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 32,
+        "survives_absent": 36,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.96875,
+      "seed": 0,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0,
+      "written_test_ids": {
+        "exact": 23,
+        "exact_share": 1.0,
+        "invented": 0,
+        "invented_ids": []
+      }
+    },
+    "union-free-id/seed=1": {
+      "arm": "union-free-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2354,
+      "completion_tokens_per_case": 181.07692307692307,
+      "cost_usd": 0.018320999999999997,
+      "evidence_cost_usd": 0.018320999999999997,
+      "kills_per_defect": 0.8157894736842105,
+      "labelled_kills": 32,
+      "matched": 30,
+      "measured_prompt_tokens": 10304,
+      "precision": 0.967741935483871,
+      "predicted_kills": 31,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ],
+          "test_pricing.py::test_euro_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": []
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": []
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [
+            "d-always-rounds-up"
+          ],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 10304,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 31,
+        "survives_absent": 37,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.9375,
+      "seed": 1,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0,
+      "written_test_ids": {
+        "exact": 23,
+        "exact_share": 1.0,
+        "invented": 0,
+        "invented_ids": []
+      }
+    },
+    "union-free-id/seed=2": {
+      "arm": "union-free-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2398,
+      "completion_tokens_per_case": 184.46153846153845,
+      "cost_usd": 0.018519,
+      "evidence_cost_usd": 0.018519,
+      "kills_per_defect": 0.8421052631578947,
+      "labelled_kills": 32,
+      "matched": 31,
+      "measured_prompt_tokens": 10304,
+      "precision": 0.96875,
+      "predicted_kills": 32,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ],
+          "test_pricing.py::test_euro_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": []
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [
+            "d-always-rounds-up"
+          ],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 10304,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 32,
+        "survives_absent": 36,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.96875,
+      "seed": 2,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0,
+      "written_test_ids": {
+        "exact": 23,
+        "exact_share": 1.0,
+        "invented": 0,
+        "invented_ids": []
+      }
+    },
+    "union-free-id/seed=3": {
+      "arm": "union-free-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2396,
+      "completion_tokens_per_case": 184.30769230769232,
+      "cost_usd": 0.01851,
+      "evidence_cost_usd": 0.01851,
+      "kills_per_defect": 0.868421052631579,
+      "labelled_kills": 32,
+      "matched": 32,
+      "measured_prompt_tokens": 10304,
+      "precision": 0.9696969696969697,
+      "predicted_kills": 33,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ],
+          "test_pricing.py::test_euro_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": []
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [
+            "d-always-rounds-up"
+          ],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 10304,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 33,
+        "survives_absent": 35,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 1.0,
+      "seed": 3,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0,
+      "written_test_ids": {
+        "exact": 23,
+        "exact_share": 1.0,
+        "invented": 0,
+        "invented_ids": []
+      }
+    },
+    "union-free-id/seed=4": {
+      "arm": "union-free-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2360,
+      "completion_tokens_per_case": 181.53846153846155,
+      "cost_usd": 0.018348,
+      "evidence_cost_usd": 0.018348,
+      "kills_per_defect": 0.8157894736842105,
+      "labelled_kills": 32,
+      "matched": 30,
+      "measured_prompt_tokens": 10304,
+      "precision": 0.967741935483871,
+      "predicted_kills": 31,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ],
+          "test_pricing.py::test_euro_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": []
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": []
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [
+            "d-always-rounds-up"
+          ],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 10304,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 31,
+        "survives_absent": 37,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.9375,
+      "seed": 4,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0,
+      "written_test_ids": {
+        "exact": 23,
+        "exact_share": 1.0,
+        "invented": 0,
+        "invented_ids": []
+      }
+    },
+    "union-free-id/seed=5": {
+      "arm": "union-free-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2432,
+      "completion_tokens_per_case": 187.07692307692307,
+      "cost_usd": 0.018672,
+      "evidence_cost_usd": 0.018672,
+      "kills_per_defect": 0.8947368421052632,
+      "labelled_kills": 32,
+      "matched": 32,
+      "measured_prompt_tokens": 10304,
+      "precision": 0.9411764705882353,
+      "predicted_kills": 34,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ],
+          "test_pricing.py::test_euro_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-not-rounded",
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": []
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [
+            "d-always-rounds-up"
+          ],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 10304,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 34,
+        "survives_absent": 34,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 1.0,
+      "seed": 5,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0,
+      "written_test_ids": {
+        "exact": 23,
+        "exact_share": 1.0,
+        "invented": 0,
+        "invented_ids": []
+      }
+    },
+    "union-free-id/seed=6": {
+      "arm": "union-free-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2371,
+      "completion_tokens_per_case": 182.3846153846154,
+      "cost_usd": 0.018397499999999997,
+      "evidence_cost_usd": 0.018397499999999997,
+      "kills_per_defect": 0.7894736842105263,
+      "labelled_kills": 32,
+      "matched": 29,
+      "measured_prompt_tokens": 10304,
+      "precision": 0.9666666666666667,
+      "predicted_kills": 30,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ],
+          "test_pricing.py::test_euro_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": []
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [
+            "d-always-rounds-up"
+          ],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 10304,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 30,
+        "survives_absent": 38,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.90625,
+      "seed": 6,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0,
+      "written_test_ids": {
+        "exact": 23,
+        "exact_share": 1.0,
+        "invented": 0,
+        "invented_ids": []
+      }
+    },
+    "union-free-id/seed=7": {
+      "arm": "union-free-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2409,
+      "completion_tokens_per_case": 185.30769230769232,
+      "cost_usd": 0.018568499999999998,
+      "evidence_cost_usd": 0.018568499999999998,
+      "kills_per_defect": 0.868421052631579,
+      "labelled_kills": 32,
+      "matched": 32,
+      "measured_prompt_tokens": 10304,
+      "precision": 0.9696969696969697,
+      "predicted_kills": 33,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ],
+          "test_pricing.py::test_euro_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ],
+          "test_cart.py::test_checkout_default_unchanged": [
+            "d-checkout-default-moves"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": []
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [
+            "d-always-rounds-up"
+          ],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 10304,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 33,
+        "survives_absent": 35,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 1.0,
+      "seed": 7,
+      "shedding_detectable": true,
+      "unanswered_pairs": 0,
+      "undecodable_ids": 0,
+      "written_test_ids": {
+        "exact": 23,
+        "exact_share": 1.0,
+        "invented": 0,
+        "invented_ids": []
+      }
+    },
+    "union-free-id/seed=8": {
+      "arm": "union-free-id",
+      "cached_prompt_share": 0.0,
+      "cached_tokens": 0,
+      "completion_tokens": 2396,
+      "completion_tokens_per_case": 184.30769230769232,
+      "cost_usd": 0.01851,
+      "evidence_cost_usd": 0.01851,
+      "kills_per_defect": 0.8421052631578947,
+      "labelled_kills": 32,
+      "matched": 31,
+      "measured_prompt_tokens": 10304,
+      "precision": 0.96875,
+      "predicted_kills": 32,
+      "predictions": {
+        "01-missed-obligation": {
+          "test_receipt.py::test_positive_line": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ],
+          "test_receipt.py::test_two_decimal_formatting": [
+            "d-line-total-adds-instead-of-multiplies",
+            "d-money-format-no-symbol",
+            "d-money-format-one-decimal",
+            "d-show-fields-drops-unit-price"
+          ]
+        },
+        "02-qualifier-missed": {
+          "test_pricing.py::test_dollar_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ],
+          "test_pricing.py::test_euro_symbol": [
+            "d-amount-parsed-with-symbol",
+            "d-symbol-maps-to-wrong-code"
+          ]
+        },
+        "03-superficial-test": {
+          "test_loan.py::test_returns_a_payment_for_each_month": [
+            "d-one-entry-short"
+          ]
+        },
+        "04-non-discriminating-input": {
+          "test_billing.py::test_half_of_a_month": [
+            "d-days-used-ignored"
+          ]
+        },
+        "05-circular-expected-result": {
+          "test_orders.py::test_total_applies_tax": [
+            "d-total-skips-tax"
+          ]
+        },
+        "06-mocked-out-behavior": {
+          "test_coupon.py::test_coupon_uses_selected_rate": [
+            "d-coupon-adds-rate"
+          ]
+        },
+        "07-declaration-mismatch": {
+          "test_users.py::test_existing_id_returns_the_record": [
+            "d-lookup-ignores-user-id"
+          ]
+        },
+        "08-unrequested-change": {
+          "test_cart.py::test_apply_discount": [
+            "d-discount-increases-total"
+          ]
+        },
+        "08-unrequested-change-in-service": {
+          "test_cart.py::test_apply_discount_formats_as_money": [
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_apply_discount_supports_other_currency": [
+            "d-currency-argument-ignored",
+            "d-discount-not-applied",
+            "d-money-missing-decimals"
+          ],
+          "test_cart.py::test_checkout_still_works": []
+        },
+        "08-unrequested-change-risky-adjacent": {
+          "test_orders.py::test_cancel_order_marks_cancelled": [
+            "d-cancel-does-not-set-status",
+            "d-cancel-returns-none"
+          ],
+          "test_orders.py::test_ship_order_still_marks_shipped": []
+        },
+        "08-unrequested-change-separable": {
+          "test_inventory.py::test_restock_increases_quantity": [
+            "d-restock-does-not-update-item",
+            "d-restock-returns-previous-quantity"
+          ],
+          "test_report.py::test_low_stock_report_filters_by_threshold": []
+        },
+        "08-unrequested-change-test-support": {
+          "test_pricing.py::test_line_total_applies_the_item_discount": [
+            "d-discount-treated-as-fraction",
+            "d-item-discount-ignored"
+          ],
+          "test_pricing.py::test_line_total_multiplies_quantity_by_price": [],
+          "test_pricing.py::test_line_total_of_a_single_item": []
+        },
+        "09-revision-cycle": {
+          "test_rounding.py::test_rounds_to_nearest": [
+            "d-always-rounds-up"
+          ],
+          "test_rounding.py::test_ties_round_to_even": [
+            "d-always-rounds-up",
+            "d-ties-round-up"
+          ]
+        }
+      },
+      "prompt_tokens": 10304,
+      "reason_usage": {
+        "kills_absent": 0,
+        "kills_empty": 0,
+        "kills_with_reason": 32,
+        "survives_absent": 33,
+        "survives_empty": 0,
+        "survives_with_reason": 0,
+        "survives_without_prose": 1.0
+      },
+      "recall": 0.96875,
+      "seed": 8,
+      "shedding_detectable": true,
+      "unanswered_pairs": 3,
+      "undecodable_ids": 3,
+      "written_test_ids": {
+        "exact": 22,
+        "exact_share": 0.9565217391304348,
+        "invented": 1,
+        "invented_ids": [
+          "test_cart.py::test_checkout_default-unchanged"
+        ]
+      }
+    },
     "union/seed=0": {
       "arm": "union",
       "completion_tokens": 2435,
@@ -6073,6 +10799,15 @@
     "run_usd": 4.25
   },
   "output_token_ratios": {
+    "free-test-id": {
+      "mean_completion_tokens": 2403.3333333333335,
+      "projected_output_tokens": 449285.8589738714,
+      "projected_run_usd": 3.814142865382421,
+      "ratio_to_reasoned": 0.8226524169931161,
+      "ratio_to_verdict": 1.439121756487026,
+      "saved_output_tokens": 96857.14102612861,
+      "saved_usd": 0.4358571346175787
+    },
     "kills-only": {
       "mean_completion_tokens": 2600.222222222222,
       "projected_output_tokens": 486092.8188491233,
@@ -6090,6 +10825,24 @@
       "ratio_to_verdict": 0.49301397205588826,
       "saved_output_tokens": 392226.76259841025,
       "saved_usd": 1.7650204316928462
+    },
+    "no-test-id": {
+      "mean_completion_tokens": 2110.3333333333335,
+      "projected_output_tokens": 394511.61902407487,
+      "projected_run_usd": 3.567658785608337,
+      "ratio_to_reasoned": 0.7223595633818888,
+      "ratio_to_verdict": 1.263672654690619,
+      "saved_output_tokens": 151631.38097592513,
+      "saved_usd": 0.6823412143916631
+    },
+    "per-test": {
+      "mean_completion_tokens": 2456.0,
+      "projected_output_tokens": 459131.5130262808,
+      "projected_run_usd": 3.8584483086182635,
+      "ratio_to_reasoned": 0.8406800289050318,
+      "ratio_to_verdict": 1.4706586826347305,
+      "saved_output_tokens": 87011.4869737192,
+      "saved_usd": 0.3915516913817364
     },
     "reasoned": {
       "mean_completion_tokens": 2921.4444444444443,
@@ -6136,6 +10889,15 @@
       "saved_output_tokens": 96753.28391587117,
       "saved_usd": 0.4353897776214203
     },
+    "union-free-id": {
+      "mean_completion_tokens": 2387.222222222222,
+      "projected_output_tokens": 446274.0027764044,
+      "projected_run_usd": 3.80058951249382,
+      "ratio_to_reasoned": 0.8171376411972768,
+      "ratio_to_verdict": 1.4294743845642048,
+      "saved_output_tokens": 99868.99722359562,
+      "saved_usd": 0.4494104875061803
+    },
     "verdict": {
       "mean_completion_tokens": 1670.0,
       "projected_output_tokens": 312194.4734339939,
@@ -6152,6 +10914,17 @@
     2
   ],
   "seeds_by_arm": {
+    "free-test-id": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
     "kills-only": [
       0,
       1,
@@ -6167,6 +10940,28 @@
       0,
       1,
       2
+    ],
+    "no-test-id": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "per-test": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
     ],
     "reasoned": [
       0,
@@ -6195,6 +10990,17 @@
       2
     ],
     "union": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "union-free-id": [
       0,
       1,
       2,

--- a/docs/experiments/pair-response-shape/pilot.py
+++ b/docs/experiments/pair-response-shape/pilot.py
@@ -129,6 +129,7 @@ model host is allowed. Writes findings.json beside this file.
 
 from __future__ import annotations
 
+import argparse
 import ast
 import json
 import sys
@@ -157,6 +158,10 @@ UNION_STAGE = "pair mapping pilot (union)"
 TAGGED_STAGE = "pair mapping pilot (tagged)"
 TAGGED_SINGLE_STAGE = "pair mapping pilot (tagged-single)"
 ALIAS_STAGE = "pair mapping pilot (tagged-alias)"
+PER_TEST_STAGE = "pair mapping pilot (per-test)"
+NO_TEST_ID_STAGE = "pair mapping pilot (no-test-id)"
+FREE_TEST_ID_STAGE = "pair mapping pilot (free-test-id)"
+UNION_FREE_ID_STAGE = "pair mapping pilot (union-free-id)"
 
 ARMS = (
     "listing",
@@ -167,8 +172,47 @@ ARMS = (
     "tagged",
     "tagged-single",
     "tagged-alias",
+    "per-test",
+    "no-test-id",
+    "free-test-id",
+    "union-free-id",
 )
 TAGGED_ARMS = ("tagged", "tagged-single", "tagged-alias")
+
+# Arms that keep `test_id` in the response but do NOT enumerate it: the shipped
+# `_Unions` schema, sent with `test_id` left out of the `allowed` mapping so
+# `constrain` leaves it a plain `str` and the judge writes the node id itself.
+#
+# **Why this is not merely a third way of asking #324's question.** Removing the
+# field works only while a batch holds one test. Leaving the field free keeps the
+# schema identical from call to call — which is what #324 needs — AND keeps a
+# multi-test batch expressible, which the batching finding above wants. The two
+# results were otherwise pulling against each other.
+#
+# The cost moves from the schema to the answer: an invented or paraphrased node
+# id is now possible. It is not silent. `supplied_ids.py::scan` already runs on
+# every shipped call alongside `constrain`, precisely because the harness targets
+# providers whose structured-output support differs, so an unsupplied id is
+# recorded as an `UnusableAnswer` rather than believed. These arms count the same
+# thing locally: an entry naming a test the call never offered is DROPPED and
+# counted, never guessed at, which is the #163 rule the alias arm is scored under.
+FREE_ID_ARMS = ("free-test-id", "union-free-id")
+
+# Arms that issue ONE CALL PER TEST rather than one per case, which is what
+# `defects/pair_mapping.py::_batches` does in the shipped stage: it groups pairs
+# by test id and partitions within each group, so a batch always holds exactly
+# one test. Every other arm here batches a whole case, which is why none of them
+# can answer #324 — the question is whether the response still needs a `test_id`
+# when the request only ever offers one test, and that only arises under
+# test-major batching.
+#
+# `per-test`, `no-test-id` and `free-test-id` send BYTE-IDENTICAL request
+# content: same shared prompt, same single-test instruction, same source, defect
+# and test blocks. Only the response schema differs — enumerated `test_id`,
+# no `test_id`, and free-text `test_id` respectively — which is the variable
+# under test. `union-free-id` batches by case instead, so it is NOT in this
+# tuple; its comparison is against `union`, whose request it matches exactly.
+PER_TEST_ARMS = ("per-test", "no-test-id", "free-test-id")
 
 # Arms drawn nine times instead of three. The two candidates left standing —
 # `kills-only` and `union` — separated by a single labelled edge on one draw,
@@ -182,11 +226,11 @@ TAGGED_ARMS = ("tagged", "tagged-single", "tagged-alias")
 # That error is not hypothetical: on three seeds `kills-only` averaged 0.9688 and
 # looked like the best arm here; on nine it averages 0.9410 and is the worst of
 # these four. Everything else stays at three; those arms are already decided.
-DEEP_SEED_ARMS = ("verdict", "reasoned", "kills-only", "union")
+DEEP_SEED_ARMS = ("verdict", "reasoned", "kills-only", "union", *PER_TEST_ARMS, *FREE_ID_ARMS)
 # Arms whose entries carry a `reason` field at all, so that whether it was filled
 # is a question with an answer. `listing` and `verdict` have no such field and are
 # left out, which also keeps their recorded entries in `findings.json` unchanged.
-REASON_ARMS = ("reasoned", "kills-only", "union", *TAGGED_ARMS)
+REASON_ARMS = ("reasoned", "kills-only", "union", *TAGGED_ARMS, *PER_TEST_ARMS, *FREE_ID_ARMS)
 
 # The pair stage's share of #314's Gate 2 run, from
 # `dogfood-logs/314-gate2-run1/output.log` and that run's ledger entry. Used only
@@ -244,6 +288,20 @@ _UNION_INSTRUCTION = """\
 For each test, return one entry per OFFERED DEFECT — every defect id, not only
 the ones it catches — with `fails` true if the test would fail on that defect and
 false if it would not. A test with five defects offered returns five entries.
+
+An entry whose `fails` is true also carries `reason`: one short sentence naming
+what the test asserts that the defect would change. An entry whose `fails` is
+false carries NO `reason` field at all — not an empty one."""
+
+# Used UNCHANGED by both per-test arms, so that the only thing separating them is
+# the response schema. It therefore says nothing about a `test_id` field: one arm
+# has one and the other does not, and an instruction mentioning it would make the
+# arms differ in the request as well as in the schema.
+_SINGLE_TEST_INSTRUCTION = """\
+You are given exactly ONE test. Return one entry per OFFERED DEFECT — every
+defect id, not only the ones the test catches — with `fails` true if the test
+would fail on that defect and false if it would not. Five defects offered means
+five entries.
 
 An entry whose `fails` is true also carries `reason`: one short sentence naming
 what the test asserts that the defect would change. An entry whose `fails` is
@@ -393,6 +451,32 @@ class _Unions(StrictResponseModel):
     tests: list[_UnionTest]
 
 
+class _NoTestId(StrictResponseModel):
+    """The shipped union with the `test_id` echo removed, and the wrapper with it.
+
+    #324's thesis is that the per-call `test_id` enum is what stops any call
+    caching: it is the only part of the schema that changes between one pair call
+    and the next, and removing it collapses 1,762 distinct schemas to 7. The
+    field can go because `_batches` in the shipped stage puts exactly one test in
+    a batch, so the caller already knows which test the answer is about and does
+    not need to be told.
+
+    **Removing the field is not the same experiment as leaving it unconstrained,
+    and is deliberately the safer of the two.** Unconstrained, the judge would
+    have to echo a long pytest node id exactly, and a paraphrase would cost the
+    whole call's judgements — the failure `tagged-alias` reproduced. Absent,
+    there is nothing left to get wrong.
+
+    The `tests` wrapper goes too rather than being kept with one member: a
+    one-element list whose element carries no identity is pure scaffolding, and
+    keeping it would leave a second thing changed for no measured reason.
+    """
+
+    # `_Kills` first, for the same left-to-right union resolution reason as
+    # `_UnionTest`.
+    defects: list[_Kills | _Survives]
+
+
 class _Tagged(StrictResponseModel):
     defect_id: str
     fails: bool
@@ -518,6 +602,8 @@ def _decode(
     arm: str,
     defect_alias: dict[str, str] | None,
     test_alias: dict[str, str] | None,
+    node: str | None = None,
+    offered_tests: set[str] | None = None,
 ) -> tuple[list[tuple[str, list]], int]:
     """The response as (test id, judgements), with aliases resolved to full ids.
 
@@ -527,7 +613,30 @@ def _decode(
     obtained, which is a different claim from the model having considered the
     pair and answered no. Dropping it silently would let the alias arm buy
     coverage it never earned.
+
+    The free-id arms are held to the same rule and for the same reason: their
+    `test_id` is a plain string the judge wrote, so an id the call never offered
+    is exactly what `supplied_ids.py::scan` would record as an `UnusableAnswer`
+    on a real run. Matching is EXACT — no nearest-match, no case folding, no
+    trimming — because a charitable match here would hide the failure mode the
+    arm exists to measure.
     """
+    if arm == "no-test-id":
+        # The test the answer is about comes from the caller, which is the whole
+        # claim being tested: under test-major batching the request offered one
+        # test, so the response never had to name it. `node` is that test.
+        assert node is not None
+        return [(node, list(raw.defects))], 0
+    if arm in FREE_ID_ARMS:
+        assert offered_tests is not None
+        decoded: list[tuple[str, list]] = []
+        undecodable = 0
+        for entry in raw.tests:
+            if entry.test_id in offered_tests:
+                decoded.append((entry.test_id, list(entry.defects)))
+            else:
+                undecodable += len(entry.defects)
+        return decoded, undecodable
     if defect_alias is None:
         return [(entry.test_id, list(entry.defects)) for entry in raw.tests], 0
 
@@ -621,10 +730,55 @@ def _score(cases: list[dict], predictions: dict[str, dict[str, set[str]]]) -> di
     }
 
 
+def _call_units(arm: str, case: dict) -> list[tuple[dict, str | None]]:
+    """The calls one case becomes, as (case-shaped payload, the single test id).
+
+    Every arm but the two per-test ones sends the whole case in one call and gets
+    `(case, None)`. A per-test arm sends one call per test, each carrying a case
+    narrowed to that one test — which makes `_blocks` render a `## Tests` block
+    holding exactly that test, with no other change to the request.
+    """
+    if arm not in PER_TEST_ARMS:
+        return [(case, None)]
+    return [({**case, "tests": {node: body}}, node) for node, body in sorted(case["tests"].items())]
+
+
 def _arm_setup(arm: str, case: dict):
     """Schema, stage, instruction, allowed ids and alias maps for one call."""
     defect_ids = [defect["id"] for defect in case["defects"]]
     test_ids = sorted(case["tests"])
+    if arm in FREE_ID_ARMS:
+        # The SHIPPED schema, unchanged — `test_id` is simply left out of
+        # `allowed`, so `constrain` leaves it a plain `str`. That is the whole
+        # arm: same response shape, no per-call enum on the test.
+        #
+        # `free-test-id` matches `per-test`'s request byte for byte and
+        # `union-free-id` matches `union`'s, so each has a control differing in
+        # the schema alone.
+        return (
+            _Unions,
+            FREE_TEST_ID_STAGE if arm == "free-test-id" else UNION_FREE_ID_STAGE,
+            _SINGLE_TEST_INSTRUCTION if arm == "free-test-id" else _UNION_INSTRUCTION,
+            {"defect_id": defect_ids},
+            None,
+            None,
+        )
+    if arm in PER_TEST_ARMS:
+        # One `allowed` mapping for both arms. `constrain` walks the model's own
+        # fields and ignores a key naming a field it does not have, so the
+        # `test_id` entry constrains `per-test` and is silently unused by
+        # `no-test-id` — which is what keeps the two requests identical.
+        return (
+            _Unions if arm == "per-test" else _NoTestId,
+            PER_TEST_STAGE if arm == "per-test" else NO_TEST_ID_STAGE,
+            _SINGLE_TEST_INSTRUCTION,
+            {
+                "test_id": test_ids,
+                "defect_id": defect_ids,
+            },
+            None,
+            None,
+        )
     if arm == "listing":
         return (
             _Listing,
@@ -763,6 +917,26 @@ def _projection(reasoned_tokens: float, arm_tokens: float) -> dict:
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--arms",
+        default="",
+        help=(
+            "comma-separated arms to CALL this run; every other arm keeps the row "
+            "findings.json already holds. Default: all of them. Use this to add an "
+            "arm without re-issuing the calls behind figures already written up — "
+            "the recordings for the earlier arms are no longer in the live cache, "
+            "so a full run would re-draw them live and could move a published table "
+            "for reasons that have nothing to do with the new arm."
+        ),
+    )
+    options = parser.parse_args()
+    selected = tuple(name.strip() for name in options.arms.split(",") if name.strip()) or ARMS
+    unknown = [name for name in selected if name not in ARMS]
+    if unknown:
+        print(f"unknown arm(s): {', '.join(unknown)}", file=sys.stderr)
+        return 1
+
     cases = _cases()
     if not cases:
         print("no archetype cases carry defect labels", file=sys.stderr)
@@ -796,7 +970,9 @@ def main() -> int:
         "seeds_by_arm": by_arm,
         "arms": {},
     }
-    schedule = [(name, seed) for name in ARMS for seed in by_arm[name]]
+    schedule = [(name, seed) for name in ARMS if name in selected for seed in by_arm[name]]
+    if set(selected) != set(ARMS):
+        print(f"calling only: {', '.join(selected)}; every other arm is carried from findings.json")
     for arm, seed in schedule:
         config = RunConfig(mode=Mode.RECORD, seed=seed)
         client = config.build_client()
@@ -805,6 +981,8 @@ def main() -> int:
         undecodable = 0
         tags: Counter[str] = Counter()
         survives = {"tag_only": 0, "tag_and_reason": 0, "freeform": 0}
+        written_ids = {"exact": 0, "invented": 0}
+        invented: list[str] = []
         # Where a `reason` field exists, whether it was actually filled. For the
         # kills-only arm this is the whole measurement: the instruction to leave
         # a surviving pair's reason empty is stated in prose and enforced by
@@ -819,23 +997,44 @@ def main() -> int:
             "survives_absent": 0,
         }
         for case in cases:
-            model, stage, instruction, allowed, defect_alias, test_alias = _arm_setup(arm, case)
-            batch = partition([case["name"]], 1, key=lambda name: name)[0]
-            raw = client.complete(
-                assemble(_blocks(case, instruction, defect_alias, test_alias)),
-                constrain(model, allowed),
-                batch.request_partition(),
-                parse_as=model,
-                stage=stage,
-            )
             predicted: dict[str, set[str]] = {}
-            if arm == "listing":
-                decoded: list = []
-                for entry in raw.tests:
-                    predicted[entry.test_id] = set(entry.catches)
-            else:
-                decoded, missed = _decode(raw, arm, defect_alias, test_alias)
+            decoded: list = []
+            # One iteration for every arm but the two per-test ones, and one per
+            # test for those. The accounting below runs over the accumulated
+            # `decoded`, so it does not care which of the two happened.
+            for unit, node_id in _call_units(arm, case):
+                model, stage, instruction, allowed, defect_alias, test_alias = _arm_setup(arm, unit)
+                key = case["name"] if node_id is None else f"{case['name']}::{node_id}"
+                batch = partition([key], 1, key=lambda name: name)[0]
+                raw = client.complete(
+                    assemble(_blocks(unit, instruction, defect_alias, test_alias)),
+                    constrain(model, allowed),
+                    batch.request_partition(),
+                    parse_as=model,
+                    stage=stage,
+                )
+                if arm == "listing":
+                    for entry in raw.tests:
+                        predicted[entry.test_id] = set(entry.catches)
+                    continue
+                offered_tests = set(unit["tests"])
+                if arm in FREE_ID_ARMS:
+                    # The measurement the free-id arms exist for: how often a
+                    # judge writing the node id itself writes one that was
+                    # offered. Kept as the ids themselves, not just a count, so
+                    # a miss can be read as a paraphrase or as an invention.
+                    for entry in raw.tests:
+                        if entry.test_id in offered_tests:
+                            written_ids["exact"] += 1
+                        else:
+                            written_ids["invented"] += 1
+                            invented.append(entry.test_id)
+                unit_decoded, missed = _decode(
+                    raw, arm, defect_alias, test_alias, node_id, offered_tests
+                )
                 undecodable += missed
+                decoded.extend(unit_decoded)
+            if arm != "listing":
                 for node, judgements in decoded:
                     predicted[node] = {judged.defect_id for judged in judgements if judged.fails}
                     for judged in judgements:
@@ -863,6 +1062,16 @@ def main() -> int:
             shedding.append(_unanswered(case, predicted, arm, decoded))
 
         usage = summarize(client.observed_calls)
+        # The figure #324 turns on, and the one no earlier round of this pilot
+        # recorded. `cached_tokens` is None where no call reported one, which is
+        # not the same claim as zero — `StageUsage.cached_prompt_share` keeps that
+        # distinction and so does this. The denominator is the prompt tokens of
+        # the calls that DID report, not every call's.
+        measured = sum(stage.measured_prompt_tokens for stage in usage.stages)
+        reported = [
+            stage.cached_tokens for stage in usage.stages if stage.cached_tokens is not None
+        ]
+        cached = sum(reported) if reported else None
         label = f"{arm}/seed={seed}"
         carried = previous.get(label) or {}
         entry = {
@@ -875,6 +1084,9 @@ def main() -> int:
             "cost_usd": usage.run_spend_usd or carried.get("cost_usd", 0.0),
             "evidence_cost_usd": usage.evidence_cost_usd,
             "prompt_tokens": sum(stage.prompt_tokens for stage in usage.stages),
+            "cached_tokens": cached,
+            "measured_prompt_tokens": measured,
+            "cached_prompt_share": (cached / measured) if cached is not None and measured else None,
             "completion_tokens": sum(stage.completion_tokens for stage in usage.stages),
             "completion_tokens_per_case": sum(stage.completion_tokens for stage in usage.stages)
             / len(cases),
@@ -901,6 +1113,16 @@ def main() -> int:
                     else None
                 ),
             }
+        if arm in FREE_ID_ARMS:
+            total_ids = written_ids["exact"] + written_ids["invented"]
+            entry["written_test_ids"] = {
+                **written_ids,
+                "exact_share": (written_ids["exact"] / total_ids) if total_ids else None,
+                # Every distinct id the judge wrote that the call never offered.
+                # Sorted rather than in arrival order so two runs over the same
+                # input write the same file (M0.5, byte-identical reruns).
+                "invented_ids": sorted(set(invented)),
+            }
         if arm in TAGGED_ARMS:
             answered_survives = sum(survives.values())
             entry["tag_usage"] = {
@@ -913,18 +1135,33 @@ def main() -> int:
             }
         findings["arms"][label] = entry
 
+    # Every arm not called this run keeps the row it already had, so a partial run
+    # extends the record rather than truncating it. Rebuilt in ARMS order so the
+    # file and the printed table read the same however the run was invoked.
+    ordered: dict = {}
+    for name in ARMS:
+        for seed in by_arm[name]:
+            label = f"{name}/seed={seed}"
+            row = findings["arms"].get(label) or previous.get(label)
+            if row is not None:
+                ordered[label] = row
+    findings["arms"] = ordered
+
     per_arm = {arm: [row for row in findings["arms"].values() if row["arm"] == arm] for arm in ARMS}
+    # An arm with no rows at all — never called, nothing carried — is left out of
+    # the aggregates rather than dividing by zero.
+    scored = [arm for arm in ARMS if per_arm[arm]]
     means = {
-        arm: sum(row["completion_tokens"] for row in rows) / len(rows)
-        for arm, rows in per_arm.items()
+        arm: sum(row["completion_tokens"] for row in per_arm[arm]) / len(per_arm[arm])
+        for arm in scored
     }
     findings["output_token_ratios"] = {
         arm: {
             "mean_completion_tokens": means[arm],
-            "ratio_to_verdict": means[arm] / means["verdict"] if means["verdict"] else None,
-            **_projection(means["reasoned"], means[arm]),
+            "ratio_to_verdict": (means[arm] / means["verdict"] if means.get("verdict") else None),
+            **_projection(means.get("reasoned") or 0.0, means[arm]),
         }
-        for arm in ARMS
+        for arm in scored
     }
     findings["gate2_reference"] = {
         "pair_stage_output_tokens": GATE2_PAIR_OUTPUT_TOKENS,
@@ -934,10 +1171,21 @@ def main() -> int:
     }
 
     OUT.write_text(json.dumps(findings, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    def _fmt(value, places: int) -> str:
+        """`None` printed as such rather than crashing the summary.
+
+        `precision` is None when an arm predicted no kills at all. That is a
+        catastrophic result and the one most worth seeing printed, so it must not
+        be the case that takes the report down before the row is written.
+        """
+        return "n/a" if value is None else f"{value:.{places}f}"
+
     for label, figures in findings["arms"].items():
         print(
-            f"{label:28s} recall={figures['recall']:.4f} precision={figures['precision']:.4f} "
-            f"kills/defect={figures['kills_per_defect']:.3f} "
+            f"{label:28s} recall={_fmt(figures['recall'], 4)} "
+            f"precision={_fmt(figures['precision'], 4)} "
+            f"kills/defect={_fmt(figures['kills_per_defect'], 3)} "
             f"unanswered={figures['unanswered_pairs']} "
             f"undecodable={figures['undecodable_ids']} "
             f"detectable={figures['shedding_detectable']} "
@@ -948,7 +1196,7 @@ def main() -> int:
     # whose recall moves more between seeds than the arms differ from each other
     # has not been separated by this experiment.
     print()
-    for arm in ARMS:
+    for arm in scored:
         rows = per_arm[arm]
         recalls = [row["recall"] for row in rows]
         guards = [row["kills_per_defect"] for row in rows]
@@ -957,6 +1205,11 @@ def main() -> int:
             f"{arm:13s} n={len(rows)} recall min={min(recalls):.4f} max={max(recalls):.4f} "
             f"mean={sum(recalls) / len(recalls):.4f}  "
             f"kills/defect {min(guards):.3f}-{max(guards):.3f}  "
+            # Prompt tokens are in this line because #324 is a PROMPT-cost issue,
+            # not an output-cost one: the per-test arms issue one call per test
+            # and repeat the delivered source in each, so they buy a cacheable
+            # schema by sending more prompt. Both halves have to be visible.
+            f"prompt mean={sum(row['prompt_tokens'] for row in rows) / len(rows):.0f} "
             f"out mean={means[arm]:.0f} "
             f"(x{ratios['ratio_to_verdict']:.2f} verdict, "
             f"x{ratios['ratio_to_reasoned']:.2f} reasoned)"
@@ -968,10 +1221,15 @@ def main() -> int:
     # of draws at or below the bar. Read those when comparing `verdict`,
     # `kills-only` and `union`, which is why all three were drawn nine times.
     print()
+    if not per_arm["verdict"]:
+        print("no verdict rows, so no bar to compare against")
+        return 0
     bar = min(row["recall"] for row in per_arm["verdict"])
     print(f"bar = verdict's worst of {len(per_arm['verdict'])} draws = {bar:.4f}")
     for arm in DEEP_SEED_ARMS:
         rows = per_arm[arm]
+        if not rows:
+            continue
         recalls = sorted(row["recall"] for row in rows)
         below = [value for value in recalls if value < bar]
         spread = max(recalls) - min(recalls)
@@ -994,8 +1252,52 @@ def main() -> int:
             f"(field absent on {absent})  kills carrying a reason={killed}"
         )
 
+    # #324's question, asked head to head. Every other comparison in this script
+    # crosses a batching boundary as well as a schema one; these two arms differ
+    # in the response schema alone, so the gap between them is what dropping
+    # `test_id` costs and nothing else. Reported seed by seed as well as pooled,
+    # because a mean over nine draws hides a single draw that collapsed.
+    if per_arm["per-test"] and per_arm["no-test-id"]:
+        print()
+        control = {row["seed"]: row for row in per_arm["per-test"]}
+        candidate = {row["seed"]: row for row in per_arm["no-test-id"]}
+        print("#324 head to head — per-test (keeps test_id) vs no-test-id (drops it)")
+        for seed in sorted(set(control) & set(candidate)):
+            left, right = control[seed], candidate[seed]
+            print(
+                f"  seed={seed}  recall {left['recall']:.4f} -> {right['recall']:.4f}  "
+                f"kills/defect {left['kills_per_defect']:.3f} -> {right['kills_per_defect']:.3f}  "
+                f"out {left['completion_tokens']} -> {right['completion_tokens']}  "
+                f"prompt {left['prompt_tokens']} -> {right['prompt_tokens']}  "
+                f"cached {_fmt(left.get('cached_prompt_share'), 4)} -> "
+                f"{_fmt(right.get('cached_prompt_share'), 4)}"
+            )
+
+    # Whether a judge asked to write the node id itself writes one that exists.
+    # An id the call never offered costs that whole entry's judgements, so the
+    # exact-match share and the lost-pair count are the two figures that decide
+    # whether a free-text `test_id` is usable.
+    printed = False
+    for arm in FREE_ID_ARMS:
+        rows = [row for row in per_arm[arm] if "written_test_ids" in row]
+        if not rows:
+            continue
+        if not printed:
+            print()
+            printed = True
+        shares = [row["written_test_ids"]["exact_share"] for row in rows]
+        lost = sum(row["undecodable_ids"] for row in rows)
+        invented_ids = sorted({i for row in rows for i in row["written_test_ids"]["invented_ids"]})
+        print(
+            f"{arm:14s} test ids written exactly: min={min(shares):.4f} max={max(shares):.4f}  "
+            f"pairs lost to an id never offered={lost}  "
+            f"distinct invented ids={invented_ids or 'none'}"
+        )
+
     print()
     for arm in TAGGED_ARMS:
+        if not per_arm[arm]:
+            continue
         shares = [row["tag_usage"]["tag_share"] for row in per_arm[arm]]
         pooled: Counter[str] = Counter()
         for row in per_arm[arm]:

--- a/src/acceptance/cli.py
+++ b/src/acceptance/cli.py
@@ -28,6 +28,7 @@ from acceptance.config import (
     DEFAULT_MODEL,
     DEFAULT_PAIR_BATCH_SIZE,
     DEFAULT_SEED,
+    DEFAULT_TESTS_PER_BATCH,
     RunConfig,
 )
 from acceptance.coverage.classify import ImplementationCoverage, classify_coverage
@@ -196,6 +197,7 @@ def run_check(
         declaration_text=declaration_text,
         policy=config.scope_expansion_policy,
         pair_batch_size=config.pair_batch_size,
+        tests_per_batch=config.tests_per_batch,
         link_pair_batch_size=config.link_pair_batch_size,
         link_distance_threshold=config.link_distance_threshold,
         task_identifier=task,
@@ -733,6 +735,18 @@ def _add_model_flags(parser: argparse.ArgumentParser, default_mode: str) -> None
         ),
     )
     parser.add_argument(
+        "--tests-per-batch",
+        type=int,
+        default=DEFAULT_TESTS_PER_BATCH,
+        help=(
+            "Tests sharing one pair-judgement call (determinism; default: "
+            f"{DEFAULT_TESTS_PER_BATCH}). Does NOT change how many judgements a "
+            "response carries — --pair-batch-size still caps that, so more tests "
+            "per call means fewer defects offered with each. Changing it "
+            "invalidates recorded pair-judgement transcripts."
+        ),
+    )
+    parser.add_argument(
         "--embedding-model",
         default=DEFAULT_EMBEDDING_MODEL,
         help=(
@@ -890,6 +904,7 @@ def main(argv: list[str] | None = None) -> int:
             seed=_seed_from(args),
             temperature=args.temperature,
             pair_batch_size=args.pair_batch_size,
+            tests_per_batch=args.tests_per_batch,
             embedding_model=args.embedding_model,
             link_distance_threshold=args.link_distance_threshold,
         )
@@ -964,6 +979,7 @@ def main(argv: list[str] | None = None) -> int:
             seed=_seed_from(args),
             temperature=args.temperature,
             pair_batch_size=args.pair_batch_size,
+            tests_per_batch=args.tests_per_batch,
             embedding_model=args.embedding_model,
             link_distance_threshold=args.link_distance_threshold,
         )
@@ -1014,6 +1030,7 @@ def main(argv: list[str] | None = None) -> int:
             seed=_seed_from(args),
             temperature=args.temperature,
             pair_batch_size=args.pair_batch_size,
+            tests_per_batch=args.tests_per_batch,
             embedding_model=args.embedding_model,
             link_distance_threshold=args.link_distance_threshold,
         )

--- a/src/acceptance/config.py
+++ b/src/acceptance/config.py
@@ -22,7 +22,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from acceptance.defects.pair_mapping import DEFAULT_PAIR_BATCH_SIZE
+from acceptance.defects.pair_mapping import DEFAULT_PAIR_BATCH_SIZE, DEFAULT_TESTS_PER_BATCH
 from acceptance.llm import DEFAULT_TRANSCRIPT_ROOT, Mode, ModelClient, TranscriptStore
 from acceptance.review_state import DeterminismControls, LinkPrefilter, ReviewProvenance
 
@@ -153,6 +153,12 @@ class RunConfig(BaseModel):
     # worse than no control: it accepts a value, records nothing, and reads
     # as a knob that was turned.
     pair_batch_size: int = Field(default=DEFAULT_PAIR_BATCH_SIZE, ge=1)
+    # How many tests share one pair request. A determinism control like the batch
+    # size beside it, hashed into the pair request for the same reason, and
+    # separate from it because the two do different things: `pair_batch_size`
+    # caps judgements per response, this one shapes the rectangle those
+    # judgements are drawn from. See `pair_mapping.py::_batches`.
+    tests_per_batch: int = Field(default=DEFAULT_TESTS_PER_BATCH, ge=1)
     # And for obligation linking (#144), whose unit is a PAIR of obligations
     # rather than an obligation — see the constant's note.
     link_pair_batch_size: int = Field(default=DEFAULT_LINK_PAIR_BATCH_SIZE, ge=1)

--- a/src/acceptance/defects/pair_mapping.py
+++ b/src/acceptance/defects/pair_mapping.py
@@ -56,7 +56,7 @@ from acceptance.defects.reachability import Pair, form_pairs, prefilter
 from acceptance.evidence.discovery import DiscoveredTest
 from acceptance.llm import ModelClient, StrictResponseModel
 from acceptance.model_base import PersistableModel
-from acceptance.partition import partition
+from acceptance.partition import Batch
 from acceptance.request_blocks import Block, BlockKind, assemble
 from acceptance.review_state import (
     ChangeSet,
@@ -89,6 +89,23 @@ PAIR_STAGE_LOGIC_VERSION = 1
 # rather than a list per test, so the same number of judgements produces more
 # output than the mapping stage's did.
 DEFAULT_PAIR_BATCH_SIZE = 40
+
+# How many tests may share one request. This used to be fixed at 1 — see
+# `_batches` for why that was chosen and why it changed.
+#
+# **The judgement budget is unchanged.** `DEFAULT_PAIR_BATCH_SIZE` still caps
+# judgements per response, so four tests share a call by being offered a quarter
+# as many defects each, not by making the response four times larger. That keeps
+# DR-164's shedding argument intact: what binds is how many independent
+# judgements one response carries, and that number has not moved.
+#
+# 4 rather than some larger number because the evidence supports the DIRECTION
+# and not the magnitude. `docs/experiments/pair-response-shape/` measured 2-3
+# tests per call against 1 and found 0.9688 recall against 0.8785 over nine draws
+# each, but its calls carried at most 15 judgements where these carry 40, and it
+# never varied the shape of the rectangle at a fixed budget. Treat 4 as the
+# smallest step that gets the measured effect, not as a tuned value.
+DEFAULT_TESTS_PER_BATCH = 4
 
 _SYSTEM_PROMPT = """\
 You are given concrete DEFECTS — specific ways the delivered code could be wrong
@@ -317,46 +334,127 @@ def _subject(batch_pairs: list[Pair]) -> str:
     return "\n".join(lines)
 
 
-def _batches(pairs: list[Pair], size: int):
-    """Partition `pairs` into requests, one test per request.
+def _batches(pairs: list[Pair], size: int, tests_per_batch: int = DEFAULT_TESTS_PER_BATCH):
+    """Partition `pairs` into requests, each one a full rectangle.
 
-    **Per test rather than across tests, and the reason is the limit's meaning.**
-    `constrain` narrows each id field independently, so a batch spanning several
-    tests offers a schema in which every test x every defect is expressible — a
-    batch of 3 pairs over 2 tests and 3 defects permits 6 answers. The prompt
-    would ask for 3 and the schema would invite 6, and the extras would have to
-    be dropped on the way back in, which is a silent filter of exactly the kind
-    DR-164 exists to forbid.
+    **A batch is a rectangle: every test in it is offered every defect in it.**
+    That invariant is the whole design, and it is what the original one-test-per-
+    request rule was really protecting. `constrain` narrows each id field
+    independently, so a batch spanning several tests offers a schema in which
+    every test x every defect is expressible. If the offered pairs are a ragged
+    subset of that cross product, the prompt asks for fewer answers than the
+    schema invites and the extras have to be dropped on the way back — a silent
+    filter of exactly the kind DR-164 forbids. When the batch IS the cross
+    product, there is nothing to drop, and the number of tests stops mattering.
 
-    With one test per request the schema's cross product IS the offered set, so
-    the limit counts the judgements the response is actually asked to carry.
-    A test with more open defects than `size` is split across several requests.
+    One test per request was the simplest way to guarantee a rectangle, not a
+    finding that one test was better. Measurement says it is worse:
+    `docs/experiments/pair-response-shape/` scored 2-3 tests per call at 0.9688
+    mean recall against 0.8785 for one, over nine draws each against #315's
+    human-reviewed kill labels, with the gap falling entirely on the cases where
+    the two batched differently. Read its *Dropping `test_id`* section before
+    changing this; in particular the shape of the rectangle at a fixed judgement
+    budget is NOT measured, so `tests_per_batch` is a deliberate knob.
 
-    The cost is more requests than a test-major batch would issue. It is smaller
-    than it looks — the system prompt and the shared prefix are what caching
-    discounts, and the alternative restates every defect under every test in the
-    prompt anyway — but it is a real figure for #316 to watch as pair counts grow.
+    Tests owed the SAME set of defects can share a call while keeping the
+    rectangle; tests owed different sets cannot, so they are grouped by the
+    defects they are still owed. That set is ragged in practice — `judge_pairs`
+    drops pairs the prefilter proves unreachable and pairs carried from a prior
+    run — which is why this groups rather than simply slicing the test list.
+
+    `size` still caps judgements per response, so more tests in a call means
+    fewer defects with each. A group whose tests are owed more defects than fit
+    is split across several requests, as before.
     """
     by_test: dict[str, list[Pair]] = {}
     for pair in pairs:
         by_test.setdefault(pair.test.test_id, []).append(pair)
-    batches = []
-    for test_id in sorted(by_test):
-        batches.extend(partition(by_test[test_id], size, key=lambda pair: pair.key))
-    return batches
+
+    # Tests owed an identical defect set, keyed by that set so the grouping is a
+    # pure function of the input — batch composition must not depend on
+    # iteration order or replay misses (see `partition.partition`).
+    groups: dict[tuple[str, ...], list[str]] = {}
+    for test_id, test_pairs in by_test.items():
+        groups.setdefault(tuple(sorted({p.defect.id for p in test_pairs})), []).append(test_id)
+
+    width = max(1, min(tests_per_batch, size))
+    grouped: list[list[Pair]] = []
+    for defect_ids in sorted(groups):
+        test_ids = sorted(groups[defect_ids])
+        for start in range(0, len(test_ids), width):
+            tests_here = test_ids[start : start + width]
+            # Whole defect set where it fits, otherwise as many as the judgement
+            # budget allows once it is shared between this call's tests.
+            depth = max(1, size // len(tests_here))
+            for first in range(0, len(defect_ids), depth):
+                wanted = set(defect_ids[first : first + depth])
+                grouped.append(
+                    sorted(
+                        (
+                            pair
+                            for test_id in tests_here
+                            for pair in by_test[test_id]
+                            if pair.defect.id in wanted
+                        ),
+                        key=lambda pair: pair.key,
+                    )
+                )
+
+    return [
+        Batch(items=tuple(items), index=index, count=len(grouped), size=size)
+        for index, items in enumerate(grouped)
+    ]
 
 
-def _allowed(batch_pairs: list[Pair]) -> dict[str, list[str]]:
+def _scanned_ids(batch_pairs: list[Pair]) -> dict[str, list[str]]:
+    """What this call supplied — the set `scan` checks the answer against.
+
+    Both id fields, including `test_id`, which `_constrained_ids` deliberately
+    leaves out of the schema. The two halves of the supplied-id guarantee are
+    separable and this is the seam: `constrain` makes a wrong id unrepresentable,
+    `scan` makes one detectable, and `supplied_ids.py::scan` says in its own
+    docstring that it runs even where `constrain` already bound the field.
+    """
     return {
         "test_id": sorted({pair.test.test_id for pair in batch_pairs}),
         "defect_id": sorted({pair.defect.id for pair in batch_pairs}),
     }
 
 
+def _constrained_ids(batch_pairs: list[Pair]) -> dict[str, list[str]]:
+    """What goes into the SCHEMA — the defect ids, and no longer the test ids.
+
+    **Why `test_id` came out.** It was the only part of a pair request that
+    changed from one call to the next, and a provider's prompt cache keys on a
+    prefix that includes the response schema: #316's Gate 2 run measured a 0.0%
+    cached share across all seven stages and 1,012 calls, with 1,762 distinct
+    schemas across 1,762 pair calls, collapsing to 7 with this enum removed
+    (#324). Leaving the field a plain `str` is what makes a call's schema
+    identical to its neighbour's.
+
+    **The judge is not thereby trusted.** `_scanned_ids` still supplies the test
+    ids and `scan` still checks every answer against them, so an id that was
+    never offered is recorded as an `UnusableAnswer` rather than believed, and
+    `_ask` drops any pair the batch did not offer. `docs/experiments/
+    pair-response-shape/` measured the risk over nine draws of each arm: with
+    several tests in a call the judge wrote a real node id on 95.65-100% of
+    entries, the single exception being one mangling of a real id that cost 3
+    pair judgements on 1 draw, and recall was 0.9653 against the enumerated
+    arm's 0.9688 — indistinguishable at that sample size.
+
+    **This is why the two changes shipped together.** Leaving the field free
+    while a call still carried ONE test measured 0.8021 against 0.8785, with no
+    bad ids at all. Dropping the enum is safe with several tests in a call and
+    was measured to be unsafe with one.
+    """
+    return {"defect_id": sorted({pair.defect.id for pair in batch_pairs})}
+
+
 def _ask(
     batch_pairs: list[Pair],
     batch,
     client: ModelClient,
+    tests_per_batch: int = DEFAULT_TESTS_PER_BATCH,
 ) -> tuple[
     dict[tuple[str, str], tuple[bool, str]],
     dict[tuple[str, str], str],
@@ -387,11 +485,15 @@ def _ask(
             Block(BlockKind.SUBJECT, _subject(batch_pairs)),
         ]
     )
-    allowed = _allowed(batch_pairs)
     result = client.complete(
         messages,
-        constrain(_PairVerdicts, allowed),
-        batch.request_partition(),
+        constrain(_PairVerdicts, _constrained_ids(batch_pairs)),
+        # `tests_per_batch` folded in beside `size` for the reason
+        # `Batch.request_partition` gives about `size`: it is a run control, so
+        # changing it must invalidate every recorded transcript, and it would not
+        # otherwise — two values produce identical batches whenever a group holds
+        # fewer tests than either.
+        {**batch.request_partition(), "tests_per_batch": tests_per_batch},
         parse_as=_LenientPairVerdicts,
         stage=_STAGE,
     )
@@ -420,7 +522,7 @@ def _ask(
                 )
             else:
                 answered[key] = (judged.fails, reason)
-    return answered, unusable_shape, scan(result, allowed, _STAGE)
+    return answered, unusable_shape, scan(result, _scanned_ids(batch_pairs), _STAGE)
 
 
 # `DerivedSupport` and `derive_support` used to live here, deriving a support
@@ -441,6 +543,7 @@ def judge_pairs(
     batch_size: int = DEFAULT_PAIR_BATCH_SIZE,
     unusable: UnusableAnswerLog | None = None,
     prior: list[PairVerdict] | None = None,
+    tests_per_batch: int = DEFAULT_TESTS_PER_BATCH,
 ) -> PairMappingResult:
     """Judge every pair the prefilter does not prove unreachable.
 
@@ -485,8 +588,10 @@ def judge_pairs(
     # #314's Gate 2 and several thousand on a large diff.
     #
     # The request is untouched, so every recorded transcript still replays.
-    batches = _batches(to_ask, batch_size)
-    answers = map_calls(batches, lambda batch: _ask(list(batch.items), batch, client))
+    batches = _batches(to_ask, batch_size, tests_per_batch)
+    answers = map_calls(
+        batches, lambda batch: _ask(list(batch.items), batch, client, tests_per_batch)
+    )
 
     fresh: list[PairVerdict] = []
     for batch, (answered, unusable_shape, scanned) in zip(batches, answers):

--- a/src/acceptance/pipeline.py
+++ b/src/acceptance/pipeline.py
@@ -40,7 +40,11 @@ from acceptance.coverage.open_questions import (
 from acceptance.coverage.recommendations import recommend_tests
 from acceptance.coverage.unrequested import detect_unrequested_changes
 from acceptance.defects.enumeration import enumerate_defects
-from acceptance.defects.pair_mapping import DEFAULT_PAIR_BATCH_SIZE, judge_pairs
+from acceptance.defects.pair_mapping import (
+    DEFAULT_PAIR_BATCH_SIZE,
+    DEFAULT_TESTS_PER_BATCH,
+    judge_pairs,
+)
 from acceptance.defects.support import (
     apply_derived_support,
     derive_support,
@@ -246,6 +250,7 @@ def run_review(
     declaration_text: str | None = None,
     policy: ScopeExpansionPolicy = ScopeExpansionPolicy.STRICT,
     pair_batch_size: int = DEFAULT_PAIR_BATCH_SIZE,
+    tests_per_batch: int = DEFAULT_TESTS_PER_BATCH,
     link_pair_batch_size: int = DEFAULT_LINK_PAIR_BATCH_SIZE,
     link_distance_threshold: float | None = DEFAULT_LINK_DISTANCE_THRESHOLD,
     task_identifier: str = "<inline>",
@@ -366,6 +371,7 @@ def run_review(
         client,
         repo=repo,
         batch_size=pair_batch_size,
+        tests_per_batch=tests_per_batch,
         unusable=unusable,
         prior=list(ledger_prior.pair_verdicts) if ledger_prior is not None else None,
     )

--- a/tests/benchmark/degenerate_judges.py
+++ b/tests/benchmark/degenerate_judges.py
@@ -50,6 +50,7 @@ from tests.support import (
     _EMPTY_BY_SCHEMA,
     _completed,
     _fake_response,
+    _tests_offered,
     constant_embedding_fn,
 )
 
@@ -150,11 +151,13 @@ def degenerate_client(obligations: list[dict], *, always_strong: bool) -> ModelC
             # and my derivation refuses to classify a criterion whose defects are
             # partly unknown — so a double that skipped one would drive the run
             # `indeterminate` rather than steering the rating this suite is about.
-            # Both id sets come off the schema. The pair stage constrains
-            # `test_id` as well as `defect_id` (`_allowed`), unlike the mapping
-            # stage this replaced, whose per-batch test ids #302 dropped from the
-            # schema and left only in the prompt.
-            tests = _enums(schema, "test_id")
+            # The defect ids come off the schema; the TEST ids come off the
+            # prompt. #324 dropped the `test_id` enum for the same reason #302
+            # dropped the mapping stage's — a per-call enum is the one part of
+            # the request that changes between calls, so nothing caches — and
+            # left the test ids where the model reads them. Reading them from
+            # the schema here would silently answer for no tests at all.
+            tests = _tests_offered(**kwargs)
             defect_ids = _enums(schema, "defect_id")
             verdict: dict[str, Any] = {"fails": always_strong}
             if always_strong:

--- a/tests/benchmark/test_coverage.py
+++ b/tests/benchmark/test_coverage.py
@@ -38,6 +38,7 @@ from tests.support import (
     _completed,
     _fake_response,
     _supplied_enum,
+    _tests_offered,
     client_finding_nothing,
     constant_embedding_fn,
 )
@@ -749,7 +750,7 @@ def test_the_shared_pipeline_partitions_the_pair_call(tmp_path):
             pair_calls.append(
                 [
                     (test_id, defect_id)
-                    for test_id in _supplied_enum("test_id", **kwargs)
+                    for test_id in _tests_offered(**kwargs)
                     for defect_id in _supplied_enum("defect_id", **kwargs)
                 ]
             )
@@ -802,9 +803,9 @@ def test_the_shared_pipeline_partitions_the_pair_call(tmp_path):
     one_per_call = run(1)
     batched = run(500)
 
-    # The control reaches the stage: a smaller batch means more calls. Not "one
-    # call at 500" — the stage partitions each test's pairs separately, so the
-    # floor is one call per test however large the batch.
+    # The control reaches the stage: a smaller batch means more calls. Since
+    # #324 a request may span several tests, so the floor is no longer one call
+    # per test — but a batch size of one still forces one judgement per call.
     assert len(one_per_call) > len(batched) > 0
     assert all(len(pairs) == 1 for pairs in one_per_call)
     # The same pairs judged either way. Partitioning changes the asking, not the

--- a/tests/defects/test_pair_mapping.py
+++ b/tests/defects/test_pair_mapping.py
@@ -20,11 +20,13 @@ from __future__ import annotations
 
 import json
 import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 
 from acceptance.change.diff import extract_change_set
 from acceptance.defects.pair_mapping import (
     DEFAULT_PAIR_BATCH_SIZE,
+    DEFAULT_TESTS_PER_BATCH,
     defect_text,
     judge_pairs,
     source_digest,
@@ -76,6 +78,27 @@ def _offered(field: str, **kwargs) -> list[str]:
     return found
 
 
+_TEST_HEADING = "### test "
+
+
+def _offered_tests(**kwargs) -> list[str]:
+    """The tests this call offered, read off the PROMPT rather than the schema.
+
+    `test_id` stopped being an enum in #324, so the schema no longer carries the
+    work list for tests. The prompt does: `_subject` writes a `### test <id>`
+    heading per test. Reading it from there keeps the double answering exactly
+    what it was asked, and keeps the reading honest — a request that named a
+    test nowhere the model could see would now answer nothing, where reading the
+    schema would have hidden that.
+    """
+    text = "\n".join(message["content"] for message in kwargs["messages"])
+    return [
+        line[len(_TEST_HEADING) :].strip()
+        for line in text.splitlines()
+        if line.startswith(_TEST_HEADING)
+    ]
+
+
 class _Judge:
     """A double that answers every pair a call offers, and records what it was asked.
 
@@ -122,7 +145,7 @@ class _Judge:
         return {"defect_id": defect_id, "fails": False}
 
     def _completion_fn(self, **kwargs):
-        tests = _offered("test_id", **kwargs)
+        tests = _offered_tests(**kwargs)
         defects = _offered("defect_id", **kwargs)
         self.requests.append(
             {
@@ -376,7 +399,15 @@ def test_one_misshapen_answer_does_not_discard_the_rest_of_its_batch(tmp_path):
 # --- carry --------------------------------------------------------------------
 
 
-def _judged(judge, defect_sets, tests, repo, prior=None, batch_size=DEFAULT_PAIR_BATCH_SIZE):
+def _judged(
+    judge,
+    defect_sets,
+    tests,
+    repo,
+    prior=None,
+    batch_size=DEFAULT_PAIR_BATCH_SIZE,
+    tests_per_batch=DEFAULT_TESTS_PER_BATCH,
+):
     return judge_pairs(
         defect_sets,
         tests,
@@ -384,6 +415,7 @@ def _judged(judge, defect_sets, tests, repo, prior=None, batch_size=DEFAULT_PAIR
         judge.client,
         repo=repo,
         batch_size=batch_size,
+        tests_per_batch=tests_per_batch,
         prior=prior,
     )
 
@@ -479,6 +511,9 @@ def test_which_pairs_share_a_request_does_not_change_what_carries(tmp_path):
 
 
 def test_no_request_carries_more_judgements_than_the_limit(tmp_path):
+    """The limit counts judgements, and still does now that a request may span
+    several tests: four tests sharing a call are offered a quarter as many
+    defects each, not four times as many judgements."""
     repo = _repo(tmp_path, {"test_billing.py": "x"})
     defects = [_defect_set(*[f"defect {index}" for index in range(5)])]
     tests = [_test(f"test_case_{index}") for index in range(4)]
@@ -486,14 +521,93 @@ def test_no_request_carries_more_judgements_than_the_limit(tmp_path):
 
     _judged(judge, defects, tests, repo, batch_size=3)
 
-    # One request per test, so each test's 5 defects split 3 + 2: 8 requests.
-    assert judge.calls == 8
+    assert judge.calls > 0
     for request in judge.requests:
-        # The schema's cross product IS the offered set, because a request never
-        # spans two tests. That equality is what makes the limit mean the number
-        # of judgements the response is actually asked to carry.
-        assert len(request["test_id"]) == 1
         assert len(request["test_id"]) * len(request["defect_id"]) <= 3
+
+
+def test_every_request_is_a_full_rectangle(tmp_path):
+    """Every test in a request is offered every defect in it, and nothing else.
+
+    This replaces the one-test-per-request rule, which was only ever the
+    simplest way of guaranteeing it. `constrain` narrows each id field
+    independently, so a request's schema permits its tests x its defects. If the
+    pairs it was built from are a ragged subset of that cross product, the schema
+    invites answers the prompt never asked for and they are dropped on the way
+    back in — the silent filter DR-164 forbids.
+
+    `pairs_asked` is exactly that cross product, summed over every request, so
+    asserting it equals the real pair set says both things at once: no pair was
+    missed, and no request invited one that does not exist.
+    """
+    repo = _repo(tmp_path, {"test_billing.py": "x"})
+    defects = [_defect_set(*[f"defect {index}" for index in range(5)])]
+    tests = [_test(f"test_case_{index}") for index in range(4)]
+    judge = _Judge()
+
+    _judged(judge, defects, tests, repo, batch_size=3)
+
+    every_pair = {(defect.id, test.test_id) for defect in defects[0].defects for test in tests}
+    assert judge.pairs_asked() == every_pair
+
+
+def test_a_ragged_pair_set_is_still_split_into_rectangles(tmp_path):
+    """The case the rectangle rule actually has to survive.
+
+    `judge_pairs` drops pairs carried from a prior run, so what is left to ask is
+    routinely ragged — one test still owed three defects beside another owed two.
+    Tests owed different sets cannot share a call without inviting a pair that
+    was never offered, so they must be grouped by what they are owed.
+    """
+    repo = _repo(tmp_path, {"test_billing.py": "x"})
+    defects = [_defect_set("divides by 30", "ignores days", "rounds down")]
+    tests = [_test("test_half_month"), _test("test_full_month")]
+
+    first = _judged(_Judge(), defects, tests, repo)
+    # Carry all but one pair, so the two tests are left owed different defect
+    # sets and cannot share a call.
+    ordered = sorted(first.verdicts, key=lambda verdict: (verdict.test_id, verdict.defect_id))
+    kept = ordered[1:]
+    assert len(kept) == len(ordered) - 1
+
+    judge = _Judge()
+    _judged(judge, defects, tests, repo, prior=kept)
+
+    still_owed = {(defect.id, test.test_id) for defect in defects[0].defects for test in tests} - {
+        (verdict.defect_id, verdict.test_id) for verdict in kept
+    }
+    assert still_owed
+    assert judge.pairs_asked() == still_owed
+
+
+def test_changing_how_many_tests_share_a_call_invalidates_the_transcripts(tmp_path):
+    """`tests_per_batch` is a determinism control, so it belongs in the request
+    key exactly as the batch size does — otherwise a run at a new value replays
+    answers produced under the old one.
+
+    Checked where it cannot be faked: one test and one defect, so both values
+    produce the identical single batch and the only thing that can separate the
+    two requests is the descriptor.
+    """
+    repo = _repo(tmp_path, {"test_billing.py": "x"})
+    defects = [_defect_set("divides by 30")]
+    tests = [_test("test_half_month")]
+
+    store = TranscriptStore(_tmp())
+    keys = []
+    for width in (1, 4):
+        judge = _Judge()
+        judge.client = ModelClient(
+            model=_DEFAULT_MODEL,
+            mode=Mode.RECORD,
+            store=store,
+            completion_fn=judge._completion_fn,
+        )
+        _judged(judge, defects, tests, repo, tests_per_batch=width)
+        keys.append(sorted(path.name for path in Path(store.root).glob("*.json")))
+
+    assert len(keys[0]) == 1
+    assert len(keys[1]) == 2, "the second run replayed the first's transcript"
 
 
 # The two tests that used to sit here exercised this module's own shadow
@@ -961,11 +1075,16 @@ def test_the_defect_list_sits_in_the_shared_prefix_of_every_call(tmp_path):
     repo = _repo(tmp_path, {"test_billing.py": "x"})
     judge = _Judge()
 
+    # One test per call, so the two requests differ in their test and in nothing
+    # else. The property is about where the shared block sits, not about how the
+    # pairs were grouped, and pinning the grouping here would make this test fail
+    # for reasons that belong to `_batches`.
     _judged(
         judge,
         [_defect_set("divides by 30", "ignores days")],
         [_test("test_half_month"), _test("test_full_month")],
         repo,
+        tests_per_batch=1,
     )
 
     assert judge.calls == 2

--- a/tests/support.py
+++ b/tests/support.py
@@ -122,6 +122,27 @@ def _pairs_asked_about(**kwargs) -> list[str]:
     return found
 
 
+def _tests_offered(**kwargs) -> list[str]:
+    """The tests a pair-judgement call offered, read off its prompt.
+
+    `test_id` stopped being enumerated in the pair schema (#324), so
+    `_supplied_enum("test_id", ...)` now finds nothing there. The work list lives
+    where the model reads it instead: `pair_mapping.py::_subject` writes a
+    `### test <id>` heading per test. Reading it here rather than from the schema
+    also keeps a double honest — a request naming a test nowhere the model could
+    see would answer nothing, where the schema would have hidden that.
+    """
+    heading = "### test "
+    found: list[str] = []
+    for message in kwargs.get("messages") or []:
+        for line in message.get("content", "").splitlines():
+            if line.startswith(heading):
+                test_id = line[len(heading) :].strip()
+                if test_id and test_id not in found:
+                    found.append(test_id)
+    return found
+
+
 def _supplied_enum(field: str, **kwargs) -> list[str]:
     """The ids a call supplied for `field`, read back off the schema it sent.
 


### PR DESCRIPTION
Closes #324.

Two changes to `defects/pair_mapping.py` that ship together, because shipping either alone is measured to be worse.

## 1. `_batches` builds rectangles instead of one test per request

Tests owed an identical defect set are grouped and share a call, up to a new `DEFAULT_TESTS_PER_BATCH = 4`. `DEFAULT_PAIR_BATCH_SIZE` still caps judgements per response at 40, so four tests in a call are offered a quarter as many defects each — the response does not get larger, and DR-164's argument about how many judgements one response can carry is untouched.

One test per request was only ever the simplest way to guarantee that a batch is a *rectangle* — every test in it offered every defect in it. The rectangle is what stops the schema inviting answers the prompt never asked for. Any number of tests satisfies it, so long as the batch is built that way.

## 2. `test_id` is no longer enumerated in the schema

`_allowed` split into `_constrained_ids`, which puts only the defect ids into the schema, and `_scanned_ids`, which still hands both sets to `supplied_ids.scan`. A test id the call never offered is recorded as an `UnusableAnswer` rather than believed. Narrowing and detecting were always separable; only the narrowing had to go.

That enum was the only part of a pair request that changed from one call to the next, which is why #316's Gate 2 measured a **0.0% cached prompt share** over 1,012 calls, with 1,762 distinct schemas across 1,762 pair calls.

## Why they ship together

`docs/experiments/pair-response-shape/` measured both, nine draws each against #315's human-reviewed kill labels.

| arm | tests per call | `test_id` | mean recall | below the 0.9375 bar |
|---|---|---|---|---|
| union | 2–3 | enumerated | 0.9688 | 1 of 9 |
| union-free-id | 2–3 | free text | 0.9653 | 1 of 9 |
| per-test | 1 | enumerated | 0.8785 | 9 of 9 |
| free-test-id | 1 | free text | 0.8021 | 9 of 9 |

A free-text `test_id` with **one** test per call costs 7.6 points. With several it is indistinguishable from the enumerated arm — same median, same spread, same sub-bar count, higher kills-per-defect ceiling. Grouping tests is worth more than either change: the whole 0.9688-vs-0.8785 gap falls on the cases where the two arms batched differently, and none of it on the five single-test cases, where both score 1.0000.

The judge writes real node ids: 100% exact under one-test batching, 95.65–100% under multi-test. The single exception across nine draws was one mangling of a real id, costing 3 pair judgements on 1 draw.

## Also

`tests_per_batch` is a new `RunConfig` field and `--tests-per-batch` flag, folded into the pair request key beside `size` so changing it invalidates transcripts rather than replaying answers produced under another value.

Two test doubles read the offered test ids off the schema enum and would now answer for no tests at all — passing by accident. `tests/support.py::_tests_offered` reads them off the prompt's `### test <id>` headings instead, where the model reads them. The test pinning one-test-per-request is replaced by two pinning what it protected: every request is a full rectangle, and a ragged pair set — the case that arises whenever verdicts carry from a prior run — is still split into rectangles.

## What this does not show

**Whether anything actually caches.** Every prompt in the pilot is under the provider's 1,024-token minimum, so nothing there could cache whatever the schema did. That needs one real `acceptance check --mode record`, and #324's second acceptance item stays open until it runs.

The pair-response-shape README also records a finding this PR does not act on: at a fixed judgement budget, the *shape* of the rectangle — how tests trade against defects — is unmeasured. `DEFAULT_TESTS_PER_BATCH = 4` is the smallest step that gets the measured effect, not a tuned value.

## Verification

- `1636 passed, 2 xfailed` locally.
- `ruff check .` and `ruff format --check .` clean.
- Landing without Gate 2, on an explicit waiver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)